### PR TITLE
Docs: Fix github file location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ docs/docs-components/metadata.js
 stats.html
 screenshots
 .DS_Store
+.idea
 # We use yarn, not npm
 package-lock.json
 

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -1,8 +1,6 @@
 // @flow strict
 import { type Element, type Node as ReactNode } from 'react';
 import { Badge, Box, Flex, Heading, Link, SlimBanner, Text } from 'gestalt';
-import * as gestaltChart from 'gestalt-charts'; // eslint-disable-line import/no-namespace
-import * as gestaltDatepicker from 'gestalt-datepicker'; // eslint-disable-line import/no-namespace
 import trackButtonClick from './buttons/trackButtonClick';
 import { DOCS_COPY_MAX_WIDTH_PX } from './consts';
 import componentData from './data/components';
@@ -14,24 +12,8 @@ import { SlimBannerExperiment } from './SlimBannerExperiment';
 
 const webComponentData = getByPlatform(componentData, { platform: 'web' });
 
-const gestaltChartComponents = Object.keys(gestaltChart);
-const gestaltDatepickerComponents = Object.keys(gestaltDatepicker);
-
-const buildSourceLinkPath = (componentName: string) => {
-  let packageName = 'gestalt';
-
-  if (gestaltChartComponents.includes(componentName)) {
-    packageName = 'gestalt-charts';
-  }
-
-  if (gestaltDatepickerComponents.includes(componentName)) {
-    packageName = 'gestalt-datepicker';
-  }
-  return `packages/${packageName}/src/${componentName}.js`;
-};
-
-const buildSourceLinkUrl = (componentName: string) =>
-  ['https://github.com/pinterest/gestalt/blob/master', buildSourceLinkPath(componentName)].join(
+const buildSourceLinkUrl = (packageFileLocation: string) =>
+  ['https://github.com/pinterest/gestalt/blob/master', `packages/${packageFileLocation}`].join(
     '/',
   );
 
@@ -47,10 +29,7 @@ type Props = {
     | 'trends',
   children?: ReactNode,
   description?: string,
-  /**
-   * Only use if name !== file name
-   */
-  fileName?: string,
+  packageFileLocation?: string,
   /**
    * Only use if name !== file name and the link should point to a directory
    */
@@ -66,7 +45,7 @@ export default function PageHeader({
   badge,
   children,
   description = '',
-  fileName,
+  packageFileLocation,
   folderName,
   pdocsLink = false,
   margin = 'default',
@@ -74,8 +53,9 @@ export default function PageHeader({
   slimBanner = null,
   type = 'component',
 }: Props): ReactNode {
-  const sourcePathName = folderName ?? fileName ?? name;
+  const sourcePathName = folderName ?? packageFileLocation;
   let sourceLink = buildSourceLinkUrl(sourcePathName);
+
   if (folderName) {
     // Strip the file extension if linking to a folder
     sourceLink = sourceLink.replace(/\.js$/, '');

--- a/docs/pages/web/accordion.js
+++ b/docs/pages/web/accordion.js
@@ -32,6 +32,7 @@ export default function DocsPage({
     <Page title={generatedDocGen.Accordion?.description}>
       <PageHeader
         name={generatedDocGen.Accordion?.displayName}
+        packageFileLocation={generatedDocGen.Accordion?.packageFileLocation}
         description={generatedDocGen.Accordion?.description}
       >
         <SandpackExample name="Main Example" code={mainExample} layout="column" hideEditor />

--- a/docs/pages/web/activationcard.js
+++ b/docs/pages/web/activationcard.js
@@ -23,7 +23,7 @@ export default function ActivationCardPage({
 }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample name="Main Example" code={mainExample} layout="column" hideEditor />
       </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/web/avatar.js
+++ b/docs/pages/web/avatar.js
@@ -27,6 +27,7 @@ export default function AvatarPage({ generatedDocGen }: { generatedDocGen: DocGe
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/avatargroup.js
+++ b/docs/pages/web/avatargroup.js
@@ -28,7 +28,7 @@ export default function AvatarGroupPage({
 }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="No image source" hideEditor previewHeight={200} />
       </PageHeader>
 

--- a/docs/pages/web/badge.js
+++ b/docs/pages/web/badge.js
@@ -21,7 +21,7 @@ import variantsType from '../../examples/badge/variantsType';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Badge example" hideEditor previewHeight={150} />
       </PageHeader>
 

--- a/docs/pages/web/box.js
+++ b/docs/pages/web/box.js
@@ -96,6 +96,7 @@ export default function BoxPage({ generatedDocGen }: { generatedDocGen: DocGen }
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/button.js
+++ b/docs/pages/web/button.js
@@ -34,6 +34,7 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/buttongroup.js
+++ b/docs/pages/web/buttongroup.js
@@ -14,7 +14,7 @@ import variantsWrap from '../../examples/buttongroup/variantsWrap';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen.description}>
         <SandpackExample code={main} name="ButtonGroup Main Example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -30,6 +30,7 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/callout.js
+++ b/docs/pages/web/callout.js
@@ -28,7 +28,7 @@ import variantWarning from '../../examples/callout/variantWarning';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/chartgraph.js
+++ b/docs/pages/web/chartgraph.js
@@ -59,6 +59,7 @@ export default function ComponentPage({
     <Page title={generatedDocGen.ChartGraph?.displayName}>
       <PageHeader
         name={generatedDocGen.ChartGraph?.displayName}
+        packageFileLocation={generatedDocGen?.ChartGraph?.packageFileLocation}
         description={generatedDocGen.ChartGraph?.description}
         slimBanner={
           <SlimBanner

--- a/docs/pages/web/checkbox.js
+++ b/docs/pages/web/checkbox.js
@@ -31,7 +31,7 @@ import withImageExample from '../../examples/checkbox/withImageExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/collage.js
+++ b/docs/pages/web/collage.js
@@ -18,7 +18,7 @@ import variantsLayoutKey from '../../examples/collage/variantsLayoutKey';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Collage example" hideEditor previewHeight={325} />
       </PageHeader>
 

--- a/docs/pages/web/column.js
+++ b/docs/pages/web/column.js
@@ -22,7 +22,7 @@ const ignoredProps = ['smSpan', 'mdSpan', 'lgSpan'];
 export default function ColumnPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={ignoredProps} />
 

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -29,6 +29,7 @@ export default function ComboBoxPage({ generatedDocGen }: { generatedDocGen: Doc
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/container.js
+++ b/docs/pages/web/container.js
@@ -13,7 +13,7 @@ import variantsResponsive from '../../examples/container/variantsResponsive';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/datapoint.js
+++ b/docs/pages/web/datapoint.js
@@ -26,7 +26,7 @@ import withBadgeExample from '../../examples/datapoint/withBadgeExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           name="Main Example"
           code={mainExample}

--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -102,6 +102,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
         badge="experimental"
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         slimBanner={
           <SlimBanner
             type="warning"

--- a/docs/pages/web/datepicker.js
+++ b/docs/pages/web/datepicker.js
@@ -109,7 +109,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
 
   return (
     <Page title="DatePicker">
-      <PageHeader name="DatePicker" description={generatedDocGen?.description} pdocsLink>
+      <PageHeader name="DatePicker" packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -112,6 +112,7 @@ export default function DatePickerPage({
       <PageHeader
         badge="pilot"
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBanner

--- a/docs/pages/web/divider.js
+++ b/docs/pages/web/divider.js
@@ -23,7 +23,7 @@ import useWhitespaceToSeparateGroups from '../../examples/divider/useWhitespaceT
 export default function DividerPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           name="Main Example"
           code={mainExample}

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -38,6 +38,7 @@ export default function ComponentPage({
     <Page title={generatedDocGen.Dropdown?.displayName}>
       <PageHeader
         name={generatedDocGen?.Dropdown.displayName}
+        packageFileLocation={generatedDocGen?.Dropdown?.packageFileLocation}
         description={generatedDocGen?.Dropdown.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/fieldset.js
+++ b/docs/pages/web/fieldset.js
@@ -17,7 +17,7 @@ import variantsLegend from '../../examples/fieldset/variantsLegend';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/flex.js
+++ b/docs/pages/web/flex.js
@@ -29,6 +29,7 @@ export default function DocsPage({
     <Page title={generatedDocGen?.Flex?.displayName}>
       <PageHeader
         name={generatedDocGen?.Flex?.displayName}
+        packageFileLocation={generatedDocGen?.Flex?.packageFileLocation}
         description={generatedDocGen?.Flex?.description}
         pdocsLink
       >

--- a/docs/pages/web/heading.js
+++ b/docs/pages/web/heading.js
@@ -29,7 +29,7 @@ import variantsExample from '../../examples/heading/variantsExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           name="Use to help group text and items into sections in a logical order."
           code={mainExample}

--- a/docs/pages/web/helpbutton.js
+++ b/docs/pages/web/helpbutton.js
@@ -24,6 +24,7 @@ export default function DocsPage({ generatedDocGen }: DocsType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/icon.js
+++ b/docs/pages/web/icon.js
@@ -24,7 +24,7 @@ const HEIGHT = 150;
 export default function IconPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Button example" hideEditor previewHeight={HEIGHT} />
       </PageHeader>
 

--- a/docs/pages/web/iconbutton.js
+++ b/docs/pages/web/iconbutton.js
@@ -31,6 +31,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/iconbuttonfloating.js
+++ b/docs/pages/web/iconbuttonfloating.js
@@ -19,7 +19,7 @@ import variantsWithTooltip from '../../examples/iconbuttonfloating/variantsWithT
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main IconButtonFloating example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/iconbuttonlink.js
+++ b/docs/pages/web/iconbuttonlink.js
@@ -18,6 +18,7 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
         slimBanner={

--- a/docs/pages/web/image.js
+++ b/docs/pages/web/image.js
@@ -17,7 +17,7 @@ import scalingImageToFitContainer from '../../examples/image/scalingImageToFitCo
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/label.js
+++ b/docs/pages/web/label.js
@@ -13,7 +13,7 @@ import variantWithFormComponent from '../../examples/label/variantWithFormCompon
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/layer.js
+++ b/docs/pages/web/layer.js
@@ -14,7 +14,7 @@ import stackingUsingZIndexExample from '../../examples/layer/stackingUsingZIndex
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title="Layer">
-      <PageHeader name="Layer" description={generatedDocGen?.description} />
+      <PageHeader name="Layer" packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/letterbox.js
+++ b/docs/pages/web/letterbox.js
@@ -18,7 +18,7 @@ import variantWide from '../../examples/letterbox/variantWide';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Letterbox example" hideEditor previewHeight={250} />
       </PageHeader>
 

--- a/docs/pages/web/link.js
+++ b/docs/pages/web/link.js
@@ -39,7 +39,7 @@ import variantTarget from '../../examples/link/variantTarget';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Badge example" hideEditor previewHeight={150} />
       </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} excludeProps={['disabled']} />

--- a/docs/pages/web/list.js
+++ b/docs/pages/web/list.js
@@ -37,6 +37,7 @@ export default function ListPage({
     <Page title={generatedDocGen?.List.displayName}>
       <PageHeader
         name={generatedDocGen?.List.displayName}
+        packageFileLocation={generatedDocGen?.List?.packageFileLocation}
         description={generatedDocGen?.List.description}
       >
         <SandpackExample

--- a/docs/pages/web/mask.js
+++ b/docs/pages/web/mask.js
@@ -18,7 +18,7 @@ import variantWillChangeTransform from '../../examples/mask/variantWillChangeTra
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={variantContent} hideEditor name="Image Mask example" />
       </PageHeader>
 

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -21,6 +21,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/modal.js
+++ b/docs/pages/web/modal.js
@@ -24,7 +24,7 @@ export default function ModalPage({ generatedDocGen }: { generatedDocGen: DocGen
 
   return (
     <Page title="Modal">
-      <PageHeader name="Modal" description={generatedDocGen?.description} pdocsLink>
+      <PageHeader name="Modal" packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           code={accessibilityExample}
           name="Modal Main Example"

--- a/docs/pages/web/modalalert.js
+++ b/docs/pages/web/modalalert.js
@@ -36,7 +36,7 @@ export default function ModalAlertPage({
 }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name="ModalAlert Main Example"

--- a/docs/pages/web/numberfield.js
+++ b/docs/pages/web/numberfield.js
@@ -33,7 +33,7 @@ const previewHeightPx = 235;
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           hideEditor

--- a/docs/pages/web/overlaypanel.js
+++ b/docs/pages/web/overlaypanel.js
@@ -32,6 +32,7 @@ export default function SheetPage({
     <Page title={generatedDocGen?.OverlayPanel.displayName}>
       <PageHeader
         name={generatedDocGen?.OverlayPanel.displayName}
+        packageFileLocation={generatedDocGen?.OverlayPanel?.packageFileLocation}
         description={generatedDocGen?.OverlayPanel.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/pageheader.js
+++ b/docs/pages/web/pageheader.js
@@ -36,6 +36,7 @@ export default function PageHeaderPage({
     <Page title={generatedDocGen?.displayName}>
       <DocsPageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/pog.js
+++ b/docs/pages/web/pog.js
@@ -15,7 +15,7 @@ import main from '../../examples/pog/main';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title="Pog">
-      <PageHeader name="Pog" description={generatedDocGen?.description}>
+      <PageHeader name="Pog" description={generatedDocGen?.description} packageFileLocation={generatedDocGen?.packageFileLocation}>
         <SandpackExample
           name="Main Example"
           code={main}

--- a/docs/pages/web/popover.js
+++ b/docs/pages/web/popover.js
@@ -25,6 +25,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -25,6 +25,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBannerExperiment

--- a/docs/pages/web/pulsar.js
+++ b/docs/pages/web/pulsar.js
@@ -23,7 +23,7 @@ import size from '../../examples/pulsar/size';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Primary Pulsar example" hideEditor previewHeight={250} />
       </PageHeader>
 

--- a/docs/pages/web/radiobutton.js
+++ b/docs/pages/web/radiobutton.js
@@ -12,6 +12,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
       <PageHeader
         name="RadioButton"
         badge="deprecated"
+        packageFileLocation={generatedDocGen?.packageFileLocation}
         description="Use RadioButtons when you have a few options that a user can choose from. Never use radio buttons if the user can select more than one option from a list."
         slimBanner={
           <SlimBanner

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -34,6 +34,7 @@ export default function DocsPage({
     <Page title={generatedDocGen?.RadioGroup?.displayName}>
       <PageHeader
         name={generatedDocGen?.RadioGroup?.displayName}
+        packageFileLocation={generatedDocGen?.RadioGroup?.packageFileLocation}
         description={generatedDocGen?.RadioGroup.description}
       >
         <SandpackExample

--- a/docs/pages/web/searchfield.js
+++ b/docs/pages/web/searchfield.js
@@ -29,7 +29,7 @@ export default function SearchFieldPage({
 }): ReactNode {
   return (
     <Page title="SearchField">
-      <PageHeader name="SearchField" description={generatedDocGen?.description}>
+      <PageHeader name="SearchField" packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           name="Main example"
           code={mainExample}

--- a/docs/pages/web/segmentedcontrol.js
+++ b/docs/pages/web/segmentedcontrol.js
@@ -16,7 +16,7 @@ import sizeExample from '../../examples/segmentedcontrol/sizeExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title="SegmentedControl">
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen.description}>
         <SandpackExample code={mainExample} name="SegmentedControl Main Example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/selectlist.js
+++ b/docs/pages/web/selectlist.js
@@ -33,6 +33,7 @@ export default function DocsPage({
     <Page title={generatedDocGen?.SelectList?.displayName}>
       <PageHeader
         name={generatedDocGen?.SelectList?.displayName}
+        packageFileLocation={generatedDocGen?.SelectList?.packageFileLocation}
         description={generatedDocGen?.SelectList?.description}
       >
         <SandpackExample

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -36,6 +36,7 @@ export default function SheetMobilePage({
       <PageHeader
         badge="pilot"
         name={generatedDocGen?.SheetMobile.displayName}
+        packageFileLocation={generatedDocGen?.SheetMobile.packageFileLocation}
         description={generatedDocGen?.SheetMobile.description}
         pdocsLink
         slimBanner={

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -46,6 +46,7 @@ export default function SideNavigationPage({
     <Page title={generatedDocGen.SideNavigation?.displayName ?? ''}>
       <PageHeader
         name={generatedDocGen.SideNavigation?.displayName}
+        packageFileLocation={generatedDocGen?.SideNavigation.packageFileLocation}
         description={generatedDocGen.SideNavigation?.description}
       >
         <SandpackExample

--- a/docs/pages/web/slimbanner.js
+++ b/docs/pages/web/slimbanner.js
@@ -38,7 +38,7 @@ export default function SlimBannerPage({
 }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/spinner.js
+++ b/docs/pages/web/spinner.js
@@ -22,7 +22,7 @@ import main from '../../examples/spinner/main';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name="Primary Spinner example"

--- a/docs/pages/web/status.js
+++ b/docs/pages/web/status.js
@@ -24,7 +24,7 @@ import useToCommunicateAStepIn from '../../examples/status/useToCommunicateAStep
 export default function StatusPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title="Status">
-      <PageHeader name="Status" description={generatedDocGen?.description}>
+      <PageHeader name="Status" description={generatedDocGen?.description} packageFileLocation={generatedDocGen?.packageFileLocation}>
         <SandpackExample
           name="Main Example"
           code={mainExample}

--- a/docs/pages/web/sticky.js
+++ b/docs/pages/web/sticky.js
@@ -12,7 +12,7 @@ import main from '../../examples/sticky/main';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Sticky top" layout="column" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/switch.js
+++ b/docs/pages/web/switch.js
@@ -20,7 +20,7 @@ import variantLabel from '../../examples/switch/variantLabel';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen?.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Primary Switch example" hideEditor previewHeight={150} />
       </PageHeader>
       <GeneratedPropTable generatedDocGen={generatedDocGen} />

--- a/docs/pages/web/table.js
+++ b/docs/pages/web/table.js
@@ -43,6 +43,7 @@ export default function DocsPage({
     <Page title={generatedDocGen.Table?.displayName}>
       <PageHeader
         name={generatedDocGen.Table?.displayName}
+        packageFileLocation={generatedDocGen.Table?.packageFileLocation}
         description={generatedDocGen.Table?.description}
       >
         <SandpackExample code={main} name="Main Table example" hideEditor />

--- a/docs/pages/web/tableofcontents.js
+++ b/docs/pages/web/tableofcontents.js
@@ -25,6 +25,7 @@ export default function TableOfContentsPage({
     <Page title={generatedDocGen?.TableOfContents.displayName}>
       <PageHeader
         name={generatedDocGen?.TableOfContents.displayName}
+        packageFileLocation={generatedDocGen.TableOfContents?.packageFileLocation}
         description={generatedDocGen?.TableOfContents.description}
       >
         <SandpackExample code={main} hideEditor name="Main TableOfContents example" />

--- a/docs/pages/web/tabs.js
+++ b/docs/pages/web/tabs.js
@@ -23,7 +23,7 @@ import wrapping from '../../examples/tabs/wrapping';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen.displayName} description={generatedDocGen.description}>
+      <PageHeader name={generatedDocGen.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen.description}>
         <SandpackExample
           code={mainExample}
           name="Tabs Main Example"

--- a/docs/pages/web/tag.js
+++ b/docs/pages/web/tag.js
@@ -27,7 +27,7 @@ import variantWarning from '../../examples/tag/variantWarning';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen.description}>
         <SandpackExample code={main} name="Tag Main Example" hideEditor />
       </PageHeader>
 

--- a/docs/pages/web/tagdata.js
+++ b/docs/pages/web/tagdata.js
@@ -28,7 +28,7 @@ import tooltip from '../../examples/tagdata/tooltip';
 export default function TagDataPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Tagdata Example" hideEditor previewHeight={150} />
       </PageHeader>
 

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -26,6 +26,7 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/taparealink.js
+++ b/docs/pages/web/taparealink.js
@@ -23,6 +23,7 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/text.js
+++ b/docs/pages/web/text.js
@@ -31,7 +31,7 @@ import variantTitle from '../../examples/text/variantTitle';
 export default function TextPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main Badge example" hideEditor previewHeight={150} />
       </PageHeader>
 

--- a/docs/pages/web/textarea.js
+++ b/docs/pages/web/textarea.js
@@ -32,7 +32,7 @@ import withTagsExample from '../../examples/textarea/withTagsExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -40,7 +40,7 @@ import useHelperTextImportantInformation from '../../examples/textfield/useHelpe
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample
           code={main}
           name={`Main ${generatedDocGen?.displayName} example`}

--- a/docs/pages/web/tiledata.js
+++ b/docs/pages/web/tiledata.js
@@ -1,4 +1,4 @@
-// @flow strict
+ // @flow strict
 import { type Node as ReactNode } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
 import docGen, { type DocGen } from '../../docs-components/docgen';
@@ -22,7 +22,7 @@ import tooltip from '../../examples/tiledata/tooltip';
 export default function TileDataPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description}>
         <SandpackExample code={main} name="Main TileData Example" hideEditor previewHeight={150} />
       </PageHeader>
 

--- a/docs/pages/web/toast.js
+++ b/docs/pages/web/toast.js
@@ -39,6 +39,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
         name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen.packageFileLocation}
         description={generatedDocGen?.description}
         pdocsLink
       >

--- a/docs/pages/web/tooltip.js
+++ b/docs/pages/web/tooltip.js
@@ -30,6 +30,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
     <Page title="Tooltip">
       <PageHeader
         name="Tooltip"
+        packageFileLocation={generatedDocGen.packageFileLocation}
         description={generatedDocGen?.description}
         slimBanner={
           <SlimBanner

--- a/docs/pages/web/upsell.js
+++ b/docs/pages/web/upsell.js
@@ -35,6 +35,7 @@ export default function DocsPage({
     <Page title={generatedDocGen?.Upsell?.displayName}>
       <PageHeader
         name={generatedDocGen?.Upsell?.displayName}
+        packageFileLocation={generatedDocGen.Upsell?.packageFileLocation}
         description={generatedDocGen?.Upsell?.description}
       >
         <SandpackExample

--- a/docs/pages/web/utilities/defaultlabelprovider.js
+++ b/docs/pages/web/utilities/defaultlabelprovider.js
@@ -345,7 +345,11 @@ function getLabelsTable(/* fallbackLabels: { [string]: { [string]: mixed } } */)
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader
+        name={generatedDocGen?.displayName}
+        packageFileLocation={generatedDocGen.packageFileLocation}
+        description={generatedDocGen?.description}
+      />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/utilities/scrollboundarycontainer.js
+++ b/docs/pages/web/utilities/scrollboundarycontainer.js
@@ -20,7 +20,7 @@ export default function ScrollBoundaryContainerPage({
 }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen?.description} />
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description} />
 
       <GeneratedPropTable generatedDocGen={generatedDocGen} />
 

--- a/docs/pages/web/video.js
+++ b/docs/pages/web/video.js
@@ -22,7 +22,7 @@ import withChildrenExample from '../../examples/video/withChildrenExample';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title="Video">
-      <PageHeader name="Video" description={generatedDocGen?.description} pdocsLink>
+      <PageHeader name="Video" packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen?.description} pdocsLink>
         <SandpackExample
           name="Main Example"
           code={mainExample}

--- a/docs/pages/web/washanimated.js
+++ b/docs/pages/web/washanimated.js
@@ -13,7 +13,7 @@ import main from '../../examples/washanimated/main';
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader name={generatedDocGen?.displayName} description={generatedDocGen.description}>
+      <PageHeader name={generatedDocGen?.displayName} packageFileLocation={generatedDocGen.packageFileLocation} description={generatedDocGen.description}>
         <SandpackExample
           code={main}
           name="WashAnimated main example"

--- a/docs/pages/web/zindex_classes.js
+++ b/docs/pages/web/zindex_classes.js
@@ -14,6 +14,7 @@ export default function DocsPage(): ReactNode {
     <Page title="Z-Index Classes">
       <PageHeader
         name="Z-Index Classes"
+        packageFileLocation="gestalt/src/zIndex.js"
         description="FixedZIndex and CompositeZIndex are utility classes that generate z-indices for Gestalt components."
       />
 

--- a/scripts/generateMetadata.js
+++ b/scripts/generateMetadata.js
@@ -43,6 +43,9 @@ async function docgen(filePath) {
   try {
     // Take only the first exported component
     const [parsed] = reactDocs.parse(contents, { resolver });
+    const [, packageFileLocation] = filePath.split("/packages/");
+
+    parsed.packageFileLocation = packageFileLocation;
 
     if (parsed.description) {
       parsed.description = parsed.description


### PR DESCRIPTION
### Summary

#### What changed?

In order to provide the right github file url I decided to intro [packageFileLocation](https://github.com/andreyctkn/gestalt/blob/fix/docs_github_view_sources/scripts/generateMetadata.js#L48) which can be generated on the fly for the `generateMetadata` step.  As a second step I passed this `prop` to all docs components. 

#### Why?

the current documentation sometimes has a wrong reference to the github file for example: https://gestalt.pinterest.systems/web/utilities/defaultlabelprovider -> https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/DefaultLabelProvider.js

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)

I tested locally the docs build via clicking all links for github 
