### PR TITLE
Docs: integrate PDocs in web component docs

### DIFF
--- a/docs/docs-components/AccessibilityChecklist.js
+++ b/docs/docs-components/AccessibilityChecklist.js
@@ -82,7 +82,7 @@ export default function AccessibilityChecklist({ component }: Props): Node {
     <Module.Expandable
       accessibilityExpandLabel="Expand the module"
       accessibilityCollapseLabel="Collapse the module"
-      id="internal-documentation-module"
+      id="accessibility-module"
       items={[
         {
           children: a11ySummaryNotAvailable ? (

--- a/docs/docs-components/AccessibilityChecklist.js
+++ b/docs/docs-components/AccessibilityChecklist.js
@@ -82,7 +82,7 @@ export default function AccessibilityChecklist({ component }: Props): Node {
     <Module.Expandable
       accessibilityExpandLabel="Expand the module"
       accessibilityCollapseLabel="Collapse the module"
-      id="accessibility-module"
+      id="internal-documentation-module"
       items={[
         {
           children: a11ySummaryNotAvailable ? (

--- a/docs/docs-components/InternalDocumentationSection.js
+++ b/docs/docs-components/InternalDocumentationSection.js
@@ -5,7 +5,7 @@ import Card from './Card.js';
 
 type Props = {| items: $ReadOnlyArray<{| href: string, text: string |}> |};
 
-export default function AccessibilitySection({ items }: Props): Node {
+export default function InternalDocumentationSection({ items }: Props): Node {
   return (
     <Card name="Internal documentation" showHeading>
       <Module.Expandable

--- a/docs/docs-components/InternalDocumentationSection.js
+++ b/docs/docs-components/InternalDocumentationSection.js
@@ -24,7 +24,13 @@ export default function AccessibilitySection({ items }: Props): Node {
                     key={text}
                     text={
                       <Text>
-                        <Link externalLinkIcon="default" underline="always" href={href}>
+                        <Link
+                          externalLinkIcon="default"
+                          underline="always"
+                          href={href}
+                          target="blank"
+                          rel="nofollow"
+                        >
                           {text}
                         </Link>
                       </Text>

--- a/docs/docs-components/InternalDocumentationSection.js
+++ b/docs/docs-components/InternalDocumentationSection.js
@@ -1,0 +1,41 @@
+// @flow strict
+import { type Node } from 'react';
+import { Link, List, Module, Text } from 'gestalt';
+import Card from './Card.js';
+
+type Props = {| items: $ReadOnlyArray<{| href: string, text: string |}> |};
+
+export default function AccessibilitySection({ items }: Props): Node {
+  return (
+    <Card name="Internal documentation" showHeading>
+      <Module.Expandable
+        accessibilityExpandLabel="Expand the module"
+        accessibilityCollapseLabel="Collapse the module"
+        id="internal-documentation-module"
+        items={[
+          {
+            title: 'PDocs available',
+            icon: 'lock',
+            iconAccessibilityLabel: 'Access is restricted to Pinterest employees.',
+            children: (
+              <List label="PDocs available" type="unordered" labelDisplay="hidden">
+                {items.map(({ href, text }) => (
+                  <List.Item
+                    key={text}
+                    text={
+                      <Text>
+                        <Link externalLinkIcon="default" underline="always" href={href}>
+                          {text}
+                        </Link>
+                      </Text>
+                    }
+                  />
+                ))}
+              </List>
+            ),
+          },
+        ]}
+      />
+    </Card>
+  );
+}

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -51,7 +51,7 @@ type Props = {|
   name: string,
   slimBanner?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
-  pdocsLink?: string,
+  pdocsLink?: boolean,
 |};
 
 export default function PageHeader({
@@ -60,7 +60,7 @@ export default function PageHeader({
   description = '',
   fileName,
   folderName,
-  pdocsLink,
+  pdocsLink = false,
   margin = 'default',
   name,
   slimBanner = null,
@@ -157,11 +157,10 @@ export default function PageHeader({
                   <Flex alignItems="center" gap={1}>
                     <Text>
                       <Link
-                        href={pdocsLink}
+                        href="#Internal-documentation"
                         onClick={() =>
                           trackButtonClick('Consult PDocs for this component', sourcePathName)
                         }
-                        target="blank"
                         underline="always"
                       >
                         Consult PDocs for this component

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -7,6 +7,7 @@ import trackButtonClick from './buttons/trackButtonClick.js';
 import { DOCS_COPY_MAX_WIDTH_PX } from './consts.js';
 import componentData from './data/components.js';
 import getByPlatform from './data/utils/getByPlatform.js';
+import InternalOnlyIconButton from './InternalOnlyIconButton.js';
 import Markdown from './Markdown.js';
 import PageHeaderQualitySummary from './PageHeaderQualitySummary.js';
 import { SlimBannerExperiment } from './SlimBannerExperiment.js';
@@ -50,6 +51,7 @@ type Props = {|
   name: string,
   slimBanner?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
+  pdocsLink?: string,
 |};
 
 export default function PageHeader({
@@ -58,6 +60,7 @@ export default function PageHeader({
   description = '',
   fileName,
   folderName,
+  pdocsLink,
   margin = 'default',
   name,
   slimBanner = null,
@@ -134,7 +137,6 @@ export default function PageHeader({
                     View source on GitHub
                   </Link>
                 </Text>
-
                 <Text>
                   <Link
                     href={`https://github.com/pinterest/gestalt/releases?q=${name
@@ -151,6 +153,23 @@ export default function PageHeader({
                     See recent changes on GitHub
                   </Link>
                 </Text>
+                {pdocsLink ? (
+                  <Flex alignItems="center" gap={1}>
+                    <Text>
+                      <Link
+                        href={pdocsLink}
+                        onClick={() =>
+                          trackButtonClick('Consult PDocs for this component', sourcePathName)
+                        }
+                        target="blank"
+                        underline="always"
+                      >
+                        Consult PDocs for this component
+                      </Link>
+                    </Text>
+                    <InternalOnlyIconButton />
+                  </Flex>
+                ) : null}
               </Flex>
             )}
           </Flex>

--- a/docs/pages/get_started/developers/tooling/web.js
+++ b/docs/pages/get_started/developers/tooling/web.js
@@ -1,6 +1,6 @@
 // @flow strict
 import { type Node } from 'react';
-import { Box, ButtonLink, Flex, Icon, Image, Link, List, Table, Text } from 'gestalt';
+import { Box, ButtonLink, Flex, Image, Link, List, Table, Text } from 'gestalt';
 import trackButtonClick from '../../../../docs-components/buttons/trackButtonClick.js';
 import { DOCS_COPY_MAX_WIDTH_PX } from '../../../../docs-components/consts.js';
 import InternalOnlyIconButton from '../../../../docs-components/InternalOnlyIconButton.js';
@@ -27,14 +27,16 @@ function TableEntry({
             column: 0,
           }}
         >
-          <Link href={href} target="blank" onClick={() => trackButtonClick(metric)}>
-            <Text size="100" underline overflow="noWrap">
+          <Text size="100" underline overflow="noWrap">
+            <Link
+              externalLinkIcon="default"
+              href={href}
+              target="blank"
+              onClick={() => trackButtonClick(metric)}
+            >
               {metric}
-            </Text>
-          </Link>
-          <Box aria-hidden>
-            <Icon accessibilityLabel="" icon="visit" size={12} />
-          </Box>
+            </Link>
+          </Text>
           <InternalOnlyIconButton />
         </Flex>
       </Table.Cell>

--- a/docs/pages/web/avatar.js
+++ b/docs/pages/web/avatar.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -26,7 +27,7 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar"
+        pdocsLink
       >
         <SandpackExample
           code={mainExample}
@@ -35,9 +36,7 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
           previewHeight={150}
         />
       </PageHeader>
-
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
-
       <MainSection name="Usage guidelines">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -58,7 +57,6 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
           />
         </MainSection.Subsection>
       </MainSection>
-
       <MainSection name="Best Practices">
         <MainSection.Subsection columns={2}>
           <MainSection.Card
@@ -165,7 +163,6 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
           />
         </MainSection.Subsection>
       </MainSection>
-
       <AccessibilitySection
         name={generatedDocGen?.displayName}
         description={`
@@ -227,8 +224,16 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
           />
         </MainSection.Subsection>
       </MainSection>
-
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/avatar.js
+++ b/docs/pages/web/avatar.js
@@ -229,8 +229,8 @@ export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocG
       <InternalDocumentationSection
         items={[
           {
-            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
-            text: 'Ads logging extension',
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar',
+            text: 'Avatar extension',
           },
         ]}
       />

--- a/docs/pages/web/avatar.js
+++ b/docs/pages/web/avatar.js
@@ -23,7 +23,11 @@ import verifiedExample from '../../examples/avatar/verifiedExample.js';
 export default function AvatarPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar"
+      >
         <SandpackExample
           code={mainExample}
           name="Main Avatar example"

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -93,7 +93,11 @@ function ColorSchemeLayout({ children }: ColorCardProps): Node {
 export default function BoxPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink
+      >
         <SandpackExample code={main} name="Main example" hideEditor previewHeight={150} />
       </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={ignoredProps} />

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -5,6 +5,7 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -510,6 +511,14 @@ For a correct implementation, make sure the  ‘visually-hidden’ element is co
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://w.pinadmin.com/display/EPD/Deep+dive%3A+Layout+components.+Box+vs+Flex',
+            text: 'Technical training: Box vs Flex',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -550,11 +550,6 @@ To control focus or position anchored components relative to Button, use \`ref\`
             href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar',
             text: 'Avatar extension',
           },
-        ]}
-      />
-
-      <InternalDocumentationSection
-        items={[
           {
             href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
             text: 'Ads logging extension',

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -4,6 +4,7 @@ import { Button, SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -538,6 +539,16 @@ To control focus or position anchored components relative to Button, use \`ref\`
         </MainSection.Subsection>
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar',
+            text: 'Avatar extension',
+          },
+        ]}
+      />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -32,7 +32,11 @@ const PREVIEW_HEIGHT = 300;
 export default function DocsPage({ generatedDocGen }: DocType): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink
+      >
         <SandpackExample code={main} name="Main Button example" hideEditor previewHeight={150} />
       </PageHeader>
       <PropTable

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -547,8 +547,8 @@ To control focus or position anchored components relative to Button, use \`ref\`
       <InternalDocumentationSection
         items={[
           {
-            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#avatar',
-            text: 'Avatar extension',
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#button',
+            text: 'Button extension',
           },
           {
             href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -549,6 +549,15 @@ To control focus or position anchored components relative to Button, use \`ref\`
         ]}
       />
 
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -25,7 +25,11 @@ const PREVIEW_HEIGHT = 300;
 export default function DocsPage({ generatedDocGen }: DocType): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
+      >
         <SandpackExample
           code={main}
           name="Main ButtonLink example"

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -238,6 +239,20 @@ These optional props control the behavior of ButtonLink. External links commonly
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation',
+            text: 'Link navigation',
+          },
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -28,7 +28,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
+        pdocsLink
       >
         <SandpackExample
           code={main}

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -43,6 +43,7 @@ import { DateField } from 'gestalt-datepicker';
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -209,6 +210,15 @@ import { it } from 'date-fns/locale';
           </CombinationNew>
         </MainSection.Subsection>
       </MainSection>
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#datefield',
+            text: 'DateField extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -102,11 +102,7 @@ const PREVIEW_HEIGHT = 480;
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="DatePicker">
-      <PageHeader
-        name="DatePicker"
-        description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#datepicker"
-      >
+      <PageHeader name="DatePicker" description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -43,6 +43,7 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -331,6 +332,15 @@ import { it } from 'date-fns/locale';
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#datepicker',
+            text: 'Datepicker extension',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -102,7 +102,11 @@ const PREVIEW_HEIGHT = 480;
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="DatePicker">
-      <PageHeader name="DatePicker" description={generatedDocGen?.description}>
+      <PageHeader
+        name="DatePicker"
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#datepicker"
+      >
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -42,6 +42,7 @@ import { Flex, SelectList, SlimBanner } from 'gestalt';
 import { DateRange } from 'gestalt-datepicker';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -372,6 +373,15 @@ On mobile devices, the \`radiogroup\` prop is not shown.
           />
         </MainSection.Subsection>
       </MainSection>
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#daterange',
+            text: 'DateRange extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/flex.js
+++ b/docs/pages/web/flex.js
@@ -5,6 +5,7 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -158,6 +159,14 @@ export default function DocsPage({
         </MainSection.Subsection>
       </MainSection>
       <QualityChecklist component={generatedDocGen?.Flex.displayName} />
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://w.pinadmin.com/display/EPD/Deep+dive%3A+Layout+components.+Box+vs+Flex',
+            text: 'Technical training: Box vs Flex',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/flex.js
+++ b/docs/pages/web/flex.js
@@ -30,6 +30,7 @@ export default function DocsPage({
       <PageHeader
         name={generatedDocGen?.Flex?.displayName}
         description={generatedDocGen?.Flex?.description}
+        pdocsLink
       >
         <SandpackExample code={main} name="Main example source" hideEditor previewHeight={150} />
       </PageHeader>

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -5,6 +5,7 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -320,6 +321,14 @@ Follow these guidelines for \`bgColor\`
         </MainSection.Subsection>
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -27,7 +27,11 @@ import tooltipVariant from '../../examples/iconbutton/tooltipVariant.js';
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension"
+      >
         <SandpackExample code={main} name="IconButton example" hideEditor />
       </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -30,7 +30,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension"
+        pdocsLink
       >
         <SandpackExample code={main} name="IconButton example" hideEditor />
       </PageHeader>

--- a/docs/pages/web/iconbuttonlink.js
+++ b/docs/pages/web/iconbuttonlink.js
@@ -16,7 +16,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
+        pdocsLink
         slimBanner={
           <SlimBanner
             type="info"

--- a/docs/pages/web/iconbuttonlink.js
+++ b/docs/pages/web/iconbuttonlink.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import { Icon, SlimBanner } from 'gestalt';
 import docGen, { type DocGen, type DocType, overrideTypes } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -55,6 +56,20 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onN
         />
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation',
+            text: 'Link navigation',
+          },
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/iconbuttonlink.js
+++ b/docs/pages/web/iconbuttonlink.js
@@ -16,6 +16,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
         slimBanner={
           <SlimBanner
             type="info"

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -4,6 +4,7 @@ import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -517,6 +518,19 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onN
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation',
+            text: 'Link navigation',
+          },
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -119,6 +120,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#masonry',
+            text: 'Masonry extension',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -21,7 +21,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#masonry"
+        pdocsLink
       >
         <SandpackExample
           name="Main Masonry example"

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -18,7 +18,11 @@ const PREVIEW_HEIGHT = 400;
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#masonry"
+      >
         <SandpackExample
           name="Main Masonry example"
           code={main}

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -262,6 +263,15 @@ For mobile, all \`sizes\` are unified into a full mobile viewport Modal. Notice 
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#modal',
+            text: 'Modal extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -21,11 +21,7 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
 
   return (
     <Page title="Modal">
-      <PageHeader
-        name="Modal"
-        description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#modal"
-      >
+      <PageHeader name="Modal" description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           code={accessibilityExample}
           name="Modal Main Example"

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -21,7 +21,11 @@ export default function ModalPage({ generatedDocGen }: {| generatedDocGen: DocGe
 
   return (
     <Page title="Modal">
-      <PageHeader name="Modal" description={generatedDocGen?.description}>
+      <PageHeader
+        name="Modal"
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#modal"
+      >
         <SandpackExample
           code={accessibilityExample}
           name="Modal Main Example"

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import DocsPageHeader from '../../docs-components/PageHeader.js'; // renaming to avoid confusion
@@ -31,6 +32,7 @@ export default function PageHeaderPage({ generatedDocGen }: {| generatedDocGen: 
       <DocsPageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
+        pdocsLink
       >
         <SandpackExample
           code={defaultExample}
@@ -399,6 +401,19 @@ PageHeader doesn't depend on DeviceTypeProvider to display a mobile view; instea
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation',
+            text: 'Link navigation',
+          },
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -4,6 +4,7 @@ import { SlimBanner } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import { type DocGen, multipleDocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -34,6 +35,7 @@ export default function SheetMobilePage({
         badge="pilot"
         name={generatedDocGen?.SheetMobile.displayName}
         description={generatedDocGen?.SheetMobile.description}
+        pdocsLink
         slimBanner={
           <SlimBanner
             type="warning"
@@ -378,6 +380,15 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#She
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.SheetMobile.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-providers#sheetmobile-handlers-onopen-onclose',
+            text: 'GlobalEventsHandlerProvider: SheetMobile handlers (onOpen, onClose)',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -5,6 +5,7 @@ import AccessibilitySection from '../../docs-components/AccessibilitySection.js'
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -122,6 +123,15 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -25,7 +25,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension"
+        pdocsLink
       >
         <SandpackExample code={main} name="TapArea example" hideEditor />
       </PageHeader>

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -22,7 +22,11 @@ import withLinkButton from '../../examples/taparea/withLinkButton.js';
 export default function DocsPage({ generatedDocGen }: DocType): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension"
+      >
         <SandpackExample code={main} name="TapArea example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/taparealink.js
+++ b/docs/pages/web/taparealink.js
@@ -18,7 +18,11 @@ import mouseCursor from '../../examples/taparealink/mouseCursor.js';
 export default function DocsPage({ generatedDocGen }: DocType): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
+      >
         <SandpackExample code={main} name="TapAreaLink example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/taparealink.js
+++ b/docs/pages/web/taparealink.js
@@ -21,7 +21,7 @@ export default function DocsPage({ generatedDocGen }: DocType): Node {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation"
+        pdocsLink
       >
         <SandpackExample code={main} name="TapAreaLink example" hideEditor />
       </PageHeader>

--- a/docs/pages/web/taparealink.js
+++ b/docs/pages/web/taparealink.js
@@ -4,6 +4,7 @@ import { Box, SlimBanner, TapAreaLink } from 'gestalt';
 import CombinationNew from '../../docs-components/CombinationNew.js';
 import docGen, { type DocGen, type DocType } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -115,6 +116,20 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onN
         />
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/link-navigation',
+            text: 'Link navigation',
+          },
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-ads-logging-extension#ads-logging-extension',
+            text: 'Ads logging extension',
+          },
+        ]}
+      />
+
       <MainSection name="Related">
         <MainSection.Subsection
           description={`

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -34,7 +34,11 @@ import textOnly from '../../examples/toast/textOnly.js';
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#toast"
+      >
         <SandpackExample code={main} name="Main Toast example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -37,7 +37,7 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#toast"
+        pdocsLink
       >
         <SandpackExample code={main} name="Main Toast example" hideEditor />
       </PageHeader>

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -323,6 +324,15 @@ Once a toast is triggered, allow for a cooldown period of about 7 seconds before
       </MainSection>
 
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#toast',
+            text: 'Toast extension',
+          },
+        ]}
+      />
 
       <MainSection name="Related">
         <MainSection.Subsection

--- a/docs/pages/web/utilities/colorschemeprovider.js
+++ b/docs/pages/web/utilities/colorschemeprovider.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
@@ -37,6 +38,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
         </MainSection.Subsection>
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-providers#colorschemeprovider',
+            text: 'Gestalt Providers in Pinboard',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/utilities/defaultlabelprovider.js
+++ b/docs/pages/web/utilities/defaultlabelprovider.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import { Link, Table, Text } from 'gestalt';
 import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
@@ -405,6 +406,15 @@ export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen
           </Table.Body>
         </Table>
       </MainSection>
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-providers#defaultlabelprovider',
+            text: 'Gestalt Providers in Pinboard',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/utilities/devicetypeprovider.js
+++ b/docs/pages/web/utilities/devicetypeprovider.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
@@ -49,6 +50,15 @@ The example shows a component with different desktop and mobile UIs.`}
           }
         />
       </MainSection>
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-providers#devicetypeprovider',
+            text: 'Gestalt Providers in Pinboard',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/utilities/globaleventshandlerprovider.js
+++ b/docs/pages/web/utilities/globaleventshandlerprovider.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import { SlimBanner } from 'gestalt';
 import docGen, { type DocGen } from '../../../docs-components/docgen.js';
 import GeneratedPropTable from '../../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../../docs-components/MainSection.js';
 import Page from '../../../docs-components/Page.js';
 import PageHeader from '../../../docs-components/PageHeader.js';
@@ -167,6 +168,15 @@ It's implemented in the following components:
 `}
         />
       </MainSection>
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-providers#globaleventshandlerprovider',
+            text: 'Gestalt Providers in Pinboard',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/video.js
+++ b/docs/pages/web/video.js
@@ -19,11 +19,7 @@ import withChildrenExample from '../../examples/video/withChildrenExample.js';
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Video">
-      <PageHeader
-        name="Video"
-        description={generatedDocGen?.description}
-        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#video"
-      >
+      <PageHeader name="Video" description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           name="Main Example"
           code={mainExample}

--- a/docs/pages/web/video.js
+++ b/docs/pages/web/video.js
@@ -3,6 +3,7 @@ import { type Node } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection.js';
 import docGen, { type DocGen } from '../../docs-components/docgen.js';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable.js';
+import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection.js';
 import MainSection from '../../docs-components/MainSection.js';
 import Page from '../../docs-components/Page.js';
 import PageHeader from '../../docs-components/PageHeader.js';
@@ -150,6 +151,15 @@ For more information about autoplay, check the [MDN Web Docs: video](https://dev
         </MainSection.Subsection>
       </MainSection>
       <QualityChecklist component={generatedDocGen?.displayName} />
+
+      <InternalDocumentationSection
+        items={[
+          {
+            href: 'https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#video',
+            text: 'Video extension',
+          },
+        ]}
+      />
     </Page>
   );
 }

--- a/docs/pages/web/video.js
+++ b/docs/pages/web/video.js
@@ -19,7 +19,11 @@ import withChildrenExample from '../../examples/video/withChildrenExample.js';
 export default function DocsPage({ generatedDocGen }: {| generatedDocGen: DocGen |}): Node {
   return (
     <Page title="Video">
-      <PageHeader name="Video" description={generatedDocGen?.description}>
+      <PageHeader
+        name="Video"
+        description={generatedDocGen?.description}
+        pdocsLink="https://pdocs.pinadmin.com/docs/webapp/docs/gestalt-extensions#video"
+      >
         <SandpackExample
           name="Main Example"
           code={mainExample}


### PR DESCRIPTION
Docs: integrate PDocs in web component docs #3241

Pinterest web is our main customer for web components. 

We have internal documentation around wrappers and Pinterest-specific implementations. 

This sections aims to provide more visibility to this critical docs  for engineers. 


![Screenshot 2023-10-05 at 6 23 38 PM](https://github.com/pinterest/gestalt/assets/10593890/19d37ca4-09a5-42f7-b4c6-d20264f7fa25)
![Screenshot 2023-10-05 at 6 24 05 PM](https://github.com/pinterest/gestalt/assets/10593890/159cfc02-60ac-4930-974a-e676d5feefae)
