### PR TITLE
List: Add Sizing to List

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "css.lint.validProperties": ["composes"],
   "editor.codeActionsOnSave": {
+    "source.organizeImports": false,
     "source.fixAll.eslint": true,
     "source.fixAll.shellcheck": true
   },

--- a/docs/examples/list/fontSize.js
+++ b/docs/examples/list/fontSize.js
@@ -1,0 +1,37 @@
+// @flow strict
+import { type Node as ReactNode, useState } from 'react';
+import { Box, List, SegmentedControl, Text } from 'gestalt';
+
+export default function Example(): ReactNode {
+  const [selectedItemIndex, setSelectedItemIndex] = useState(0);
+  const items = ['100', '200', '300', '400', '500', '600'];
+  return (
+    <Box
+      padding={8}
+      height="100%"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      direction="column"
+      gap={6}
+    >
+      <List type="ordered" size={items[selectedItemIndex]}>
+        <List.Item text="List item text" />
+        <List.Item text="List item text">
+          <List.Item text="List item text" />
+          <List.Item text={<Text>List Item text</Text>} />
+        </List.Item>
+        <List.Item text="List item text" />
+      </List>
+      <Box width="500px" paddingY={8}>
+        <SegmentedControl
+          items={items}
+          selectedItemIndex={selectedItemIndex}
+          onChange={({ activeIndex }) => {
+            setSelectedItemIndex(activeIndex);
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/docs/pages/web/list.js
+++ b/docs/pages/web/list.js
@@ -9,6 +9,8 @@ import PageHeader from '../../docs-components/PageHeader';
 import SandpackExample from '../../docs-components/SandpackExample';
 import dontUseIfDisplayingFewerThanTwo from '../../examples/list/dontUseIfDisplayingFewerThanTwo';
 import dontUseIfWholeItemIsSelectable from '../../examples/list/dontUseIfWholeItemIsSelectable';
+import fontSize from '../../examples/list/fontSize';
+import sizingExample from '../../examples/list/fontSize';
 import includeLinksIfRelevant from '../../examples/list/includeLinksIfRelevant';
 import labelsExample from '../../examples/list/labelsExample';
 import labelsExample1 from '../../examples/list/labelsExample1';
@@ -294,6 +296,16 @@ List's \`label\` prop is used for accessibility purposes. See the [accessibility
                 layout="column"
               />
             }
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Size"
+          description={`
+          List can be used with different font sizes. The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [Text sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details. `}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={<SandpackExample name="Font Sizing" code={fontSize} />}
           />
         </MainSection.Subsection>
 

--- a/docs/pages/web/list.js
+++ b/docs/pages/web/list.js
@@ -10,7 +10,6 @@ import SandpackExample from '../../docs-components/SandpackExample';
 import dontUseIfDisplayingFewerThanTwo from '../../examples/list/dontUseIfDisplayingFewerThanTwo';
 import dontUseIfWholeItemIsSelectable from '../../examples/list/dontUseIfWholeItemIsSelectable';
 import fontSize from '../../examples/list/fontSize';
-import sizingExample from '../../examples/list/fontSize';
 import includeLinksIfRelevant from '../../examples/list/includeLinksIfRelevant';
 import labelsExample from '../../examples/list/labelsExample';
 import labelsExample1 from '../../examples/list/labelsExample1';

--- a/packages/gestalt/src/List.js
+++ b/packages/gestalt/src/List.js
@@ -5,6 +5,7 @@ import ListItem from './ListItem'; // eslint-disable import/no-cycle
 import Text from './Text';
 
 type ListType = 'bare' | 'ordered' | 'unordered';
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
 type Props = {
   /**
@@ -24,6 +25,10 @@ type Props = {
    */
   spacing?: 'regular' | 'condensed',
   /**
+   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [Text sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details.
+   */
+  size?: Size,
+  /**
    * Determines the style of the list. See the [type variant](https://gestalt.pinterest.systems/web/list#Type) to learn more.
    */
   type?: ListType,
@@ -38,12 +43,19 @@ function List({
   label,
   labelDisplay = 'visible',
   spacing = 'regular',
+  size = '300',
   type,
   children,
 }: Props): ReactNode {
   return (
     // We need this InternalList to avoid the circular dependency src/List.js -> src/ListItem.js -> src/List.js
-    <InternalList type={type} spacing={spacing} label={label} labelDisplay={labelDisplay}>
+    <InternalList
+      type={type}
+      spacing={spacing}
+      size={size}
+      label={label}
+      labelDisplay={labelDisplay}
+    >
       {children}
     </InternalList>
   );

--- a/packages/gestalt/src/List.js
+++ b/packages/gestalt/src/List.js
@@ -25,11 +25,11 @@ type Props = {
    */
   spacing?: 'regular' | 'condensed',
   /**
-   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [Text sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details.
+   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [Text sizes variant](https://gestalt.pinterest.systems/web/List#Size) for more details.
    */
   size?: Size,
   /**
-   * Determines the style of the list. See the [type variant](https://gestalt.pinterest.systems/web/list#Type) to learn more.
+   * Determines the style of the list. See the [type variant](https://gestalt.pinterest.systems/web/list#Type) to learn more about how sizing is applied.
    */
   type?: ListType,
 };

--- a/packages/gestalt/src/List/InternalList.js
+++ b/packages/gestalt/src/List/InternalList.js
@@ -22,6 +22,7 @@ const STYLE_SEQUENCE_UNORDERED = Object.freeze([
 const STYLE_SEQUENCE_ORDERED = Object.freeze([...ORDERED_SEQUENCE, ...ORDERED_SEQUENCE]);
 
 type ListType = 'bare' | 'ordered' | 'unordered';
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
 
 type Props = {
   /**
@@ -41,6 +42,10 @@ type Props = {
    */
   spacing?: 'regular' | 'condensed',
   /**
+   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [sizes variant](https://gestalt.pinterest.systems/web/text#Sizes) for more details.
+   */
+  size?: Size,
+  /**
    * Determines the style of the list. See the [type variant](https://gestalt.pinterest.systems/web/list#Type) to learn more.
    */
   type?: ListType,
@@ -50,12 +55,13 @@ function InternalList({
   label,
   labelDisplay = 'visible',
   spacing = 'regular',
+  size = '300',
   type,
   children,
 }: Props): ReactNode {
   const id = useId();
   const { nestedLevel } = useNesting();
-  const { type: inheritedType, style: inheritedStyle } = useList();
+  const { type: inheritedType, style: inheritedStyle, size: inheritedFontSize } = useList();
 
   const listType = type ?? inheritedType ?? 'unordered';
 
@@ -97,6 +103,7 @@ function InternalList({
     <ListProvider
       type={listType}
       spacing={spacing}
+      size={size}
       style={
         isListParent
           ? { ol: STYLE_SEQUENCE_ORDERED, ul: STYLE_SEQUENCE_UNORDERED }
@@ -111,7 +118,7 @@ function InternalList({
               display={hiddenLabel ? 'visuallyHidden' : 'block'}
               marginBottom={hiddenLabel ? 0 : 4}
             >
-              <ListText text={label} />
+              <ListText text={label} size={inheritedFontSize} />
             </Box>
             {formattedListElement}
           </Flex>

--- a/packages/gestalt/src/List/Message.js
+++ b/packages/gestalt/src/List/Message.js
@@ -1,14 +1,17 @@
 // @flow strict
-import { Children, type Element, type Node as ReactNode } from 'react';
+import { Children, cloneElement, type Element, type Node as ReactNode } from 'react';
 import { useColorScheme } from '../contexts/ColorSchemeProvider';
 import styles from '../List.css';
 import Text from '../Text';
 
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
+
 type Props = {
+  size: ?Size,
   text: string | Element<typeof Text>,
 };
 
-export default function ListText({ text }: Props): ReactNode {
+export default function ListText({ size, text }: Props): ReactNode {
   const { name: colorSchemeName } = useColorScheme();
 
   // Flow shuold catch if text is missing. In case Flow is not enabled and text is missing, the errors are not that helpful. This surfaces the problem more explicitly.
@@ -17,7 +20,7 @@ export default function ListText({ text }: Props): ReactNode {
   }
 
   if (typeof text === 'string') {
-    return <Text>{text}</Text>;
+    return <Text size={size || undefined}>{text}</Text>;
   }
 
   // If `text` is a Text component, we need to override any text colors within to ensure they all match
@@ -31,7 +34,11 @@ export default function ListText({ text }: Props): ReactNode {
       ? styles.textColorOverrideLight
       : styles.textColorOverrideDark;
 
-    return <span className={textColorOverrideStyles}>{text}</span>;
+    return (
+      <span className={textColorOverrideStyles}>
+        {cloneElement(text, { size: size || undefined })}
+      </span>
+    );
   }
 
   throw new Error(

--- a/packages/gestalt/src/ListItem.js
+++ b/packages/gestalt/src/ListItem.js
@@ -26,7 +26,12 @@ type Props = {
  *
  */
 function ListItem({ text, children }: Props): ReactNode {
-  const { type: inheritedType, spacing: inheritedSpacing, style: inheritedStyle } = useList();
+  const {
+    type: inheritedType,
+    spacing: inheritedSpacing,
+    style: inheritedStyle,
+    size: inheritedFontSize,
+  } = useList();
 
   const isOrdered = inheritedType === 'ordered';
   const isUnordered = inheritedType === 'unordered';
@@ -67,8 +72,11 @@ function ListItem({ text, children }: Props): ReactNode {
   });
 
   return (
-    <li className={className}>
-      <ListText text={text} />
+    <li
+      className={className}
+      style={{ fontSize: inheritedFontSize && `var(--font-size-${inheritedFontSize})` }}
+    >
+      <ListText text={text} size={inheritedFontSize || undefined} />
       {listChildren}
     </li>
   );

--- a/packages/gestalt/src/__snapshots__/List.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/List.test.js.snap
@@ -23,6 +23,11 @@ exports[`List renders a bare unordered list 1`] = `
     >
       <li
         className="noStyle listItem"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -35,6 +40,11 @@ exports[`List renders a bare unordered list 1`] = `
         >
           <li
             className="noStyle listItem"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -47,6 +57,11 @@ exports[`List renders a bare unordered list 1`] = `
             >
               <li
                 className="noStyle listItem"
+                style={
+                  Object {
+                    "fontSize": "var(--font-size-300)",
+                  }
+                }
               >
                 <div
                   className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -59,6 +74,11 @@ exports[`List renders a bare unordered list 1`] = `
                 >
                   <li
                     className="noStyle listItem"
+                    style={
+                      Object {
+                        "fontSize": "var(--font-size-300)",
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -71,6 +91,11 @@ exports[`List renders a bare unordered list 1`] = `
                     >
                       <li
                         className="noStyle listItem"
+                        style={
+                          Object {
+                            "fontSize": "var(--font-size-300)",
+                          }
+                        }
                       >
                         <div
                           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -83,6 +108,11 @@ exports[`List renders a bare unordered list 1`] = `
                         >
                           <li
                             className="noStyle listItem"
+                            style={
+                              Object {
+                                "fontSize": "var(--font-size-300)",
+                              }
+                            }
                           >
                             <div
                               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -128,6 +158,11 @@ exports[`List renders an condensed list 1`] = `
     >
       <li
         className="listItemCondensed olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -163,6 +198,11 @@ exports[`List renders an list item with custom text 1`] = `
     >
       <li
         className="listItemCondensed olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <span
           className="textColorOverrideDark"
@@ -206,6 +246,11 @@ exports[`List renders an list with a custom label 1`] = `
     >
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -241,6 +286,11 @@ exports[`List renders an list with a hidden label 1`] = `
     >
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -276,6 +326,11 @@ exports[`List renders an mixed list 1`] = `
     >
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -285,6 +340,11 @@ exports[`List renders an mixed list 1`] = `
       </li>
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -297,6 +357,11 @@ exports[`List renders an mixed list 1`] = `
         >
           <li
             className="listItem ulItemDot"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -306,6 +371,11 @@ exports[`List renders an mixed list 1`] = `
           </li>
           <li
             className="listItem ulItemDot"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -318,6 +388,11 @@ exports[`List renders an mixed list 1`] = `
             >
               <li
                 className="listItem ulItemCircle"
+                style={
+                  Object {
+                    "fontSize": "var(--font-size-300)",
+                  }
+                }
               >
                 <div
                   className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -327,6 +402,11 @@ exports[`List renders an mixed list 1`] = `
               </li>
               <li
                 className="listItem ulItemCircle"
+                style={
+                  Object {
+                    "fontSize": "var(--font-size-300)",
+                  }
+                }
               >
                 <div
                   className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -339,6 +419,11 @@ exports[`List renders an mixed list 1`] = `
                 >
                   <li
                     className="listItem olItem1"
+                    style={
+                      Object {
+                        "fontSize": "var(--font-size-300)",
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -348,6 +433,11 @@ exports[`List renders an mixed list 1`] = `
                   </li>
                   <li
                     className="listItem olItem1"
+                    style={
+                      Object {
+                        "fontSize": "var(--font-size-300)",
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -361,6 +451,11 @@ exports[`List renders an mixed list 1`] = `
           </li>
           <li
             className="listItem ulItemDot"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -372,6 +467,11 @@ exports[`List renders an mixed list 1`] = `
       </li>
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -407,6 +507,11 @@ exports[`List renders an ordered list 1`] = `
     >
       <li
         className="listItem olItem1"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -419,6 +524,11 @@ exports[`List renders an ordered list 1`] = `
         >
           <li
             className="listItem olItemA"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -431,6 +541,11 @@ exports[`List renders an ordered list 1`] = `
             >
               <li
                 className="listItem olItema"
+                style={
+                  Object {
+                    "fontSize": "var(--font-size-300)",
+                  }
+                }
               >
                 <div
                   className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -443,6 +558,11 @@ exports[`List renders an ordered list 1`] = `
                 >
                   <li
                     className="listItem olItem1"
+                    style={
+                      Object {
+                        "fontSize": "var(--font-size-300)",
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -455,6 +575,11 @@ exports[`List renders an ordered list 1`] = `
                     >
                       <li
                         className="listItem olItemA"
+                        style={
+                          Object {
+                            "fontSize": "var(--font-size-300)",
+                          }
+                        }
                       >
                         <div
                           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -467,6 +592,11 @@ exports[`List renders an ordered list 1`] = `
                         >
                           <li
                             className="listItem olItema"
+                            style={
+                              Object {
+                                "fontSize": "var(--font-size-300)",
+                              }
+                            }
                           >
                             <div
                               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -512,6 +642,11 @@ exports[`List renders an unordered list 1`] = `
     >
       <li
         className="listItem ulItemDot"
+        style={
+          Object {
+            "fontSize": "var(--font-size-300)",
+          }
+        }
       >
         <div
           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -524,6 +659,11 @@ exports[`List renders an unordered list 1`] = `
         >
           <li
             className="listItem ulItemCircle"
+            style={
+              Object {
+                "fontSize": "var(--font-size-300)",
+              }
+            }
           >
             <div
               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -536,6 +676,11 @@ exports[`List renders an unordered list 1`] = `
             >
               <li
                 className="listItem ulItemDot"
+                style={
+                  Object {
+                    "fontSize": "var(--font-size-300)",
+                  }
+                }
               >
                 <div
                   className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -548,6 +693,11 @@ exports[`List renders an unordered list 1`] = `
                 >
                   <li
                     className="listItem ulItemCircle"
+                    style={
+                      Object {
+                        "fontSize": "var(--font-size-300)",
+                      }
+                    }
                   >
                     <div
                       className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -560,6 +710,11 @@ exports[`List renders an unordered list 1`] = `
                     >
                       <li
                         className="listItem ulItemDot"
+                        style={
+                          Object {
+                            "fontSize": "var(--font-size-300)",
+                          }
+                        }
                       >
                         <div
                           className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"
@@ -572,6 +727,11 @@ exports[`List renders an unordered list 1`] = `
                         >
                           <li
                             className="listItem ulItemCircle"
+                            style={
+                              Object {
+                                "fontSize": "var(--font-size-300)",
+                              }
+                            }
                           >
                             <div
                               className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal"

--- a/packages/gestalt/src/contexts/ListProvider.js
+++ b/packages/gestalt/src/contexts/ListProvider.js
@@ -7,6 +7,7 @@ import {
   useContext,
 } from 'react';
 
+type Size = '100' | '200' | '300' | '400' | '500' | '600';
 type ListTypeContextValues = 'bare' | 'ordered' | 'unordered';
 type ListSpacingContextValues = 'regular' | 'condensed';
 type ListStyleContextValues = {
@@ -16,6 +17,7 @@ type ListStyleContextValues = {
 
 type ListContextType = {
   type: ?ListTypeContextValues,
+  size: ?Size,
   spacing: ?ListSpacingContextValues,
   style: ?ListStyleContextValues,
 };
@@ -23,20 +25,26 @@ type ListContextType = {
 type Props = {
   children: ReactNode,
   type: ?ListTypeContextValues,
+  size: ?Size,
   spacing: ?ListSpacingContextValues,
   style: ?ListStyleContextValues,
 };
 
 const ListContext: Context<ListContextType> = createContext<ListContextType>({
   type: null,
+  size: null,
   spacing: null,
   style: null,
 });
 
 const { Provider } = ListContext;
 
-function ListProvider({ children, type, spacing, style }: Props): Element<typeof Provider> {
-  const { type: inheritedType, spacing: inheritedSpacing } = useContext(ListContext);
+function ListProvider({ children, type, size, spacing, style }: Props): Element<typeof Provider> {
+  const {
+    type: inheritedType,
+    spacing: inheritedSpacing,
+    size: inheritedFontSize,
+  } = useContext(ListContext);
 
   return (
     <Provider
@@ -45,6 +53,7 @@ function ListProvider({ children, type, spacing, style }: Props): Element<typeof
         type: type ?? inheritedType,
         // List Provider is within List. Only List has a spacing prop. The spacing set on the List must be passed down on the nested providers so it does not get overriden. However, the top provider needs the spacing value set on List.
         spacing: inheritedSpacing ?? spacing,
+        size: inheritedFontSize ?? size,
         style,
       }}
     >
@@ -54,8 +63,8 @@ function ListProvider({ children, type, spacing, style }: Props): Element<typeof
 }
 
 function useList(): ListContextType {
-  const { type, spacing, style } = useContext(ListContext);
-  return { type, spacing, style };
+  const { type, size, spacing, style } = useContext(ListContext);
+  return { type, size, spacing, style };
 }
 
 export { ListProvider, useList };


### PR DESCRIPTION
Add multiple sizes for list sizing.

### Summary
We support the 'Text' Element in List, but not different font sizes. This adds more font sizing support to List to align with `Text` and passes it to the rest of the children.

Before:
![image](https://github.com/pinterest/gestalt/assets/5509813/e1e21347-39b7-42fb-9668-8ed82f9bac91)


AFter:
<img width="598" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/2d83b4c2-f353-438f-8225-26242d1e19e0">


#### What changed?

Adding support for a `size` prop to for varying and uniform font-sizes

#### Why?
List is used alongside paragraphs and other sets of text. Since it is primarily a text element, aligning with a text sizing here seems good.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
