### PR TITLE
Docs: Add a docs-update label to non-package related changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+docs-update:
+  - all:
+      - changed-files:
+          - all-globs-to-all-files: '!packages/*'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,21 @@
+name: 'Docs PR Title Checker'
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,4 +1,4 @@
-name: 'Docs PR Title Checker'
+name: 'Label Docs Updates'
 on:
   pull_request_target:
     types:

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -13,6 +13,7 @@ jobs:
   requireLabel:
     name: Require Label
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'docs-update') == false
     steps:
       - uses: zwaldowski/match-label-action@v2
         with:


### PR DESCRIPTION
Automatically add a "docs-update" label for non-docs changes. This will automatically skip package versioning.

As per #3334 this should skip the PR

### Summary
[Github ](https://github.com/actions/labeler)ships a labeler workflow, and we can use that to auto label issues based on file changes. 

#### What changed?

Adding a labeler workflow

#### Why?
Trying to avoid unused versions and only keep package related changes in npm
