### PR TITLE
Docs: fixed paragraph typo

### DIFF
--- a/docs/pages/foundations/data_visualization/charts_and_graphs/general_guidelines.js
+++ b/docs/pages/foundations/data_visualization/charts_and_graphs/general_guidelines.js
@@ -21,11 +21,12 @@ export default function GeneralGuidelines(): Node {
       <MainSection
         name="Chart use cases"
         description={`
-        The type of chart you use depends on how you are analyzing and monitoring data. Below are our most common use cases:
-        - **Trends:** to see how data changes over time
-        - **Parts-to-whole:** to see how a breakdown adds up to a total
-        - **Comparison:** to see how multiple data sets compare to each other
-        - **Connection:** to see the relationship between variables
+The type of chart you use depends on how you are analyzing and monitoring data. Below are our most common use cases:
+
+- **Trends:** to see how data changes over time
+- **Parts-to-whole:** to see how a breakdown adds up to a total
+- **Comparison:** to see how multiple data sets compare to each other
+- **Connection:** to see the relationship between variables
 
 For a great resource on understanding when to use what type of chart, [download the Financial Times Visual Vocabulary PDF](https://github.com/Financial-Times/chart-doctor/blob/main/visual-vocabulary/FT4schools_RGS.pdf).
         `}

--- a/playwright/accessibility/foundations__data_visualization__charts_and_graphs__general_guidelines.spec.mjs
+++ b/playwright/accessibility/foundations__data_visualization__charts_and_graphs__general_guidelines.spec.mjs
@@ -3,6 +3,8 @@ import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
 test('Data Viz Color Palette Accessibility check', async ({ page }) => {
-  await page.goto('/foundations/data_visualization/charts_and_graphs');
+  await page.goto(
+    '/foundations/data_visualization/charts_and_graphs/general_guidelines'
+  );
   await expectAccessiblePage({ page });
 });


### PR DESCRIPTION
### Summary
Fixed formatting in Chart use case paragraph of General guidelines for Charts and graphs.

#### What changed?
<img width="688" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/25403784-f19f-4a3e-a3fb-f0e6d4ca6b11">
/data_visualization/charts_and_graphs/general_guidelines#Chart-use-cases

From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

#### Why?
Wasn't formatted properly in the merge: 
<img width="653" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/bb2fec8b-b370-4a0b-8f34-3a1fce95ced9">

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
