### PR TITLE
Docs: Add ExperimentProvider to Sandpack examples

### DIFF
--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -15,7 +15,7 @@ import CopyCodeButton from './buttons/CopyCodeButton';
 import OpenInCodeSandboxButton from './buttons/OpenInCodeSandboxButton';
 import ShowHideEditorButton from './buttons/ShowHideEditorButton';
 import clipboardCopy from './clipboardCopy';
-import { useDocsExperimentProviderValue } from './contexts/DocsExperimentProvider';
+import { useDocsExperiments } from './contexts/DocsExperimentProvider';
 import { useLocalFiles } from './contexts/LocalFilesProvider';
 import DevelopmentEditor from './DevelopmentEditor';
 
@@ -160,7 +160,7 @@ export default function SandpackExample({
   const { colorScheme, devExampleMode, helixBot, textDirection } = useAppContext();
   const [exampleColorScheme, setExampleColorScheme] = useState<'light' | 'dark'>(colorScheme);
   const [exampleTextDirection, setExampleTextDirection] = useState<'ltr' | 'rtl'>(textDirection);
-  const experimentsObj = useDocsExperimentProviderValue();
+  const experimentsObj = useDocsExperiments();
   // If the user changes the color scheme or text direction, update examples
   useEffect(() => {
     setExampleColorScheme(colorScheme);

--- a/docs/docs-components/SandpackExample.js
+++ b/docs/docs-components/SandpackExample.js
@@ -15,6 +15,7 @@ import CopyCodeButton from './buttons/CopyCodeButton';
 import OpenInCodeSandboxButton from './buttons/OpenInCodeSandboxButton';
 import ShowHideEditorButton from './buttons/ShowHideEditorButton';
 import clipboardCopy from './clipboardCopy';
+import { useDocsExperimentProviderValue } from './contexts/DocsExperimentProvider';
 import { useLocalFiles } from './contexts/LocalFilesProvider';
 import DevelopmentEditor from './DevelopmentEditor';
 
@@ -159,7 +160,7 @@ export default function SandpackExample({
   const { colorScheme, devExampleMode, helixBot, textDirection } = useAppContext();
   const [exampleColorScheme, setExampleColorScheme] = useState<'light' | 'dark'>(colorScheme);
   const [exampleTextDirection, setExampleTextDirection] = useState<'ltr' | 'rtl'>(textDirection);
-
+  const experimentsObj = useDocsExperimentProviderValue();
   // If the user changes the color scheme or text direction, update examples
   useEffect(() => {
     setExampleColorScheme(colorScheme);
@@ -236,7 +237,7 @@ export default function SandpackExample({
           code: `import React, { StrictMode } from "react";
           import { createRoot } from "react-dom/client";
           import "./styles.css";
-          import { Box, ColorSchemeProvider } from 'gestalt';
+          import { Box, ColorSchemeProvider, ExperimentProvider } from 'gestalt';
           import App from "./App";
 
           const html = document.querySelector('html');
@@ -245,11 +246,13 @@ export default function SandpackExample({
           const root = createRoot(document.getElementById("root"));
           root.render(
             <StrictMode>
-              <ColorSchemeProvider colorScheme="${exampleColorScheme}" fullDimensions>
-                <Box color="default" height="100%" width="100%">
-                  <App />
-                </Box>
-              </ColorSchemeProvider>
+              <ExperimentProvider value={${JSON.stringify(experimentsObj)}}>
+                <ColorSchemeProvider colorScheme="${exampleColorScheme}" fullDimensions>
+                  <Box color="default" height="100%" width="100%">
+                    <App />
+                  </Box>
+                </ColorSchemeProvider>
+              </ExperimentProvider>
             </StrictMode>
           );`,
         },

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -24,17 +24,11 @@ const enabledExperiments = {
   ],
 };
 
+type Experiment = { anyEnabled: boolean, group: string };
+
 function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
   return experiments.reduce(
-    (
-      acc: {
-        [string]: {
-          anyEnabled: boolean,
-          group: string,
-        },
-      },
-      cur: string,
-    ) => ({
+    (acc: Record<string, Experiment>, cur: string) => ({
       ...acc,
       [cur]: { anyEnabled: true, group: 'enabled' },
     }),
@@ -42,7 +36,7 @@ function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
   );
 }
 
-export function useDocsExperiments() {
+export function useDocsExperiments(): Record<string, Experiment> {
   const { experiments } = useAppContext();
 
   return buildExperimentsObj(!experiments ? [] : enabledExperiments[experiments] ?? []);

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -42,7 +42,7 @@ function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
   );
 }
 
-export function useDocsExperimentProviderValue() {
+export function useDocsExperiments() {
   const { experiments } = useAppContext();
 
   return buildExperimentsObj(!experiments ? [] : enabledExperiments[experiments] ?? []);
@@ -51,6 +51,6 @@ export function useDocsExperimentProviderValue() {
 type Props = { children: ReactNode };
 
 export default function DocsExperimentProvider({ children }: Props): ReactNode {
-  const experiments = useDocsExperimentProviderValue();
+  const experiments = useDocsExperiments();
   return <ExperimentProvider value={experiments}>{children}</ExperimentProvider>;
 }

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -42,16 +42,15 @@ function buildExperimentsObj(experiments: $ReadOnlyArray<string>) {
   );
 }
 
+export function useDocsExperimentProviderValue() {
+  const { experiments } = useAppContext();
+
+  return buildExperimentsObj(!experiments ? [] : enabledExperiments[experiments] ?? []);
+}
+
 type Props = { children: ReactNode };
 
 export default function DocsExperimentProvider({ children }: Props): ReactNode {
-  const { experiments } = useAppContext();
-
-  return (
-    <ExperimentProvider
-      value={buildExperimentsObj(!experiments ? [] : enabledExperiments[experiments] ?? [])}
-    >
-      {children}
-    </ExperimentProvider>
-  );
+  const experiments = useDocsExperimentProviderValue();
+  return <ExperimentProvider value={experiments}>{children}</ExperimentProvider>;
 }

--- a/docs/examples/popover/localizationLabels.js
+++ b/docs/examples/popover/localizationLabels.js
@@ -35,7 +35,7 @@ export default function Example(): ReactNode {
               accessibilityLabel="An Bord speichern."
               anchor={anchorRef.current}
               idealDirection="down"
-              onDismiss={() => {}}
+              onDismiss={() => setOpen(false)}
               positionRelativeToAnchor
               size={240}
               showDismissButton


### PR DESCRIPTION
### Summary

Sandpack examples are now wrapped with `ExperimentProvider` so that they will have also experiments which are enabled in Docs.

#### What changed?

#### Why?

Recent Popover experiments were not working after the PR was merged.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
