### PR TITLE
PopoverEducational: Add `disablePortal`

### DIFF
--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -210,6 +210,7 @@ export default function PopoverEducational({
         id={id}
         idealDirection={idealDirection}
         onDismiss={onDismiss}
+        disablePortal
         showCaret
         shouldFocus={shouldFocus}
         role={primaryAction && !children ? 'dialog' : role}


### PR DESCRIPTION
### Summary

PopoverEducational should always be rendered near its anchor, not outside the root through portal.

#### What changed?

#### Why?

When `disablePortal` is not set, Popover is rendered through portal and `zIndex` prop of PopoverEducational will have no effect.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
