### PR TITLE
Table: fix Flow and TS types for Table.RowExpandable

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1936,11 +1936,14 @@ interface TableRowExpandableProps {
   accessibilityExpandLabel: string;
   children: Node;
   expandedContents: Node;
-  expanded?: string | undefined;
-  hoverStyle?: 'gray' | 'none' | undefined;
   id: string;
-  onExpand?: BareButtonEventHandlerType | undefined;
-  selected?: 'selected' | 'unselected' | undefined;
+  expanded?: boolean;
+  hoverStyle?: 'gray' | 'none';
+  onExpand?: AbstractEventHandler<
+    React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>,
+    { expanded: boolean }
+  >;
+  selected?: 'selected' | 'unselected';
 }
 
 interface TableRowDrawerProps {

--- a/packages/gestalt/src/TableRowExpandable.js
+++ b/packages/gestalt/src/TableRowExpandable.js
@@ -33,11 +33,7 @@ type Props = {|
    * Callback fired when the expand button component is clicked.
    */
   onExpand?: ({|
-    event:
-      | SyntheticMouseEvent<HTMLButtonElement>
-      | SyntheticKeyboardEvent<HTMLButtonElement>
-      | SyntheticMouseEvent<HTMLAnchorElement>
-      | SyntheticKeyboardEvent<HTMLAnchorElement>,
+    event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
     expanded: boolean,
   |}) => void,
   /**

--- a/packages/gestalt/src/TableRowExpandable.jsdom.test.js
+++ b/packages/gestalt/src/TableRowExpandable.jsdom.test.js
@@ -10,11 +10,7 @@ import Text from './Text.js';
 const mockOnExpand = jest.fn<
   [
     {|
-      event:
-        | SyntheticMouseEvent<HTMLButtonElement>
-        | SyntheticKeyboardEvent<HTMLButtonElement>
-        | SyntheticMouseEvent<HTMLAnchorElement>
-        | SyntheticKeyboardEvent<HTMLAnchorElement>,
+      event: SyntheticMouseEvent<HTMLButtonElement> | SyntheticKeyboardEvent<HTMLButtonElement>,
       expanded: boolean,
     |},
   ],


### PR DESCRIPTION
### Summary

#### What changed?

Table: fix Flow and TS types for Table.RowExpandable
<img width="402" alt="Screenshot 2023-10-02 at 9 58 14 PM" src="https://github.com/pinterest/gestalt/assets/10593890/06cf7b3f-0743-45e3-867e-56003534143a">

