### PR TITLE
Internal: test to fix darkmode

### DIFF
--- a/docs/examples/layer/stackingUsingZIndexExample.js
+++ b/docs/examples/layer/stackingUsingZIndexExample.js
@@ -26,7 +26,7 @@ export default function Example(): ReactNode {
               alignItems="center"
               justifyContent="center"
             >
-              <Box color="light" padding={3} display="flex" alignItems="center">
+              <Box padding={3} display="flex" alignItems="center">
                 <Text>Layer Content</Text>
                 <Box marginStart={2}>
                   <IconButton

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,6 +1,6 @@
 // @flow strict
-// import { readFileSync } from 'fs';
-// import path from 'path';
+import { readFileSync } from 'fs';
+import path from 'path';
 import { type Node as ReactNode } from 'react';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
 import Document, { type DocumentContext, Head, Html, Main, NextScript } from 'next/document';
@@ -22,10 +22,18 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-    // const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
+    const gestaltBuildDirectory = path.join(
+      process.cwd(),
+      '..',
+      '..',
+      'node_modules',
+      'gestalt',
+      'dist',
+    );
+
+    const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
     // eslint-disable-next-line no-console
-    console.log('ALBERTO', process.cwd());
-    // const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
+    console.log('ALBERTO', process.cwd(), gestaltBuildDirectory, gestaltCssText);
 
     return (
       <Html lang="en" dir={dir}>

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -22,14 +22,7 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-    const gestaltBuildDirectory = path.join(
-      process.cwd(),
-      '..',
-      '..',
-      'node_modules',
-      'gestalt',
-      'dist',
-    );
+    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'node_modules', 'gestalt', 'dist');
 
     const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
     // eslint-disable-next-line no-console

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -23,7 +23,7 @@ class GestaltDocument extends Document {
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
 
-    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'node_modules', 'gestalt', 'dist');
+    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
     const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
 
     return (

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,6 +1,6 @@
 // @flow strict
-import { readFileSync } from 'fs';
-import path from 'path';
+// import { readFileSync } from 'fs';
+// import path from 'path';
 import { type Node as ReactNode } from 'react';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
 import Document, { type DocumentContext, Head, Html, Main, NextScript } from 'next/document';

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,4 +1,5 @@
 // @flow strict
+import { readFileSync } from 'fs';
 import { type Node as ReactNode } from 'react';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
 import Document, { type DocumentContext, Head, Html, Main, NextScript } from 'next/document';
@@ -20,6 +21,7 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
+    const gestaltCssText = readFileSync('../node_modules/gestalt/dist/gestalt.css', 'utf-8');
 
     return (
       <Html lang="en" dir={dir}>
@@ -53,6 +55,8 @@ gtag('config', 'UA-12967896-44');
                 : '/gestalt_favicon.png'
             }
           />
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: gestaltCssText }} id="gestalt" />
           {/* eslint-disable-next-line react/no-danger */}
           <style dangerouslySetInnerHTML={{ __html: getSandpackCssText() }} id="sandpack" />
         </Head>

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -22,8 +22,8 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-
     const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
+    console.log('ALBERTO', process.cwd());
     const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
 
     return (

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -22,9 +22,10 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
+    // const gestaltBuildDirectory = path.join(process.cwd(), '..', 'packages', 'gestalt', 'dist');
+    // eslint-disable-next-line no-console
     console.log('ALBERTO', process.cwd());
-    const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
+    // const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
 
     return (
       <Html lang="en" dir={dir}>
@@ -58,8 +59,7 @@ gtag('config', 'UA-12967896-44');
                 : '/gestalt_favicon.png'
             }
           />
-          {/* eslint-disable-next-line react/no-danger */}
-          <style dangerouslySetInnerHTML={{ __html: gestaltCssText }} id="gestalt" />
+          {/* <style dangerouslySetInnerHTML={{ __html: gestaltCssText }} id="gestalt" /> */}
           {/* eslint-disable-next-line react/no-danger */}
           <style dangerouslySetInnerHTML={{ __html: getSandpackCssText() }} id="sandpack" />
         </Head>

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -22,9 +22,17 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'node_modules', 'gestalt', 'dist');
+    const gestaltBuildDirectory = path.join(
+      process.cwd(),
+      '..',
+      'node_modules',
+      'gestalt',
+      'dist',
+      'gestalt.css',
+    );
 
-    const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
+    const gestaltCssText = readFileSync(gestaltBuildDirectory, 'utf8');
+
     // eslint-disable-next-line no-console
     console.log('ALBERTO', process.cwd(), gestaltBuildDirectory, gestaltCssText);
 
@@ -60,7 +68,8 @@ gtag('config', 'UA-12967896-44');
                 : '/gestalt_favicon.png'
             }
           />
-          {/* <style dangerouslySetInnerHTML={{ __html: gestaltCssText }} id="gestalt" /> */}
+          {/* eslint-disable-next-line react/no-danger */}
+          <style dangerouslySetInnerHTML={{ __html: gestaltCssText }} id="gestalt" />
           {/* eslint-disable-next-line react/no-danger */}
           <style dangerouslySetInnerHTML={{ __html: getSandpackCssText() }} id="sandpack" />
         </Head>

--- a/docs/pages/_document.js
+++ b/docs/pages/_document.js
@@ -1,5 +1,6 @@
 // @flow strict
 import { readFileSync } from 'fs';
+import path from 'path';
 import { type Node as ReactNode } from 'react';
 import { getSandpackCssText } from '@codesandbox/sandpack-react';
 import Document, { type DocumentContext, Head, Html, Main, NextScript } from 'next/document';
@@ -21,7 +22,9 @@ class GestaltDocument extends Document {
     const { props } = this;
     const cookies = new Cookies(props.cookieHeader);
     const dir = cookies.cookies['gestalt-text-direction'];
-    const gestaltCssText = readFileSync('../node_modules/gestalt/dist/gestalt.css', 'utf-8');
+
+    const gestaltBuildDirectory = path.join(process.cwd(), '..', 'node_modules', 'gestalt', 'dist');
+    const gestaltCssText = readFileSync(path.join(gestaltBuildDirectory, 'gestalt.css'), 'utf8');
 
     return (
       <Html lang="en" dir={dir}>


### PR DESCRIPTION
Dark mode is broken in Gestalt Docs: components using React Portal is set outside the ColorSquemeProvider and doesn't  get the darkmode changes.

In Pinboard, we set Gestalt CSS in the page header. I was trying to replicate that... as it was mentioned as the reason why Pinboard doesn't have this same issue.

I'm testing this solution

Internal: test to fix darkmode
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/e1ae8fe4-20ee-4923-b093-7c7888811d99)
