### PR TITLE
Toast: reduce side margins from 32 to 16 px

### DIFF
--- a/packages/gestalt/src/Toast.css
+++ b/packages/gestalt/src/Toast.css
@@ -17,8 +17,8 @@
 
 .toast {
   border-radius: var(--rounding-400);
-  margin-left: 32px;
-  margin-right: 32px;
+  margin-left: 16px;
+  margin-right: 16px;
 
   /*  Ensure that maxWidth isn't greater than viewport width (for small screens)  */
   max-width: min(716px, 100vw);
@@ -28,8 +28,8 @@
   .toast {
     border-radius: var(--rounding-400);
     display: inline-block;
-    margin-left: 32px;
-    margin-right: 32px;
+    margin-left: 16px;
+    margin-right: 16px;
 
     /*  Ensure that maxWidth isn't greater than viewport width (for small screens)  */
     max-width: "min(716px, 100vw)";


### PR DESCRIPTION
### Summary

#### What changed?

Toast: reduce side margins from 32 to 16 px

#### Why?

Designs need more Toast space in mobile devices and small screens. 