### PR TITLE
Video: fix scrubber issue in mobile when mouse events don't work BUG-175963

### DIFF
--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -118,11 +118,15 @@ type Props = {
   /**
    * Callback triggered when mousedown event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
-  onPlayheadDown?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
+  onPlayheadDown?: ({
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  }) => void,
   /**
    * Callback triggered when mouseup event occurs on the playhead via the video control interface. See the [video controls variant](https://gestalt.pinterest.systems/web/video#Video-controls) to learn more.
    */
-  onPlayheadUp?: ({ event: SyntheticMouseEvent<HTMLDivElement> }) => void,
+  onPlayheadUp?: ({
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  }) => void,
   /**
    * Callback triggered when enough data is available that the media can be played. See the [MDN Web Docs: canplay event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/canplay_event).
    */
@@ -573,14 +577,18 @@ export default class Video extends PureComponent<Props, State> {
   };
 
   // Sent when mouse down event happens on playhead
-  handlePlayheadDown: (event: SyntheticMouseEvent<HTMLDivElement>) => void = (event) => {
+  handlePlayheadDown: (
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  ) => void = (event) => {
     const { onPlayheadDown } = this.props;
 
     onPlayheadDown?.({ event });
   };
 
   // Sent when mouse up event happens on playhead
-  handlePlayheadUp: (event: SyntheticMouseEvent<HTMLDivElement>) => void = (event) => {
+  handlePlayheadUp: (
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  ) => void = (event) => {
     const { onPlayheadUp } = this.props;
 
     onPlayheadUp?.({ event });

--- a/packages/gestalt/src/Video/Controls.js
+++ b/packages/gestalt/src/Video/Controls.js
@@ -17,8 +17,12 @@ type Props = {
   onFullscreenChange: () => void,
   onPause: (event: SyntheticEvent<HTMLDivElement>) => void,
   onPlay: (event: SyntheticEvent<HTMLDivElement>) => void,
-  onPlayheadDown: (event: SyntheticMouseEvent<HTMLDivElement>) => void,
-  onPlayheadUp: (event: SyntheticMouseEvent<HTMLDivElement>) => void,
+  onPlayheadDown: (
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  ) => void,
+  onPlayheadUp: (
+    event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
+  ) => void,
   onVolumeChange: (event: SyntheticEvent<HTMLDivElement>) => void,
   playing: boolean,
   seek: (time: number) => void,

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -122,8 +122,6 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
 
     if (!supportsPassive) {
-      // eslint-disable-next-line no-console
-      console.log('event.preventDefault');
       event.preventDefault();
     }
 

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -73,7 +73,6 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
     if (!supportsPassive) {
-      console.log('event.preventDefault');
       event.preventDefault();
     }
 
@@ -123,6 +122,8 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
 
     if (!supportsPassive) {
+      // eslint-disable-next-line no-console
+      console.log('event.preventDefault');
       event.preventDefault();
     }
 

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -54,6 +54,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
   handleMouseDown: (
     event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
   ) => void = (event) => {
+    // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
     if (!!event?.clientX && !event?.touches) event.preventDefault();
 
     const { onPlayheadDown } = this.props;
@@ -82,6 +83,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
   handleMouseMove: (
     event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
   ) => void = (event) => {
+    // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
     if (!!event?.clientX && !event?.touches) event.preventDefault();
 
     const { seeking } = this.state;
@@ -116,10 +118,12 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           className={styles.playhead}
           onClick={this.stopClick}
           onKeyPress={this.stopClick}
+          // onmouse events don't get correctly triggered on mobile
           onMouseDown={this.handleMouseDown}
           onMouseLeave={this.handleMouseLeave}
           onMouseMove={this.handleMouseMove}
           onMouseUp={this.handleMouseUp}
+          // ontouch events take on on mobile
           onTouchStart={this.handleMouseDown}
           onTouchMove={this.handleMouseMove}
           onTouchEnd={this.handleMouseUp}

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -123,7 +123,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           onMouseLeave={this.handleMouseLeave}
           onMouseMove={this.handleMouseMove}
           onMouseUp={this.handleMouseUp}
-          // ontouch events take on on mobile
+          // ontouch events handle scrubber on mobile
           onTouchStart={this.handleMouseDown}
           onTouchMove={this.handleMouseMove}
           onTouchEnd={this.handleMouseUp}

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -54,8 +54,28 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
   handleMouseDown: (
     event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
   ) => void = (event) => {
+    // https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+    // Test via a getter in the options object to see if the passive property is accessed
+    let supportsPassive = false;
+    try {
+      // $FlowFixMe[prop-missing]
+      const opts = Object.defineProperty({}, 'passive', {
+        // eslint-disable-next-line getter-return
+        get() {
+          supportsPassive = true;
+        },
+      });
+      window.addEventListener('testPassive', null, opts);
+      window.removeEventListener('testPassive', null, opts);
+    } catch (e) {
+      // do nothing
+    }
+
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    if (!!event?.clientX && !event?.touches) event.preventDefault();
+    if (!supportsPassive) {
+      console.log('event.preventDefault');
+      event.preventDefault();
+    }
 
     const { onPlayheadDown } = this.props;
     onPlayheadDown(event);
@@ -83,8 +103,28 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
   handleMouseMove: (
     event: SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>,
   ) => void = (event) => {
+    // https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md#feature-detection
+    // Test via a getter in the options object to see if the passive property is accessed
+    let supportsPassive = false;
+    try {
+      // $FlowFixMe[prop-missing]
+      const opts = Object.defineProperty({}, 'passive', {
+        // eslint-disable-next-line getter-return
+        get() {
+          supportsPassive = true;
+        },
+      });
+      window.addEventListener('testPassive', null, opts);
+      window.removeEventListener('testPassive', null, opts);
+    } catch (e) {
+      // do nothing
+    }
+
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    if (!!event?.clientX && !event?.touches) event.preventDefault();
+
+    if (!supportsPassive) {
+      event.preventDefault();
+    }
 
     const { seeking } = this.state;
     if (seeking && !!event?.clientX && typeof event?.clientX === 'number') {

--- a/packages/gestalt/src/Video/Playhead.jsdom.test.js
+++ b/packages/gestalt/src/Video/Playhead.jsdom.test.js
@@ -3,8 +3,14 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import VideoPlayhead from './Playhead';
 
 test('VideoPlayhead handles on mouse down and up events', () => {
-  const mockOnPlayheadDown = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
-  const mockOnPlayheadUp = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
+  const mockOnPlayheadDown = jest.fn<
+    [SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>],
+    void,
+  >();
+  const mockOnPlayheadUp = jest.fn<
+    [SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>],
+    void,
+  >();
   render(
     <VideoPlayhead
       accessibilityProgressBarLabel="Progress bar"
@@ -29,8 +35,14 @@ test('VideoPlayhead handles on mouse down and up events', () => {
 });
 
 test('VideoPlayhead ends seek when mouse leaves', () => {
-  const mockOnPlayheadDown = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
-  const mockOnPlayheadUp = jest.fn<[SyntheticMouseEvent<HTMLDivElement>], void>();
+  const mockOnPlayheadDown = jest.fn<
+    [SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>],
+    void,
+  >();
+  const mockOnPlayheadUp = jest.fn<
+    [SyntheticMouseEvent<HTMLDivElement> | SyntheticTouchEvent<HTMLDivElement>],
+    void,
+  >();
   render(
     <VideoPlayhead
       accessibilityProgressBarLabel="Progress bar"

--- a/packages/gestalt/src/Video/__snapshots__/Controls.test.js.snap
+++ b/packages/gestalt/src/Video/__snapshots__/Controls.test.js.snap
@@ -78,6 +78,9 @@ exports[`VideoControls for double digit minutes 1`] = `
         onMouseLeave={[Function]}
         onMouseMove={[Function]}
         onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
         role="progressbar"
         tabIndex="-1"
       >
@@ -244,6 +247,9 @@ exports[`VideoControls for double digit seconds 1`] = `
         onMouseLeave={[Function]}
         onMouseMove={[Function]}
         onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
         role="progressbar"
         tabIndex="-1"
       >
@@ -410,6 +416,9 @@ exports[`VideoControls for single digit minutes 1`] = `
         onMouseLeave={[Function]}
         onMouseMove={[Function]}
         onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
         role="progressbar"
         tabIndex="-1"
       >
@@ -576,6 +585,9 @@ exports[`VideoControls for single digit seconds 1`] = `
         onMouseLeave={[Function]}
         onMouseMove={[Function]}
         onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
         role="progressbar"
         tabIndex="-1"
       >
@@ -742,6 +754,9 @@ exports[`VideoControls rounds for partial seconds 1`] = `
         onMouseLeave={[Function]}
         onMouseMove={[Function]}
         onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
         role="progressbar"
         tabIndex="-1"
       >

--- a/packages/gestalt/src/Video/__snapshots__/Playhead.test.js.snap
+++ b/packages/gestalt/src/Video/__snapshots__/Playhead.test.js.snap
@@ -21,6 +21,9 @@ exports[`VideoPlayhead 1`] = `
     onMouseLeave={[Function]}
     onMouseMove={[Function]}
     onMouseUp={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
     role="progressbar"
     tabIndex="-1"
   >

--- a/packages/gestalt/src/__snapshots__/Video.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.js.snap
@@ -207,6 +207,9 @@ exports[`Video with children 1`] = `
           onMouseLeave={[Function]}
           onMouseMove={[Function]}
           onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
           role="progressbar"
           tabIndex="-1"
         >


### PR DESCRIPTION
## What
Video: fix scrubber issue in mobile when mouse events don't work

onmouse events don't get trigger properly on mobile, specifically `onMouseMove`. implementing ontouch events so that scrubber works, particularly, `onTouchMove`. 

##  Why
Bug:

Repro steps

In mWEb - Go to video pin https://www.pinterest.com/pin/52846995621056822/
When it starts to play, try to use the scrubber to move forward or backward
The scrubber does not move, but tapping on anywhere in the progress bar, the scrubber jumps to that position.
Tapping makes the scrubber move, not smooth sliding on it.

EXPECTED: The scrubber should move smoothly on the progress bar.

ACTUAL: Only on Video pins, the scrubber does not move smoothly, tapping on it makes it to jump.

eg: https://www.pinterest.com/pin/32228953576256499/

https://www.pinterest.com/pin/13792342601990034/

## Before (rigt) and after (left)
![Brave Browser - Video - Gestalt 2023-11-28 at 6 40 22 PM](https://github.com/pinterest/gestalt/assets/10593890/90b6c7d7-1ea9-4f56-a6f9-7863e3c2865d)


## Test
Tests on BrowserStack (Safari, Edge, Firefox) & on iphone (Safari) 

