### PR TITLE
Docs: Update best practices headings

### DIFF
--- a/docs/markdown/android/buttongroup.md
+++ b/docs/markdown/android/buttongroup.md
@@ -20,7 +20,7 @@ fullwidth: true
   </Group>
 </TwoCol>
 
-## Mobile best practices
+## Best practices
 
 Keep primary actions (ex: submitting a form) on the right and secondary actions (ex: cancel) on the left. When used vertically, keep the primary action at the top. 
 

--- a/docs/markdown/android/textarea.md
+++ b/docs/markdown/android/textarea.md
@@ -20,7 +20,7 @@ fullwidth: true
 </Group>
 </TwoCol>
 
-## Mobile Best practices
+## Best practices
 - Use a label to clearly denote what information the user should input. Use placeholder sparingly as they can erode usability of form fields
 - Use helper text to provide additional context that will aid the user in most effectively inputting information
 - Set the height of TextArea using text rows to ensure the typical amount of text will be visible without needing to scroll

--- a/docs/markdown/ios/button.md
+++ b/docs/markdown/ios/button.md
@@ -6,7 +6,7 @@ fullwidth: true
 
 <ImgContainer src="https://i.pinimg.com/originals/28/1a/d1/281ad184c9d118598c3617c87f444b11.png" alt="a red button that says Save" />
 
-## Mobile best practices
+## Best practices
 
 - Place primary buttons to the right or top of other buttons when in a button group.
 - Keep elements inside a button container grouped. Label text and icons should remain centered when the Button width increases.

--- a/docs/markdown/ios/iconbutton.md
+++ b/docs/markdown/ios/iconbutton.md
@@ -25,7 +25,7 @@ fullwidth: true
   </Group>
 </TwoCol>
 
-## Mobile best practices
+## Best practices
 
 - Avoid using a floating IconButton if it obscures important information on the screen 
 - IconButton on mobile should primarily utilize the LG (44px) size as the increased size will better accommodate tapping with a finger

--- a/docs/markdown/ios/sheet.md
+++ b/docs/markdown/ios/sheet.md
@@ -24,7 +24,7 @@ fullwidth: true
 </Group>
 </TwoCol>
 
-## Mobile best practices
+## Best practices
 
 - Trigger sheets via user actions, like button taps
 - Include a header title. Headers can be center or start-aligned, but they should remain consistent.

--- a/docs/markdown/ios/textarea.md
+++ b/docs/markdown/ios/textarea.md
@@ -19,7 +19,7 @@ fullwidth: true
   </Group>
 </TwoCol>
 
-## Mobile best practices
+## Best practices
 
 - Use a label to clearly denote what information the user should input. Use placeholder sparingly as they can erode usability of form fields
 - Use helper text to provide additional context that will aid the user in most effectively inputting information


### PR DESCRIPTION
### Summary
Updated heading inconsistencies

#### What changed?

Changed "Mobile best practices" to "Best practices" in iOS and Android docs: Button, IconButton and Button Group.
<img width="933" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/90c1602d-6cff-420c-8d6b-0ef84f998779">
<img width="912" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/16493b7b-a5c3-42e0-ab05-7bf38d620e2f">


#### Why?
Content design inconsistency.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-6916)

### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
