### PR TITLE
ComboBox: Disable Popover auto focus

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -512,6 +512,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
             positionRelativeToAnchor={false}
             size="flexible"
             key={suggestedOptions.length}
+            shouldFocus={false}
           >
             <Box
               aria-expanded={showOptionsList}


### PR DESCRIPTION
### Summary

Removing force-rerendering of Popover when items change for new ComboBox (that uses Popover v2).
By default Popover has auto focus enabled and is focused when opened. This was not allowing users to continuously type into ComboBox as it kept losing the focus.

Kind of reverts #3171. The bug mentioned in #3171 is automatically fixed with new Popover.

Before:

![532b3651-6045-42d8-b1f9-22709aa91a89](https://github.com/pinterest/gestalt/assets/29589560/7561849e-bbee-4297-8acd-b6999e109543)

After:

![695c65d5-9d1b-48a6-b0d0-183f375ad298](https://github.com/pinterest/gestalt/assets/29589560/ab0ad36c-018d-49f1-80d2-55f0d9c2f7e4)


#### What changed?

From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
