### PR TITLE
BannerOverlay: fixing trailing space in link examples

### DIFF
--- a/docs/examples/banneroverlay/avatar.js
+++ b/docs/examples/banneroverlay/avatar.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/desktop.js
+++ b/docs/examples/banneroverlay/desktop.js
@@ -28,7 +28,7 @@ export default function Example(): ReactNode {
         title="More to Explore"
         message={
           <Text inline>
-            Discover trending
+            Discover trending{' '}
             <Link display="inlineBlock" target="self" href="#">
               fashion
             </Link>{' '}

--- a/docs/examples/banneroverlay/doConcise.js
+++ b/docs/examples/banneroverlay/doConcise.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending fashion ideas
+          Discover trending fashion ideas{' '}
           <Link display="inlineBlock" target="self" href="#">
             in the app
           </Link>

--- a/docs/examples/banneroverlay/doEducate.js
+++ b/docs/examples/banneroverlay/doEducate.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/doNavigate.js
+++ b/docs/examples/banneroverlay/doNavigate.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/dontCritical.js
+++ b/docs/examples/banneroverlay/dontCritical.js
@@ -18,7 +18,7 @@ export default function Example(): ReactNode {
       offset={{ top: 130, bottom: 24 }}
       message={
         <Text inline>
-          Oops, something went wrong!
+          Oops, something went wrong!{' '}
           <Link display="inlineBlock" target="self" href="#">
             Download the app
           </Link>{' '}

--- a/docs/examples/banneroverlay/icon.js
+++ b/docs/examples/banneroverlay/icon.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/image.js
+++ b/docs/examples/banneroverlay/image.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/main.js
+++ b/docs/examples/banneroverlay/main.js
@@ -19,7 +19,7 @@ export default function Example(): ReactNode {
       title="More to Explore"
       message={
         <Text inline>
-          Discover trending
+          Discover trending{' '}
           <Link display="inlineBlock" target="self" href="#">
             fashion
           </Link>{' '}

--- a/docs/examples/banneroverlay/mobile.js
+++ b/docs/examples/banneroverlay/mobile.js
@@ -28,7 +28,7 @@ export default function Example(): ReactNode {
         title="More to Explore"
         message={
           <Text inline>
-            Discover trending
+            Discover trending{' '}
             <Link display="inlineBlock" target="self" href="#">
               fashion
             </Link>{' '}


### PR DESCRIPTION
### Summary

#### What changed?

Fixed BannerOverlay examples where trailing space was omitted before links.

#### Why?

React Live added those during development, and Sandpack didn't, so the examples ended up looking wrong on release of the component.