### PR TITLE
TapArea: Add cursor doc changes

### DIFF
--- a/docs/examples/taparea/mouseCursor.js
+++ b/docs/examples/taparea/mouseCursor.js
@@ -2,6 +2,21 @@
 import { type Node as ReactNode } from 'react';
 import { Box, Flex, TapArea, Text } from 'gestalt';
 
+const descriptions = {
+  'copy': 'Use the copy cursor to indicate an element is to be copied.',
+  'default':
+    'Use the default cursor over non-interactive elements. The default cursor should change to a pointer if the element it hovers over is also clickable or indicates functionally',
+  'grab': 'Use the grab cursor to indicate something can be grabbed (dragged to be moved).',
+  'grabbing':
+    'Use the grabbing cursor to indicate something is being grabbed (dragged to be moved).',
+  'move': 'Use the move cursor to indicate something is to be moved.',
+  'noDrop':
+    'Use the noDrop cursor to reinforce that an item may not be dropped at the current location.',
+  'pointer': 'Use the pointer cursor to indicate interactive elements, such as links or actions.',
+  'zoomIn': 'Use the ZoomIn cursor to indicate something can be zoomed (magnified) in.',
+  'zoomOut': 'Use the ZoomIn cursor to indicate something can be zoomed out.',
+};
+
 export default function TapAreaExample(): ReactNode {
   return (
     <Flex wrap gap={2}>
@@ -25,18 +40,3 @@ export default function TapAreaExample(): ReactNode {
     </Flex>
   );
 }
-
-const descriptions = {
-  'copy': 'Use the copy cursor to indicate an element is to be copied.',
-  'default':
-    'Use the default cursor over non-interactive elements. The default cursor should change to a pointer if the element it hovers over is also clickable or indicates functionally',
-  'grab': 'Use the grab cursor to indicate something can be grabbed (dragged to be moved).',
-  'grabbing':
-    'Use the grabbing cursor to indicate something is being grabbed (dragged to be moved).',
-  'move': 'Use the move cursor to indicate something is to be moved.',
-  'noDrop':
-    'Use the noDrop cursor to reinforce that an item may not be dropped at the current location.',
-  'pointer': 'Use the pointer cursor to indicate interactive elements, such as links or actions.',
-  'zoomIn': 'Use the ZoomIn cursor to indicate something can be zoomed (magnified) in.',
-  'zoomOut': 'Use the ZoomIn cursor to indicate something can be zoomed out.',
-};

--- a/docs/examples/taparea/mouseCursor.js
+++ b/docs/examples/taparea/mouseCursor.js
@@ -5,26 +5,38 @@ import { Box, Flex, TapArea, Text } from 'gestalt';
 export default function TapAreaExample(): ReactNode {
   return (
     <Flex wrap gap={2}>
-      {[
-        'copy',
-        'grab',
-        'grabbing',
-        'move',
-        'noDrop',
-        'pointer',
-        'zoomIn',
-        'zoomOut',
-        'default',
-      ].map((cursor) => (
+      {Object.keys(descriptions).map((cursor) => (
         <TapArea key={cursor} mouseCursor={cursor} fullWidth={false}>
-          <Box borderStyle="lg" padding={4} width={250} height={100}>
-            <Text size="200">hover here </Text>
-            <Text size="200" weight="bold">
-              {`mouseCursor="${cursor}"`}
-            </Text>
+          <Box borderStyle="lg" padding={4} width={250} height={250}>
+            <Flex direction="column" justifyContent="between" height="100%">
+              <Box>
+                <Box marginBottom={2}>
+                  <Text size="200" weight="bold">
+                    {`mouseCursor="${cursor}"`}
+                  </Text>
+                </Box>
+                <Text size="200">{descriptions[cursor]}</Text>
+              </Box>
+              <Text size="100">hover here </Text>
+            </Flex>
           </Box>
         </TapArea>
       ))}
     </Flex>
   );
 }
+
+const descriptions = {
+  'copy': 'Use the copy cursor to indicate an element is to be copied.',
+  'default':
+    'Use the default cursor over non-interactive elements. The default cursor should change to a pointer if the element it hovers over is also clickable or indicates functionally',
+  'grab': 'Use the grab cursor to indicate something can be grabbed (dragged to be moved).',
+  'grabbing':
+    'Use the grabbing cursor to indicate something is being grabbed (dragged to be moved).',
+  'move': 'Use the move cursor to indicate something is to be moved.',
+  'noDrop':
+    'Use the noDrop cursor to reinforce that an item may not be dropped at the current location.',
+  'pointer': 'Use the pointer cursor to indicate interactive elements, such as links or actions.',
+  'zoomIn': 'Use the ZoomIn cursor to indicate something can be zoomed (magnified) in.',
+  'zoomOut': 'Use the ZoomIn cursor to indicate something can be zoomed out.',
+};

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -93,7 +93,7 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Mouse cursor"
-          description={`Change the cursor on TapArea for different click interactions`}
+          description="Change the cursor on TapArea for different click interactions"
         >
           <MainSection.Card
             sandpackExample={<SandpackExample name="Mouse cursor" code={mouseCursor} hideEditor />}

--- a/docs/pages/web/taparea.js
+++ b/docs/pages/web/taparea.js
@@ -93,11 +93,10 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Mouse cursor"
-          description={`Change the cursor on TapArea for different click interactions. <br/>
-          The default cursor should be used sparingly when there are actions that only have hover actions or part of complex elements where there are other interactive elements.`}
+          description={`Change the cursor on TapArea for different click interactions`}
         >
           <MainSection.Card
-            sandpackExample={<SandpackExample name="Mouse cursor" code={mouseCursor} />}
+            sandpackExample={<SandpackExample name="Mouse cursor" code={mouseCursor} hideEditor />}
           />
         </MainSection.Subsection>
 


### PR DESCRIPTION
### Summary

Add descriptions for each type of cursor and when to use

<img width="859" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/e39fa33b-3b1e-4fe6-8b45-dd05245903e0">

