### PR TITLE
Video: preventDefault fix for mouse events

### DIFF
--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -127,7 +127,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     }
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    // supportsPassive is false for mouse events as well as touch events when passive is not supported
+    // supportsPassive is false for mouse events and touch events when passive is not supported
     if (!supportsPassive) {
       event.preventDefault();
     }

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -72,7 +72,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     }
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    if (!supportsPassive) {
+    if (!!event?.clientX || !supportsPassive) {
       event.preventDefault();
     }
 
@@ -120,8 +120,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     }
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-
-    if (!supportsPassive) {
+    if (!!event?.clientX || !supportsPassive) {
       event.preventDefault();
     }
 
@@ -163,9 +162,18 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           onMouseMove={this.handleMouseMove}
           onMouseUp={this.handleMouseUp}
           // ontouch events handle scrubber on mobile
-          onTouchStart={this.handleMouseDown}
-          onTouchMove={this.handleMouseMove}
-          onTouchEnd={this.handleMouseUp}
+          onTouchStart={(event) => {
+            console.log('onTouchStart');
+            this.handleMouseDown(event);
+          }}
+          onTouchMove={(event) => {
+            console.log('onTouchMove');
+            this.handleMouseMove(event);
+          }}
+          onTouchEnd={(event) => {
+            console.log('onTouchEnd');
+            this.handleMouseUp(event);
+          }}
           ref={this.setPlayheadRef}
           role="progressbar"
           tabIndex="-1"

--- a/packages/gestalt/src/Video/Playhead.js
+++ b/packages/gestalt/src/Video/Playhead.js
@@ -65,14 +65,18 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           supportsPassive = true;
         },
       });
-      window.addEventListener('testPassive', null, opts);
-      window.removeEventListener('testPassive', null, opts);
+      // skip this for mouse events, keep supportsPassive as false
+      if (!event?.clientX) {
+        window.addEventListener('testPassive', null, opts);
+        window.removeEventListener('testPassive', null, opts);
+      }
     } catch (e) {
       // do nothing
     }
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    if (!!event?.clientX || !supportsPassive) {
+    // supportsPassive is false for mouse events as well as touch events when passive is not supported
+    if (!supportsPassive) {
       event.preventDefault();
     }
 
@@ -113,14 +117,18 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           supportsPassive = true;
         },
       });
-      window.addEventListener('testPassive', null, opts);
-      window.removeEventListener('testPassive', null, opts);
+      // skip this for mouse events, keep supportsPassive as false
+      if (!event?.clientX) {
+        window.addEventListener('testPassive', null, opts);
+        window.removeEventListener('testPassive', null, opts);
+      }
     } catch (e) {
       // do nothing
     }
 
     // Chrome, starting with version 56 (desktop, Chrome for Android, and Android webview), where the default value for the passive option for touchstart and touchmove is true and calls to preventDefault() will have no effect.
-    if (!!event?.clientX || !supportsPassive) {
+    // supportsPassive is false for mouse events as well as touch events when passive is not supported
+    if (!supportsPassive) {
       event.preventDefault();
     }
 
@@ -162,18 +170,9 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
           onMouseMove={this.handleMouseMove}
           onMouseUp={this.handleMouseUp}
           // ontouch events handle scrubber on mobile
-          onTouchStart={(event) => {
-            console.log('onTouchStart');
-            this.handleMouseDown(event);
-          }}
-          onTouchMove={(event) => {
-            console.log('onTouchMove');
-            this.handleMouseMove(event);
-          }}
-          onTouchEnd={(event) => {
-            console.log('onTouchEnd');
-            this.handleMouseUp(event);
-          }}
+          onTouchStart={this.handleMouseDown}
+          onTouchMove={this.handleMouseMove}
+          onTouchEnd={this.handleMouseUp}
           ref={this.setPlayheadRef}
           role="progressbar"
           tabIndex="-1"


### PR DESCRIPTION
Video: preventDefault fix for mouse events

The original intention was to check passive events in touch events not mouse ones. 

Original PR: Video: fix scrubber issue in mobile when mouse events don't work BUG-175963 (https://github.com/pinterest/gestalt/pull/3310) - [Preview link](https://deploy-preview-3310--gestalt.netlify.app/?devexample=true)


In the Docs I don't see this issue, but in Pinboard I see a new focus ring that might come from not preventing the event and propagating.

BEFORE #3310
<img width="606" alt="Screenshot by Dropbox Capture" src="https://github.com/pinterest/gestalt/assets/10593890/567ff444-996e-44df-9048-1e3e2c5c34a4">

AFTER #3310
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/0c1c055c-d8e1-46e1-b87a-fc79f7d3751d)
