### PR TITLE
Internal: Skip package releases on "docs-update" label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,11 @@ on:
       - master
 
 jobs:
-  release:
-    name: Release gestalt
+  extract_labels:
+    name: Extract PR labels
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
+    outputs:
+      labels: ${{ steps.extract_labels.outputs.labels }}
     steps:
       - uses: octokit/graphql-action@v2.0.0
         id: query_labels
@@ -54,6 +55,13 @@ jobs:
         run: |
           LABELS=$(echo "${JSON_DATA}" | jq '.repository.object.associatedPullRequests.edges[0].node.labels.edges[].node.name' | tr '\n' ', ')
           echo "::set-output name=labels::${LABELS}"
+
+  release:
+    name: Release gestalt
+    needs: [extract_labels]
+    runs-on: ubuntu-latest
+    if: contains(needs.extract_labels.outputs.labels, 'docs-update') == 'false' && contains(github.event.head_commit.message, 'Version bump:') == false && github.repository == 'pinterest/gestalt'
+    steps:
       - name: Checkout the repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Summary

Introducing "docs-update" label for PRs. PRs with this label will skip releasing packages.

#### What changed?

Added a new "Extract PR labels" job before the "Release gestalt" one. 
A notable change is even if the release job is skipped, **the pipeline will appear as succeeded.** Currently there is one job in `release.yml` and if the job is skipped, the pipeline is displayed as skipped.

#### Why?

Sometimes we don't need to publish a new version of gestalt when we do changes exclusive for the docs site (i.e. typo). Because they will not effect out components in any way. Pulibshed npm packages also don't contain any changed compared to the last version. That's why in this situation releasing a new version of our libraries doesn't make sense.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
