### PR TITLE
SelectList: Add fullWidth prop to selectlist

### DIFF
--- a/docs/examples/selectlist/fullWidthExample.js
+++ b/docs/examples/selectlist/fullWidthExample.js
@@ -1,0 +1,29 @@
+// @flow strict
+import { type Node } from 'react';
+import { Box, SelectList } from 'gestalt';
+
+export default function Example(): Node {
+  return (
+    <Box
+      width={500}
+      padding={8}
+      height="100%"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <SelectList fullWidth id="selectlistexample10" label="Country" onChange={() => {}} size="lg">
+        {[
+          { label: 'Algeria', value: 'algeria' },
+          { label: 'Belgium', value: 'belgium' },
+          { label: 'Canada', value: 'canada' },
+          { label: 'Denmark', value: 'denmark' },
+          { label: 'Egypt', value: 'egypt' },
+          { label: 'France', value: 'france' },
+        ].map(({ label, value }) => (
+          <SelectList.Option key={label} label={label} value={value} />
+        ))}
+      </SelectList>
+    </Box>
+  );
+}

--- a/docs/pages/web/selectlist.js
+++ b/docs/pages/web/selectlist.js
@@ -14,6 +14,7 @@ import dontMixDropdownAndItemListInGroup from '../../examples/selectlist/dontMix
 import dontUseIfAdditionalFeaturesNeeded from '../../examples/selectlist/dontUseIfAdditionalFeaturesNeeded.js';
 import dontUseIfLessThanFourItems from '../../examples/selectlist/dontUseIfLessThanFourItems.js';
 import errorMessageExample from '../../examples/selectlist/errorMessageExample.js';
+import fullWidthExample from '../../examples/selectlist/fullWidthExample.js';
 import groupingRelatedOptionsExample from '../../examples/selectlist/groupingRelatedOptionsExample.js';
 import helperTextExample from '../../examples/selectlist/helperTextExample.js';
 import labelsWithBuiltInFeaturesExample from '../../examples/selectlist/labelsWithBuiltInFeaturesExample.js';
@@ -254,6 +255,18 @@ export default function DocsPage({
             cardSize="lg"
             sandpackExample={
               <SandpackExample name="Helper Text Example" code={helperTextExample} />
+            }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Full Width"
+          description={`Use \`fullWidth\` to take up the entire space of a container. By default, SelectList only takes the width of the longest select option.`}
+        >
+          <MainSection.Card
+            cardSize="md"
+            sandpackExample={
+              <SandpackExample name="Full Size Example" code={fullWidthExample} layout="column" />
             }
           />
         </MainSection.Subsection>

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -26,6 +26,10 @@ type Props = {
    */
   errorMessage?: string,
   /**
+   * Takes the fullWidth of the container, by default selectList will only take the width of the select element
+   */
+  fullWidth?: boolean,
+  /**
    * Used to provide more information about the form field. Be sure to localize the text. See the [helper text](https://gestalt.pinterest.systems/web/selectlist#Helper-text) variant to learn more.
    */
   helperText?: string,
@@ -77,6 +81,7 @@ function SelectList({
   children,
   disabled = false,
   errorMessage,
+  fullWidth,
   helperText,
   id,
   label,
@@ -116,7 +121,7 @@ function SelectList({
   }
 
   return (
-    <Box>
+    <Box width={fullWidth ? '100%' : undefined}>
       {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
       <Box
         color={disabled ? 'secondary' : 'default'}


### PR DESCRIPTION
This adds a fullWidth property to SelectList so it can take the entire space of a container. I

t's supported in <img width="806" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/0bea2f22-ec80-48dd-845f-6fce81fc8e9d">

We can't enable `width=100%` on all SelectLists because it may begin to overflow existing containers and break UIs, and it's hard to detect these instances from code-alone.

### Summary
This adds a `fullWidth` prop that sets the width of the selectList to be more responsive.

This also aligns with the current ComboBox behavior where the outer container can have a width
```
<Box width={320}>
<Combobox />
</Box>
```

#### What changed?

<img width="713" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/648869ec-7353-43ff-8829-b7814ab0194f">


From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
