### PR TITLE
Tooltip: Add experiment hooks for using Popover v2

### DIFF
--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -58,6 +58,7 @@ type Props = {
   margin?: 'default' | 'none',
   name: string,
   slimBanner?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
+  slimBannerExperiment?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
   pdocsLink?: boolean,
 };
@@ -72,6 +73,7 @@ export default function PageHeader({
   margin = 'default',
   name,
   slimBanner = null,
+  slimBannerExperiment = null,
   type = 'component',
 }: Props): ReactNode {
   const sourcePathName = folderName ?? fileName ?? name;
@@ -211,7 +213,12 @@ export default function PageHeader({
                 </h2>
               )}
             </Flex>
-            {slimBanner}
+
+            <Flex direction="column" gap={4}>
+              {slimBanner}
+              {slimBannerExperiment}
+            </Flex>
+
             {type === 'component' ? <PageHeaderQualitySummary name={name} /> : null}
 
             {children ? <Box marginTop={2}>{children}</Box> : null}

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -57,8 +57,8 @@ type Props = {
   folderName?: string,
   margin?: 'default' | 'none',
   name: string,
-  slimBanner?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
-  slimBannerExperiment?: Element<typeof SlimBanner | typeof SlimBannerExperiment> | null,
+  slimBanner?: Element<typeof SlimBanner> | null,
+  slimBannerExperiment?: Element<typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
   pdocsLink?: boolean,
 };

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -22,6 +22,7 @@ const enabledExperiments = {
     'web_gestalt_popover_v2_popovereducational',
     'mweb_gestalt_popover_v2_popovereducational',
   ],
+  Tooltip: ['web_gestalt_popover_v2_tooltip', 'mweb_gestalt_popover_v2_tooltip'],
 };
 
 type Experiment = { anyEnabled: boolean, group: string };

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -30,7 +30,7 @@ export default function ComboBoxPage({ generatedDocGen }: { generatedDocGen: Doc
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="ComboBox"
             description="fix and improve underlying Popover component behavior. No visual updates"

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -39,7 +39,7 @@ export default function ComponentPage({
       <PageHeader
         name={generatedDocGen?.Dropdown.displayName}
         description={generatedDocGen?.Dropdown.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="Dropdown"
             description="fix and improve underlying Popover component behavior. No visual updates"

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -25,7 +25,7 @@ export default function DocsPage({ generatedDocGen }: DocsType): ReactNode {
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="HelpButton"
             description="fix and improve underlying Popover component behavior. No visual updates"

--- a/docs/pages/web/overlaypanel.js
+++ b/docs/pages/web/overlaypanel.js
@@ -33,7 +33,7 @@ export default function SheetPage({
       <PageHeader
         name={generatedDocGen?.OverlayPanel.displayName}
         description={generatedDocGen?.OverlayPanel.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="OverlayPanel"
             description="fix and improve underlying Popover component behavior. No visual updates"

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -26,7 +26,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="Popover"
             description="fix and improve component behavior. No visual updates"

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -26,7 +26,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
       <PageHeader
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
-        slimBanner={
+        slimBannerExperiment={
           <SlimBannerExperiment
             componentName="PopoverEducational"
             description="fix and improve underlying Popover component behavior. No visual updates"

--- a/docs/pages/web/tooltip.js
+++ b/docs/pages/web/tooltip.js
@@ -10,6 +10,7 @@ import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
+import { SlimBannerExperiment } from '../../docs-components/SlimBannerExperiment';
 import avoidRepetitiveLabeling1 from '../../examples/tooltip/avoidRepetitiveLabeling1';
 import avoidRepetitiveLabeling2 from '../../examples/tooltip/avoidRepetitiveLabeling2';
 import displayLinkAtBottom from '../../examples/tooltip/displayLinkAtBottom';
@@ -42,6 +43,13 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
               href: '/web/iconbutton#With-Tooltip',
               onClick: () => {},
             }}
+          />
+        }
+        slimBannerExperiment={
+          <SlimBannerExperiment
+            componentName="Tooltip"
+            description="fix and improve component behavior. No visual updates"
+            pullRequest={3244}
           />
         }
       >

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -3,8 +3,10 @@ import { Fragment, type Node as ReactNode, useEffect, useReducer, useRef } from 
 import Box from '../Box';
 import Layer from '../Layer';
 import LegacyController from '../LegacyController';
+import Controller from '../Popover/Controller';
 import Text from '../Text';
 import useDebouncedCallback from '../useDebouncedCallback';
+import useInExperiment from '../useInExperiment';
 import { type Indexable } from '../zIndex';
 
 const noop = () => {};
@@ -123,6 +125,11 @@ export default function InternalTooltip({
     return text;
   };
 
+  const isInExperiment = useInExperiment({
+    webExperimentName: 'web_gestalt_popover_v2_tooltip',
+    mwebExperimentName: 'mweb_gestalt_popover_v2_tooltip',
+  });
+
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
       <Box
@@ -137,34 +144,66 @@ export default function InternalTooltip({
       </Box>
       {isOpen && !!anchor && (
         <Layer zIndex={zIndex}>
-          <LegacyController
-            anchor={anchor}
-            caret={false}
-            bgColor="darkGray"
-            border={false}
-            idealDirection={idealDirection}
-            onDismiss={noop}
-            positionRelativeToAnchor={false}
-            rounding={2}
-            size={null}
-          >
-            <Box
-              maxWidth={180}
-              padding={2}
-              onBlur={link ? handleTextMouseLeave : undefined}
-              onFocus={link ? handleTextMouseEnter : undefined}
-              onMouseEnter={link ? handleTextMouseEnter : undefined}
-              onMouseLeave={link ? handleTextMouseLeave : undefined}
-              role="tooltip"
-              tabIndex={0}
+          {isInExperiment ? (
+            <Controller
+              anchor={anchor}
+              caret={false}
+              bgColor="darkGray"
+              border={false}
+              idealDirection={idealDirection}
+              onDismiss={noop}
+              disablePortal
+              rounding={2}
+              size={null}
+              shouldFocus={false}
             >
-              <Text color="inverse" size="100">
-                {getTooltipText()}
-              </Text>
+              <Box
+                maxWidth={180}
+                padding={2}
+                onBlur={link ? handleTextMouseLeave : undefined}
+                onFocus={link ? handleTextMouseEnter : undefined}
+                onMouseEnter={link ? handleTextMouseEnter : undefined}
+                onMouseLeave={link ? handleTextMouseLeave : undefined}
+                role="tooltip"
+                tabIndex={0}
+              >
+                <Text color="inverse" size="100">
+                  {getTooltipText()}
+                </Text>
 
-              {Boolean(link) && <Box marginTop={1}>{link}</Box>}
-            </Box>
-          </LegacyController>
+                {Boolean(link) && <Box marginTop={1}>{link}</Box>}
+              </Box>
+            </Controller>
+          ) : (
+            <LegacyController
+              anchor={anchor}
+              caret={false}
+              bgColor="darkGray"
+              border={false}
+              idealDirection={idealDirection}
+              onDismiss={noop}
+              positionRelativeToAnchor={false}
+              rounding={2}
+              size={null}
+            >
+              <Box
+                maxWidth={180}
+                padding={2}
+                onBlur={link ? handleTextMouseLeave : undefined}
+                onFocus={link ? handleTextMouseEnter : undefined}
+                onMouseEnter={link ? handleTextMouseEnter : undefined}
+                onMouseLeave={link ? handleTextMouseLeave : undefined}
+                role="tooltip"
+                tabIndex={0}
+              >
+                <Text color="inverse" size="100">
+                  {getTooltipText()}
+                </Text>
+
+                {Boolean(link) && <Box marginTop={1}>{link}</Box>}
+              </Box>
+            </LegacyController>
+          )}
         </Layer>
       )}
     </Box>


### PR DESCRIPTION
### Summary

Tooltip and Tooltip based components now can be switched between old and new implementation of Popover using ExperimentProvider by providing the experiment names:
- web_gestalt_popover_v2_tooltip
- mweb_gestalt_popover_v2_tooltip

Also, added `slimBannerExperiment` prop to `PageHeader` in docs-components. Because there is now a use case where 2 slimbanners needs to be displayed.

#### What changed?

Tooltip component experiements can be toggled in the docs site to try them out.

Before:
<img width="1352" alt="Screenshot 2023-12-15 at 20 47 28" src="https://github.com/pinterest/gestalt/assets/29589560/f8975aff-e608-48a6-86cc-8c9174064deb">
 
![Brave Browser - Tooltip - Gestalt 2023-12-16 at 3 05 50 PM](https://github.com/pinterest/gestalt/assets/10593890/a933000b-77b9-4863-9bcd-5b82843fb354)

After:
<img width="1352" alt="Screenshot 2023-12-15 at 20 47 07" src="https://github.com/pinterest/gestalt/assets/29589560/9fb38290-30d7-4905-a0c3-055b481edb3b">

![Brave Browser - Tooltip - Gestalt 2023-12-16 at 3 04 51 PM](https://github.com/pinterest/gestalt/assets/10593890/0af1af8d-4f2e-41e7-9385-c2267bdce045)

#### Why?

This is for the 3rd phase of releasing Popover based components. The experiments are not ramped-up in Helium and this PR 

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
