### PR TITLE
ChartGraph: support to RTL

### DIFF
--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -489,7 +489,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
             a11yNavigation: 'ready',
             a11yComprehension: 'ready',
           },
-          documentation: 'notAvailable',
+          documentation: 'ready',
           figmaStatus: 'ready',
           responsive: 'ready',
           status: 'ready',

--- a/docs/examples/chartgraph/biaxial.js
+++ b/docs/examples/chartgraph/biaxial.js
@@ -47,8 +47,8 @@ export default function Example(): Node {
         data={data}
         range={{ xAxisBottom: ['auto', 'auto'] }}
         elements={[
-          { type: 'line', id: 'Spend' },
-          { type: 'line', id: 'Total ROAS (Checkout)' },
+          { type: 'line', id: 'Spend', axis: 'left' },
+          { type: 'line', id: 'Total ROAS (Checkout)', axis: 'right' },
         ]}
         type="line"
         tickFormatter={{

--- a/docs/examples/chartgraph/biaxial.js
+++ b/docs/examples/chartgraph/biaxial.js
@@ -43,12 +43,13 @@ export default function Example(): Node {
         onVisualPatternChange={() =>
           setVisualPatternSelected((value) => (value === 'default' ? 'visualPattern' : 'default'))
         }
-        layout="verticalBiaxial"
+        layout="horizontalBiaxial"
+        legend="none"
         data={data}
         range={{ xAxisBottom: ['auto', 'auto'] }}
         elements={[
-          { type: 'line', id: 'Spend', axis: 'left' },
-          { type: 'line', id: 'Total ROAS (Checkout)', axis: 'right' },
+          { type: 'line', id: 'Spend', axis: 'top' },
+          { type: 'line', id: 'Total ROAS (Checkout)', axis: 'bottom' },
         ]}
         type="line"
         tickFormatter={{

--- a/docs/examples/chartgraph/biaxial.js
+++ b/docs/examples/chartgraph/biaxial.js
@@ -43,13 +43,12 @@ export default function Example(): Node {
         onVisualPatternChange={() =>
           setVisualPatternSelected((value) => (value === 'default' ? 'visualPattern' : 'default'))
         }
-        layout="horizontalBiaxial"
-        legend="none"
+        layout="verticalBiaxial"
         data={data}
         range={{ xAxisBottom: ['auto', 'auto'] }}
         elements={[
-          { type: 'line', id: 'Spend', axis: 'top' },
-          { type: 'line', id: 'Total ROAS (Checkout)', axis: 'bottom' },
+          { type: 'line', id: 'Spend', axis: 'left' },
+          { type: 'line', id: 'Total ROAS (Checkout)', axis: 'right' },
         ]}
         type="line"
         tickFormatter={{

--- a/packages/gestalt-charts/src/ChartGraph.js
+++ b/packages/gestalt-charts/src/ChartGraph.js
@@ -501,7 +501,7 @@ function ChartGraph({
                   iconSize={16}
                   iconType="square"
                   content={
-                    legend === 'auto' || isVerticalBiaxialLayout || isHorizontalLayout ? (
+                    legend === 'auto' || isVerticalBiaxialLayout || isHorizontalBiaxialLayout ? (
                       defaultLegend
                     ) : (
                       <EmptyBox />

--- a/packages/gestalt-charts/src/ChartGraph.js
+++ b/packages/gestalt-charts/src/ChartGraph.js
@@ -275,6 +275,8 @@ function ChartGraph({
   // Internally we match Recharts for easier development and comoprehension of Recharts docs
   const layout = LAYOUT_MAP[externalLayout];
 
+  const isRtl = document?.dir === 'rtl';
+
   const isVerticalLayout = ['vertical', 'verticalBiaxial'].includes(layout);
   const isHorizontalLayout = ['horizontal', 'horizontalBiaxial'].includes(layout);
   const isVerticalBiaxialLayout = layout === 'verticalBiaxial';
@@ -413,6 +415,7 @@ function ChartGraph({
 
   const defaultTooltip = useDefaultTooltip({
     isDarkMode,
+    isRtl,
     labelMap,
     tickFormatter,
     isTimeSeries,
@@ -421,6 +424,7 @@ function ChartGraph({
   const defaultLegend = useDefaultLegend({
     isHorizontalBiaxialLayout,
     isVerticalBiaxialLayout,
+    isRtl,
     height: chartHeight,
     labelMap,
     setLegendHeight,

--- a/packages/gestalt-charts/src/ChartGraph.js
+++ b/packages/gestalt-charts/src/ChartGraph.js
@@ -322,7 +322,7 @@ function ChartGraph({
   let legendVerticalAlign = 'bottom';
   let legendAlign = 'left';
 
-  if (isVerticalBiaxialLayout && legend === 'auto') {
+  if (isVerticalBiaxialLayout) {
     legendVerticalAlign = 'top';
     legendAlign = 'right';
   }
@@ -473,7 +473,7 @@ function ChartGraph({
                 margin={{
                   top: 10,
                   right: 5,
-                  bottom: isVerticalBiaxialLayout && legend === 'auto' ? 20 : 10,
+                  bottom: isVerticalBiaxialLayout ? 20 : 10,
                   left: 5,
                 }}
               >
@@ -501,8 +501,7 @@ function ChartGraph({
                   iconSize={16}
                   iconType="square"
                   content={
-                    legend === 'auto' ||
-                    ['verticalBiaxial', 'horizontalBiaxial'].includes(layout) ? (
+                    legend === 'auto' || isVerticalBiaxialLayout || isHorizontalLayout ? (
                       defaultLegend
                     ) : (
                       <EmptyBox />

--- a/packages/gestalt-charts/src/ChartGraph/renderAxis.js
+++ b/packages/gestalt-charts/src/ChartGraph/renderAxis.js
@@ -138,7 +138,7 @@ export default function renderAxis({
             type="category"
             style={FONT_STYLE_CATEGORIES}
             tickLine={false}
-            orientation="left"
+            orientation={isRtl ? 'right' : 'left'}
             tickFormatter={(value: string) => labelMap?.[value] || value}
             // DO NOT SET yAxisId here
           />

--- a/packages/gestalt-charts/src/ChartGraph/renderAxis.js
+++ b/packages/gestalt-charts/src/ChartGraph/renderAxis.js
@@ -1,0 +1,163 @@
+// @flow strict-local
+import { Fragment, type Node } from 'react';
+import { XAxis, YAxis } from 'recharts';
+
+export default function renderAxis({
+  isHorizontalLayout,
+  isHorizontalBiaxialLayout,
+  isVerticalLayout,
+  isTimeSeries,
+  isVerticalBiaxialLayout,
+  isBar,
+  isCombo,
+  range,
+  tickFormatter,
+  labelMap,
+  tickCount,
+}: {
+  isHorizontalLayout: boolean,
+  isHorizontalBiaxialLayout: boolean,
+  isVerticalLayout: boolean,
+  isVerticalBiaxialLayout: boolean,
+  isTimeSeries: boolean,
+  isBar: boolean,
+  isCombo: boolean,
+  range:
+    | [
+        number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+        number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+      ]
+    | {
+        xAxisBottom?: [
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+        ],
+        xAxisTop?: [
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+        ],
+
+        yAxisLeft?: [
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+        ],
+
+        yAxisRight?: [
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+          number | 'auto' | 'dataMin' | 'dataMax' | ((number) => number),
+        ],
+      },
+  tickFormatter?: {
+    timeseries?: (number) => string | number,
+    xAxisTop?: (number, number) => string | number,
+    xAxisBottom?: (number, number) => string | number,
+    yAxisRight?: (number, number) => string | number,
+    yAxisLeft?: (number, number) => string | number,
+  },
+  labelMap?: { [string]: string },
+  tickCount: 5 | 3,
+}): Node {
+  const FONT_STYLE_CATEGORIES = {
+    fontSize: 'var(--font-size-100)',
+    fontFamily: 'var(--font-family-default-latin)',
+    fontWeight: 'var(--font-weight-normal)',
+  };
+
+  const FONT_STYLE_VALUES = {
+    color: 'var(--color-text-subtle)',
+    fontSize: 'var(--font-size-100)',
+    fontFamily: 'var(--font-family-default-latin)',
+    fontWeight: 'var(--font-weight-normal)',
+  };
+
+  const isRtl = document?.dir === 'rtl';
+
+  return (
+    <Fragment>
+      {isHorizontalLayout && (
+        <Fragment>
+          <XAxis
+            reversed={isRtl}
+            padding={isTimeSeries && (isBar || isCombo) ? { left: 100, right: 100 } : undefined}
+            axisLine={false}
+            dataKey="name"
+            domain={isTimeSeries ? !Array.isArray(range) && range?.xAxisBottom : undefined}
+            orientation="bottom"
+            scale={isTimeSeries ? 'time' : undefined}
+            style={FONT_STYLE_CATEGORIES}
+            tickFormatter={
+              isTimeSeries
+                ? tickFormatter?.xAxisBottom || tickFormatter?.timeseries
+                : (value: string) => labelMap?.[value] || value
+            }
+            tickLine={false}
+            type={isTimeSeries ? 'number' : 'category'}
+            // DO NOT SET xAxisId here (it breaks the component, opaque behavior from Recharts)
+          />
+          <YAxis
+            axisLine={false}
+            domain={Array.isArray(range) ? range : range?.yAxisLeft}
+            orientation="left"
+            style={FONT_STYLE_VALUES}
+            tickLine={false}
+            tickCount={tickCount}
+            yAxisId="left"
+            tickFormatter={tickFormatter?.yAxisLeft}
+          />
+        </Fragment>
+      )}
+      {isHorizontalBiaxialLayout && (
+        <YAxis
+          axisLine={false}
+          domain={Array.isArray(range) ? range : range?.yAxisLeft}
+          orientation="right"
+          style={FONT_STYLE_VALUES}
+          tickLine={false}
+          tickCount={tickCount}
+          yAxisId="right"
+          tickFormatter={tickFormatter?.yAxisRight}
+        />
+      )}
+      {isVerticalLayout && (
+        <Fragment>
+          <XAxis
+            reversed={isRtl}
+            axisLine={false}
+            domain={range}
+            type="number"
+            orientation="bottom"
+            style={FONT_STYLE_VALUES}
+            tickLine={false}
+            tickCount={tickCount}
+            xAxisId="bottom"
+            tickFormatter={tickFormatter?.xAxisBottom}
+          />
+          <YAxis
+            axisLine={false}
+            dataKey="name"
+            type="category"
+            style={FONT_STYLE_CATEGORIES}
+            tickLine={false}
+            orientation="left"
+            tickFormatter={(value: string) => labelMap?.[value] || value}
+            // DO NOT SET yAxisId here
+          />
+        </Fragment>
+      )}
+      {isVerticalBiaxialLayout && (
+        <XAxis
+          reversed={isRtl}
+          axisLine={false}
+          domain={range}
+          orientation="top"
+          style={FONT_STYLE_VALUES}
+          tickLine={false}
+          tickCount={tickCount}
+          type="number"
+          xAxisId="top"
+          tickFormatter={tickFormatter?.xAxisTop}
+        />
+      )}
+    </Fragment>
+  );
+}

--- a/packages/gestalt-charts/src/ChartGraph/renderAxis.js
+++ b/packages/gestalt-charts/src/ChartGraph/renderAxis.js
@@ -97,7 +97,7 @@ export default function renderAxis({
           <YAxis
             axisLine={false}
             domain={Array.isArray(range) ? range : range?.yAxisLeft}
-            orientation="left"
+            orientation={isRtl ? 'right' : 'left'}
             style={FONT_STYLE_VALUES}
             tickLine={false}
             tickCount={tickCount}
@@ -110,7 +110,7 @@ export default function renderAxis({
         <YAxis
           axisLine={false}
           domain={Array.isArray(range) ? range : range?.yAxisLeft}
-          orientation="right"
+          orientation={isRtl ? 'left' : 'right'}
           style={FONT_STYLE_VALUES}
           tickLine={false}
           tickCount={tickCount}

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
@@ -6,6 +6,7 @@ import LegendIcon from './LegendIcon.js';
 export default function useDefaultLegend({
   isHorizontalBiaxialLayout,
   isVerticalBiaxialLayout,
+  isRtl,
   height,
   labelMap,
   setLegendHeight,
@@ -13,6 +14,7 @@ export default function useDefaultLegend({
 }: {
   isHorizontalBiaxialLayout: boolean,
   isVerticalBiaxialLayout: boolean,
+  isRtl: boolean,
   height: number,
   labelMap: ?{ [string]: string },
   setLegendHeight: (number) => void,
@@ -70,46 +72,53 @@ export default function useDefaultLegend({
 
       if (isHorizontalBiaxialLayout) {
         return (
-          <Box color="transparent" marginBottom={6} width="100%">
-            <Flex justifyContent="between">{legendItemsArray.slice(0, 2)}</Flex>
-          </Box>
+          <div style={{ direction: isRtl ? 'rtl' : 'ltr' }}>
+            <Box color="transparent" marginBottom={6} width="100%">
+              <Flex justifyContent="between">{legendItemsArray.slice(0, 2)}</Flex>
+            </Box>
+          </div>
         );
       }
 
       if (isVerticalBiaxialLayout) {
         return (
-          <Box
-            dangerouslySetInlineStyle={{ __style: { top: '-15px' } }}
-            color="transparent"
-            position="absolute"
-            height={height}
-            display="flex"
-            alignContent="end"
-          >
-            <Flex direction="column" justifyContent="between">
-              {legendItemsArray.slice(0, 2)}
-            </Flex>
-          </Box>
+          <div style={{ direction: isRtl ? 'rtl' : 'ltr' }}>
+            <Box
+              dangerouslySetInlineStyle={{ __style: { top: '-15px' } }}
+              color="transparent"
+              position="absolute"
+              height={height}
+              display="flex"
+              alignContent="end"
+            >
+              <Flex direction="column" justifyContent="between">
+                {legendItemsArray.slice(0, 2)}
+              </Flex>
+            </Box>
+          </div>
         );
       }
 
       return (
-        <Box
-          color="transparent"
-          width="100%"
-          ref={(ref) => {
-            if (ref) setLegendHeight(ref.getBoundingClientRect().height);
-          }}
-        >
-          <Flex gap={{ row: 4, column: 0 }} wrap>
-            {legendItemsArray}
-          </Flex>
-        </Box>
+        <div style={{ direction: isRtl ? 'rtl' : 'ltr' }}>
+          <Box
+            color="transparent"
+            width="100%"
+            ref={(ref) => {
+              if (ref) setLegendHeight(ref.getBoundingClientRect().height);
+            }}
+          >
+            <Flex gap={{ row: 4, column: 0 }} wrap>
+              {legendItemsArray}
+            </Flex>
+          </Box>
+        </div>
       );
     },
     [
       isHorizontalBiaxialLayout,
       isVerticalBiaxialLayout,
+      isRtl,
       height,
       labelMap,
       setLegendHeight,

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
@@ -6,7 +6,6 @@ import LegendIcon from './LegendIcon.js';
 export default function useDefaultLegend({
   isHorizontalBiaxialLayout,
   isVerticalBiaxialLayout,
-  legend,
   height,
   labelMap,
   setLegendHeight,
@@ -14,7 +13,6 @@ export default function useDefaultLegend({
 }: {
   isHorizontalBiaxialLayout: boolean,
   isVerticalBiaxialLayout: boolean,
-  legend: 'auto' | 'none' | 'complete',
   height: number,
   labelMap: ?{ [string]: string },
   setLegendHeight: (number) => void,
@@ -70,7 +68,7 @@ export default function useDefaultLegend({
 
       const legendItemsArray = [...series, ...referenceAreas];
 
-      if (isHorizontalBiaxialLayout && legend === 'auto') {
+      if (isHorizontalBiaxialLayout) {
         return (
           <Box color="transparent" marginBottom={6} width="100%">
             <Flex justifyContent="between">{legendItemsArray.slice(0, 2)}</Flex>
@@ -78,7 +76,7 @@ export default function useDefaultLegend({
         );
       }
 
-      if (isVerticalBiaxialLayout && legend === 'auto') {
+      if (isVerticalBiaxialLayout) {
         return (
           <Box
             dangerouslySetInlineStyle={{ __style: { top: '-15px' } }}
@@ -114,7 +112,6 @@ export default function useDefaultLegend({
       isVerticalBiaxialLayout,
       height,
       labelMap,
-      legend,
       setLegendHeight,
       referenceAreaSummary,
     ],

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultTooltip.js
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultTooltip.js
@@ -7,6 +7,7 @@ export default function useDefaultTooltip({
   isDarkMode,
   labelMap,
   isTimeSeries,
+  isRtl,
   tickFormatter,
 }: {
   isDarkMode: boolean,
@@ -19,6 +20,7 @@ export default function useDefaultTooltip({
     yAxisLeft?: (number, number) => string | number,
   },
   isTimeSeries?: boolean,
+  isRtl: boolean,
 }): ({
   active: boolean,
   payload: $ReadOnlyArray<{
@@ -37,51 +39,55 @@ export default function useDefaultTooltip({
 }) => Node {
   return useCallback(
     ({ active, payload, label }) => (
-      <Box
-        color={isDarkMode ? 'elevationFloating' : 'default'}
-        borderStyle={isDarkMode ? undefined : 'shadow'}
-        maxWidth={300}
-        padding={2}
-        rounding={4}
-      >
-        {active && Array.isArray(payload) ? (
-          <Flex direction="column" gap={2}>
-            <Flex.Item>
-              {payload.map(
-                (payloadData: {
-                  dataKey: string,
-                  name: string,
-                  stroke: ?string,
-                  value: number,
-                  strokeDasharray: ?string | number,
-                  color: ?string,
-                  fill: ?string,
-                  legendType?: 'line' | 'rect',
-                  isLegend?: boolean,
-                  strokeWidth?: number,
-                }) => (
-                  <Flex key={payloadData.name} alignItems="center" gap={2}>
-                    <LegendIcon payloadData={payloadData} />
-                    <Flex.Item flex="grow">
-                      <Text size="100">{labelMap?.[payloadData.dataKey] || payloadData.name}</Text>
-                    </Flex.Item>
-                    <Text size="200" weight="bold">
-                      {payloadData.value}
-                    </Text>
-                  </Flex>
-                ),
-              )}
-            </Flex.Item>
-            <Text size="100" color="subtle">
-              {isTimeSeries && typeof label === 'number' && tickFormatter?.timeseries
-                ? tickFormatter.timeseries(label)
-                : null}
-              {!isTimeSeries ? (typeof label === 'string' && labelMap?.[label]) || label : null}
-            </Text>
-          </Flex>
-        ) : null}
-      </Box>
+      <div style={{ direction: isRtl ? 'rtl' : 'ltr' }}>
+        <Box
+          color={isDarkMode ? 'elevationFloating' : 'default'}
+          borderStyle={isDarkMode ? undefined : 'shadow'}
+          maxWidth={300}
+          padding={2}
+          rounding={4}
+        >
+          {active && Array.isArray(payload) ? (
+            <Flex direction="column" gap={2}>
+              <Flex.Item>
+                {payload.map(
+                  (payloadData: {
+                    dataKey: string,
+                    name: string,
+                    stroke: ?string,
+                    value: number,
+                    strokeDasharray: ?string | number,
+                    color: ?string,
+                    fill: ?string,
+                    legendType?: 'line' | 'rect',
+                    isLegend?: boolean,
+                    strokeWidth?: number,
+                  }) => (
+                    <Flex key={payloadData.name} alignItems="center" gap={2}>
+                      <LegendIcon payloadData={payloadData} />
+                      <Flex.Item flex="grow">
+                        <Text size="100">
+                          {labelMap?.[payloadData.dataKey] || payloadData.name}
+                        </Text>
+                      </Flex.Item>
+                      <Text size="200" weight="bold">
+                        {payloadData.value}
+                      </Text>
+                    </Flex>
+                  ),
+                )}
+              </Flex.Item>
+              <Text size="100" color="subtle">
+                {isTimeSeries && typeof label === 'number' && tickFormatter?.timeseries
+                  ? tickFormatter.timeseries(label)
+                  : null}
+                {!isTimeSeries ? (typeof label === 'string' && labelMap?.[label]) || label : null}
+              </Text>
+            </Flex>
+          ) : null}
+        </Box>
+      </div>
     ),
-    [isDarkMode, labelMap, isTimeSeries, tickFormatter],
+    [isDarkMode, labelMap, isTimeSeries, tickFormatter, isRtl],
   );
 }


### PR DESCRIPTION
### Summary

#### What changed?

ChartGraph: support to RTL
<img width="715" alt="Screenshot 2023-10-17 at 2 30 02 AM" src="https://github.com/pinterest/gestalt/assets/10593890/9c5b1185-bff6-4dba-bd65-7a74748572eb">


<img width="808" alt="Screenshot 2023-10-17 at 2 29 29 AM" src="https://github.com/pinterest/gestalt/assets/10593890/b8a06ec7-5afa-46b1-8bfa-4a855cc5afb4">
<img width="694" alt="Screenshot 2023-10-17 at 2 30 29 AM" src="https://github.com/pinterest/gestalt/assets/10593890/0c97a15b-28b3-44a7-bf0d-edec2dfd115d">

<img width="687" alt="Screenshot 2023-10-17 at 2 30 43 AM" src="https://github.com/pinterest/gestalt/assets/10593890/9abbc725-a7e8-469b-b8d1-40a991bfa332">
<img width="678" alt="Screenshot 2023-10-17 at 2 32 02 AM" src="https://github.com/pinterest/gestalt/assets/10593890/f907c520-fffe-4ad0-8832-91ca19fd5f10">

