### PR TITLE
Docs: updated Tag description

### DIFF
--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -2298,7 +2298,8 @@ const componentData: $ReadOnlyArray<ComponentData> = [
           svg: <Tag />,
         },
         alias: ['Chip', 'Pill', 'Filter Tag'],
-        description: 'Tags are objects that hold text and have a delete icon to remove them.',
+        description:
+          'Tags can be used to categorize, classify or filter content, usually via keywords.',
         category: ['Navigation'],
         status: {
           accessible: {

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -53,7 +53,7 @@ type Props = {
 };
 
 /**
- * [Tags](https://gestalt.pinterest.systems/web/tag) are objects that hold text and have a delete icon to remove them. They can appear within [TextFields](https://gestalt.pinterest.systems/web/textfield#tagsExample), [TextAreas](https://gestalt.pinterest.systems/web/textarea#tagsExample), [ComboBox](https://gestalt.pinterest.systems/web/combobox#Tags) or as standalone components.
+ * [Tags](https://gestalt.pinterest.systems/web/tag) can be used to categorize, classify or filter content, usually via keywords. They can appear within [TextFields](https://gestalt.pinterest.systems/web/textfield#tagsExample), [TextAreas](https://gestalt.pinterest.systems/web/textarea#tagsExample), [ComboBox](https://gestalt.pinterest.systems/web/combobox#Tags) or as standalone components.
  *
  * ![Tag light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tag.spec.mjs-snapshots/Tag-chromium-darwin.png)
  * ![Tag dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Tag-dark.spec.mjs-snapshots/Tag-dark-chromium-darwin.png)


### PR DESCRIPTION
### Summary
Updated description for Tag

#### What changed?

Changed from "Tags are objects that hold text and have a delete icon to remove them." to something that better describes what they are for: "

#### Why?

Better user comprehension. The original description is too vague and generic; we have a number of components that are objects that hold text and are dismissible.
<img width="659" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/c202cc71-e739-4d39-b3cd-1e870c01d3d3">
<img width="368" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/b9c1ad25-d885-43a6-8eec-0d1ed9e0b52d">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6988)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
