### PR TITLE
Docs: Fix subsection scroll-magin-top

### DIFF
--- a/docs/docs-components/MainSectionSubsection.js
+++ b/docs/docs-components/MainSectionSubsection.js
@@ -42,7 +42,7 @@ function MainSectionSubsection({
             maxWidth={DOCS_COPY_MAX_WIDTH_PX}
             dangerouslySetInlineStyle={{
               __style: {
-                scrollMarginTop: 60,
+                scrollMarginTop: 90,
               },
             }}
             id={slugifiedId}


### PR DESCRIPTION
### Summary

Updated `scroll-margin-top` for `MainSubSection` so that the title is visible on scrollsnap. 

Before:
<img width="1352" alt="Screenshot 2023-12-12 at 22 32 06" src="https://github.com/pinterest/gestalt/assets/29589560/c05909a2-fbf3-48f2-be92-5430746bddf3">

After:
<img width="1352" alt="Screenshot 2023-12-12 at 22 33 09" src="https://github.com/pinterest/gestalt/assets/29589560/1c30734e-c6e7-43f7-98aa-9a556b6dd487">


