### PR TITLE
DateField: add `size` prop to match input field pattern and fix border color

### DIFF
--- a/packages/gestalt-datepicker/dist/index.d.ts
+++ b/packages/gestalt-datepicker/dist/index.d.ts
@@ -491,6 +491,7 @@ export interface DateFieldProps {
     | AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>
     | undefined;
   readOnly?: boolean | undefined;
+  size?: 'md' | 'lg';
   value: Date | null | undefined;
 }
 

--- a/packages/gestalt-datepicker/src/DateField.css
+++ b/packages/gestalt-datepicker/src/DateField.css
@@ -48,6 +48,7 @@
 
 .formElementBase {
   appearance: none;
+  border-color: var(--color-border-container);
   border-radius: 16px;
   border-style: solid;
   border-width: 2px;
@@ -58,7 +59,8 @@
   outline: 0;
 }
 
-.formElementBase .formElementNormal {
+
+.formElementNormal {
   border-color: var(--color-border-container);
 }
 
@@ -95,6 +97,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+
+.layoutMedium {
+  min-height: 40px;
 }
 
 .layoutLarge {

--- a/packages/gestalt-datepicker/src/DateField.css
+++ b/packages/gestalt-datepicker/src/DateField.css
@@ -59,7 +59,6 @@
   outline: 0;
 }
 
-
 .formElementNormal {
   border-color: var(--color-border-container);
 }
@@ -98,7 +97,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
 
 .layoutMedium {
   min-height: 40px;

--- a/packages/gestalt-datepicker/src/DateField.css.flow
+++ b/packages/gestalt-datepicker/src/DateField.css.flow
@@ -13,6 +13,7 @@ declare module.exports: {|
   +'formLabel': string,
   +'label': string,
   +'layoutLarge': string,
+  +'layoutMedium': string,
   +'textField': string,
   +'typographyTruncate': string,
   +'visuallyHidden': string,

--- a/packages/gestalt-datepicker/src/DateField.js
+++ b/packages/gestalt-datepicker/src/DateField.js
@@ -124,6 +124,10 @@ export type Props = {
    */
   readOnly?: boolean,
   /**
+   * Defines the height of ComboBox: md: 40px, lg: 48px. Width is defined by parent component.
+   */
+  size?: 'md' | 'lg',
+  /**
    * DateField is a controlled component. `value` sets the current value of the input.  See the [controlled component example](https://gestalt.pinterest.systems/web/datefield#Controlled-component) to learn more.
    */
   value: Date | null,
@@ -157,6 +161,7 @@ function DateField({
   onError,
   onFocus,
   readOnly = false,
+  size = 'lg',
   value,
 }: Props): Node {
   const { dateFieldHandlers } = useGlobalEventsHandler() || {
@@ -188,6 +193,7 @@ function DateField({
       onError={onError}
       onFocus={onFocus}
       readOnly={readOnly}
+      size={size}
       value={value}
     />
   );

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -67,6 +67,7 @@ type CustomTextFieldProps = {
         event: SyntheticFocusEvent<HTMLInputElement>,
         value: string,
       }) => void,
+      size: 'md' | 'lg',
     },
   },
 };
@@ -96,7 +97,7 @@ const CustomTextField = forwardRef(
       styles.formElementBase,
       styles.typographyTruncate,
       styles.actionButton,
-      styles.layoutLarge,
+      ownerState?.passthroughProps?.size === 'lg' ? styles.layoutLarge : styles.layoutMedium,
       disabled ? styles.formElementDisabled : styles.formElementEnabled,
       ownerState?.passthroughProps?.errorMessage && !focused
         ? styles.formElementErrored
@@ -283,6 +284,7 @@ type InternalDateFieldProps = {
   }) => void,
   readOnly?: boolean,
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
+  size?: 'md' | 'lg',
   value: Date | null,
 };
 
@@ -306,6 +308,7 @@ function InternalDateField({
   onError,
   onFocus,
   readOnly = false,
+  size,
   value,
 }: InternalDateFieldProps): Node {
   let translations = getTranslationsFromMUIJS(localeData);
@@ -357,6 +360,7 @@ function InternalDateField({
                 onBlur,
                 onFocus,
                 onClearInput,
+                size,
               }}
               viewRenderers={null}
             />


### PR DESCRIPTION
### Summary

#### What changed?

DateField: add `size` prop to match input field pattern and fix border color

BEFORE <> AFTER
<img width="1104" alt="Screenshot 2023-10-20 at 5 33 42 PM" src="https://github.com/pinterest/gestalt/assets/10593890/ca277d82-5275-40d2-9e42-7ed8114b6fc7">

<img width="861" alt="Screenshot 2023-10-20 at 5 34 57 PM" src="https://github.com/pinterest/gestalt/assets/10593890/382bfb5a-0d86-4b1f-941c-6a448385f203">


https://jira.pinadmin.com/browse/GESTALT-6113
