### PR TITLE
Status: Add locked status

### DIFF
--- a/docs/examples/status/textAdditionsExample1.js
+++ b/docs/examples/status/textAdditionsExample1.js
@@ -10,6 +10,7 @@ export default function Example(): Node {
         <Status type="queued" title="Queued" />
         <Status type="inProgress" title="In progress" />
         <Status type="halted" title="Halted" />
+        <Status type="locked" title="Locked" />
         <Status type="ok" title="OK" />
         <Status type="canceled" title="Canceled" />
         <Status type="warning" title="Warning" />

--- a/docs/pages/foundations/iconography/ICON_DATA.json
+++ b/docs/pages/foundations/iconography/ICON_DATA.json
@@ -857,7 +857,7 @@
     },
     {
       "name": "lock",
-      "categories": ["Utility and tools"],
+      "categories": ["Utility and tools", "Status"],
       "description": "Indicates private content",
       "keywords": ["private", "safe", "privacy"]
     },

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -18,6 +18,10 @@ const ICON_COLOR_MAP = {
     icon: 'workflow-status-in-progress',
     color: 'success',
   },
+  locked: {
+    icon: 'lock',
+    color: 'subtle',
+  },
   ok: {
     icon: 'workflow-status-ok',
     color: 'success',
@@ -45,6 +49,7 @@ type StatusType =
   | 'queued'
   | 'inProgress'
   | 'halted'
+  | 'locked'
   | 'ok'
   | 'problem'
   | 'canceled'


### PR DESCRIPTION
### Summary
Added locked status to the Status component

#### What changed?

Added a locked status:
<img width="159" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/93f8edec-2e6f-4490-873f-134cfc71699c">


#### Why?

Requested by m10n, as that is another workflow state.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-7032)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
