### PR TITLE
Docs: Removed redundant "to" in description attribute that SlimBannerExperiment already includes (for ComboBox, Dropdown, HelpButton, OverlayPanel, Popover, and PopoverEducational)

### DIFF
--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -33,7 +33,7 @@ export default function ComboBoxPage({ generatedDocGen }: { generatedDocGen: Doc
         slimBanner={
           <SlimBannerExperiment
             componentName="ComboBox"
-            description="to fix and improve underlying Popover component behavior. No visual updates"
+            description="fix and improve underlying Popover component behavior. No visual updates"
             pullRequest={3244}
           />
         }

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -42,7 +42,7 @@ export default function ComponentPage({
         slimBanner={
           <SlimBannerExperiment
             componentName="Dropdown"
-            description="to fix and improve underlying Popover component behavior. No visual updates"
+            description="fix and improve underlying Popover component behavior. No visual updates"
             pullRequest={3244}
           />
         }

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -28,7 +28,7 @@ export default function DocsPage({ generatedDocGen }: DocsType): ReactNode {
         slimBanner={
           <SlimBannerExperiment
             componentName="HelpButton"
-            description="to fix and improve underlying Popover component behavior. No visual updates"
+            description="fix and improve underlying Popover component behavior. No visual updates"
             pullRequest={3244}
           />
         }

--- a/docs/pages/web/overlaypanel.js
+++ b/docs/pages/web/overlaypanel.js
@@ -36,7 +36,7 @@ export default function SheetPage({
         slimBanner={
           <SlimBannerExperiment
             componentName="OverlayPanel"
-            description="to fix and improve underlying Popover component behavior. No visual updates"
+            description="fix and improve underlying Popover component behavior. No visual updates"
             pullRequest={3244}
           />
         }

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -29,7 +29,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
         slimBanner={
           <SlimBannerExperiment
             componentName="Popover"
-            description="to fix and improve component behavior. No visual updates"
+            description="fix and improve component behavior. No visual updates"
             pullRequest={3244}
           />
         }

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -29,7 +29,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
         slimBanner={
           <SlimBannerExperiment
             componentName="PopoverEducational"
-            description="to fix and improve underlying Popover component behavior. No visual updates"
+            description="fix and improve underlying Popover component behavior. No visual updates"
             pullRequest={3244}
           />
         }


### PR DESCRIPTION
### Summary
Removing redundant "to" text in `SlimBannerExperiment` `description` attributes for `ComboBox`, `Dropdown`, `HelpButton`, `OverlayPanel`, `Popover`, and `PopoverEducational` since the component already includes it.

These were introduced in https://github.com/pinterest/gestalt/pull/3312

Alternatively, the redundant "to" could be removed from `SlimBannerExperiment`

https://github.com/pinterest/gestalt/blob/76d251c9e65cc4f99b27030ee373961c8ce6fadf/docs/docs-components/SlimBannerExperiment.js#L47-L49


### Why?

The copy on some component doc pages had a typo in the form of an extra "to".

#### Example:
![Screenshot 2023-12-12 at 1 10 51 PM](https://github.com/pinterest/gestalt/assets/551114/bd1ef0bb-e3ad-47b8-847a-6363c7e42a70)

