### PR TITLE
Docs: update description of Accordion

### DIFF
--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -1547,7 +1547,8 @@ const componentData: $ReadOnlyArray<ComponentData> = [
           svg: <Accordion />,
         },
         alias: ['Section', 'Expandable Section', 'Module', 'Disclosure', 'Stack View', 'Expander'],
-        description: 'Accordion is a container that can be expanded and collapsed to show content about a single subject.',
+        description:
+          'Accordion is a container that can be expanded and collapsed to show content about a single subject.',
         category: ['Structure'],
         status: {
           accessible: {

--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -1547,7 +1547,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
           svg: <Accordion />,
         },
         alias: ['Section', 'Expandable Section', 'Module', 'Disclosure', 'Stack View', 'Expander'],
-        description: 'Accordion is a container that holds content about one subject.',
+        description: 'Accordion is a container that can be expanded and collapsed to show content about a single subject.',
         category: ['Structure'],
         status: {
           accessible: {


### PR DESCRIPTION
Quick edit to wording here:
<img width="387" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/db8ccb1a-f7ac-4522-a517-b0c227f906d5">
to: "Accordion is a container that can be expanded and collapsed to show content about a single subject."