### PR TITLE
Divider: make vertical border lightgray

### DIFF
--- a/packages/gestalt/src/Divider.css
+++ b/packages/gestalt/src/Divider.css
@@ -2,6 +2,7 @@
   composes: block from "./Layout.css";
   composes: borderTop solid from "./Borders.css";
   composes: m0 from "./Whitespace.css";
+  composes: borderColorLightGray from "./Borders.css";
   border-bottom: 0;
   border-left: 0;
 }


### PR DESCRIPTION
This adds a set border-color to also tweak the vertical divider to match our standard border color. [Context here](https://pinterest.slack.com/archives/C0HUV5J93/p1697478365506619)

Before:
<img width="483" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/c9af04df-02c5-4e23-a84f-ff50b5a48755">

After:
<img width="367" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/4fda92f0-0c3d-4c55-a169-0c7f2023b47d">


### Summary

#### What changed?

From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
