### PR TITLE
BannerOverlay: Fixing responsiveness and margin for small desktop viewports

### DIFF
--- a/docs/pages/web/banneroverlay.js
+++ b/docs/pages/web/banneroverlay.js
@@ -26,6 +26,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader
+        badge="pilot"
         name={generatedDocGen?.displayName}
         description={generatedDocGen?.description}
         pdocsLink

--- a/packages/gestalt/src/BannerOverlay.js
+++ b/packages/gestalt/src/BannerOverlay.js
@@ -18,8 +18,8 @@ import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
 import { useDeviceType } from './contexts/DeviceTypeProvider';
 import Flex from './Flex';
 import Icon from './Icon';
-import IconButton from './IconButton';
 import Image from './Image';
+import InternalDismissButton from './shared/InternalDismissButton';
 import {
   ToastAvatarThumbnail,
   ToastIconThumbnail,
@@ -162,9 +162,8 @@ export default function BannerOverlay({
   const { lightModeBackground, darkModeBackground, textColor } = DEFAULT_COLORS;
 
   const dismissButtonComponent = (
-    <IconButton
+    <InternalDismissButton
       accessibilityLabel={accessibilityDismissButtonLabelDefault}
-      icon="cancel"
       iconColor="darkGray"
       onClick={onDismiss}
       size="xs"

--- a/packages/gestalt/src/BannerOverlay.js
+++ b/packages/gestalt/src/BannerOverlay.js
@@ -1,5 +1,11 @@
 // @flow strict
-import { Children, type Element, type ElementConfig, type Node as ReactNode } from 'react';
+import {
+  Children,
+  type Element,
+  type ElementConfig,
+  Fragment,
+  type Node as ReactNode,
+} from 'react';
 import Avatar from './Avatar';
 import styles from './BannerOverlay.css';
 import CallToAction from './BannerOverlay/CalltoAction';
@@ -166,132 +172,274 @@ export default function BannerOverlay({
   );
 
   const isMessageTextNode = checkTextNode();
-  const messageComponent = (
-    <Box marginBottom={isMobileDevice ? 2 : 0}>
-      <ToastMessage
-        text={isMessageTextNode ? undefined : messageTextElement}
-        textElement={isMessageTextNode ? messageTextElement : undefined}
-        textColor={textColor}
-      />
-    </Box>
-  );
   return (
-    <Box
-      color={isDarkMode ? darkModeBackground : lightModeBackground}
-      paddingX={4}
-      paddingY={3}
-      rounding={4}
-      borderStyle="shadow"
-      dangerouslySetInlineStyle={{
-        __style: {
-          position: 'fixed',
-          bottom: isMobileDevice ? offset.bottom : 'unset',
-          top: !isMobileDevice ? offset.top : 'unset',
-          left: '50%',
-          transform: 'translateX(-50%)',
-        },
-      }}
-      position="fixed"
-      display="flex"
-      justifyContent={isMobileDevice ? 'center' : 'between'}
-      alignContent={isMobileDevice ? 'stretch' : 'center'}
-      direction={isMobileDevice ? 'column' : 'row'}
-      smPaddingY={4}
-      fit
-      maxWidth={isMobileDevice ? 348 : 900}
-      width="100%"
-      zIndex={zIndex}
-    >
-      <Flex alignItems="center" gap={4}>
-        {!!thumbnail?.image &&
-        Children.only<Element<typeof Image>>(thumbnail.image).type.displayName === 'Image' ? (
-          <Flex.Item alignSelf={isMobileDevice ? 'baseline' : 'center'}>
-            <ToastImageThumbnail thumbnail={thumbnail.image} />
-          </Flex.Item>
-        ) : null}
+    <Fragment>
+      <Box display="none" smDisplay="flex">
+        <Box
+          color={isDarkMode ? darkModeBackground : lightModeBackground}
+          paddingX={4}
+          paddingY={3}
+          rounding={4}
+          borderStyle="shadow"
+          dangerouslySetInlineStyle={{
+            __style: {
+              position: 'fixed',
+              bottom: isMobileDevice ? offset.bottom : 'unset',
+              top: !isMobileDevice ? offset.top : 'unset',
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          position="fixed"
+          display="flex"
+          justifyContent="between"
+          alignContent="center"
+          direction="row"
+          smPaddingY={4}
+          fit
+          maxWidth={900}
+          width="calc(100% - 32px)"
+          zIndex={zIndex}
+        >
+          <Flex alignItems="center" gap={4}>
+            {!!thumbnail?.image &&
+            Children.only<Element<typeof Image>>(thumbnail.image).type.displayName === 'Image' ? (
+              <Flex.Item alignSelf="center">
+                <ToastImageThumbnail thumbnail={thumbnail.image} />
+              </Flex.Item>
+            ) : null}
 
-        {!!thumbnail?.icon &&
-        Children.only<Element<typeof Icon>>(thumbnail.icon).type.displayName === 'Icon' ? (
-          <Flex.Item alignSelf={isMobileDevice ? 'baseline' : 'center'}>
-            <ToastIconThumbnail thumbnail={thumbnail.icon} />
-          </Flex.Item>
-        ) : null}
+            {!!thumbnail?.icon &&
+            Children.only<Element<typeof Icon>>(thumbnail.icon).type.displayName === 'Icon' ? (
+              <Flex.Item alignSelf="center">
+                <ToastIconThumbnail thumbnail={thumbnail.icon} />
+              </Flex.Item>
+            ) : null}
 
-        {!!thumbnail?.avatar &&
-        Children.only<Element<typeof Avatar>>(thumbnail.avatar).type.displayName === 'Avatar' ? (
-          <Flex.Item alignSelf={isMobileDevice ? 'baseline' : 'center'}>
-            <ToastAvatarThumbnail thumbnail={thumbnail.avatar} />
-          </Flex.Item>
-        ) : null}
-        <Flex.Item flex="grow">
-          <Flex direction="row" justifyContent="between">
-            {title ? <Text weight="bold">{title}</Text> : messageComponent}
-            {isMobileDevice && !!onDismiss && (
-              <Flex.Item alignSelf={title ? 'end' : 'start'}>{dismissButtonComponent}</Flex.Item>
-            )}
+            {!!thumbnail?.avatar &&
+            Children.only<Element<typeof Avatar>>(thumbnail.avatar).type.displayName ===
+              'Avatar' ? (
+              <Flex.Item alignSelf="center">
+                <ToastAvatarThumbnail thumbnail={thumbnail.avatar} />
+              </Flex.Item>
+            ) : null}
+            <Flex.Item flex="grow">
+              <Flex direction="row" justifyContent="between">
+                {title ? (
+                  <Text weight="bold">{title}</Text>
+                ) : (
+                  <ToastMessage
+                    text={isMessageTextNode ? undefined : messageTextElement}
+                    textElement={isMessageTextNode ? messageTextElement : undefined}
+                    textColor={textColor}
+                  />
+                )}
+              </Flex>
+              {title && (
+                <ToastMessage
+                  text={isMessageTextNode ? undefined : messageTextElement}
+                  textElement={isMessageTextNode ? messageTextElement : undefined}
+                  textColor={textColor}
+                />
+              )}
+            </Flex.Item>
           </Flex>
-          {title && messageComponent}
-        </Flex.Item>
-      </Flex>
-      <Flex direction="row" alignSelf={isMobileDevice ? 'end' : 'center'} gap={4}>
-        <ButtonGroup>
-          {secondaryAction && (
-            <Flex.Item>
-              {secondaryAction.role === 'link' ? (
-                <CallToAction
-                  accessibilityLabel={secondaryAction.accessibilityLabel}
-                  color="gray"
-                  href={secondaryAction.href}
-                  label={secondaryAction.label}
-                  onClick={secondaryAction.onClick}
-                  rel={secondaryAction?.rel}
-                  role="link"
-                  size="sm"
-                  target={secondaryAction?.target}
-                />
-              ) : (
-                <CallToAction
-                  accessibilityLabel={secondaryAction.accessibilityLabel}
-                  color="gray"
-                  label={secondaryAction.label}
-                  onClick={secondaryAction.onClick}
-                  role="button"
-                  size="sm"
-                />
+          <Flex direction="row" alignSelf="center" gap={4}>
+            <ButtonGroup>
+              {secondaryAction && (
+                <Flex.Item>
+                  {secondaryAction.role === 'link' ? (
+                    <CallToAction
+                      accessibilityLabel={secondaryAction.accessibilityLabel}
+                      color="gray"
+                      href={secondaryAction.href}
+                      label={secondaryAction.label}
+                      onClick={secondaryAction.onClick}
+                      rel={secondaryAction?.rel}
+                      role="link"
+                      size="sm"
+                      target={secondaryAction?.target}
+                    />
+                  ) : (
+                    <CallToAction
+                      accessibilityLabel={secondaryAction.accessibilityLabel}
+                      color="gray"
+                      label={secondaryAction.label}
+                      onClick={secondaryAction.onClick}
+                      role="button"
+                      size="sm"
+                    />
+                  )}
+                </Flex.Item>
+              )}
+              {primaryAction && (
+                <Flex.Item>
+                  {primaryAction.role === 'link' ? (
+                    <CallToAction
+                      accessibilityLabel={primaryAction.accessibilityLabel}
+                      color="red"
+                      href={primaryAction.href}
+                      label={primaryAction.label}
+                      onClick={primaryAction.onClick}
+                      rel={primaryAction?.rel}
+                      role="link"
+                      size="sm"
+                      target={primaryAction?.target}
+                    />
+                  ) : (
+                    <CallToAction
+                      accessibilityLabel={primaryAction.accessibilityLabel}
+                      color="red"
+                      label={primaryAction.label}
+                      onClick={primaryAction.onClick}
+                      role="button"
+                      size="sm"
+                    />
+                  )}
+                </Flex.Item>
+              )}
+            </ButtonGroup>
+            {!!onDismiss && <Flex.Item alignSelf="center">{dismissButtonComponent}</Flex.Item>}
+          </Flex>
+        </Box>
+      </Box>
+      <Box display="flex" smDisplay="none">
+        <Box
+          color={isDarkMode ? darkModeBackground : lightModeBackground}
+          paddingX={4}
+          paddingY={3}
+          rounding={4}
+          borderStyle="shadow"
+          dangerouslySetInlineStyle={{
+            __style: {
+              position: 'fixed',
+              bottom: isMobileDevice ? offset.bottom : 'unset',
+              top: !isMobileDevice ? offset.top : 'unset',
+              left: '50%',
+              transform: 'translateX(-50%)',
+            },
+          }}
+          position="fixed"
+          display="flex"
+          justifyContent="center"
+          alignContent="stretch"
+          direction="column"
+          smPaddingY={4}
+          fit
+          maxWidth={348}
+          width="calc(100% - 32px)"
+          zIndex={zIndex}
+        >
+          <Flex alignItems="center" gap={4}>
+            {!!thumbnail?.image &&
+            Children.only<Element<typeof Image>>(thumbnail.image).type.displayName === 'Image' ? (
+              <Flex.Item alignSelf="baseline">
+                <ToastImageThumbnail thumbnail={thumbnail.image} />
+              </Flex.Item>
+            ) : null}
+
+            {!!thumbnail?.icon &&
+            Children.only<Element<typeof Icon>>(thumbnail.icon).type.displayName === 'Icon' ? (
+              <Flex.Item alignSelf="baseline">
+                <ToastIconThumbnail thumbnail={thumbnail.icon} />
+              </Flex.Item>
+            ) : null}
+
+            {!!thumbnail?.avatar &&
+            Children.only<Element<typeof Avatar>>(thumbnail.avatar).type.displayName ===
+              'Avatar' ? (
+              <Flex.Item alignSelf="baseline">
+                <ToastAvatarThumbnail thumbnail={thumbnail.avatar} />
+              </Flex.Item>
+            ) : null}
+            <Flex.Item flex="grow">
+              <Flex direction="row" justifyContent="between">
+                {title ? (
+                  <Text weight="bold">{title}</Text>
+                ) : (
+                  <Box marginBottom={2}>
+                    <ToastMessage
+                      text={isMessageTextNode ? undefined : messageTextElement}
+                      textElement={isMessageTextNode ? messageTextElement : undefined}
+                      textColor={textColor}
+                    />
+                  </Box>
+                )}
+                {!!onDismiss && (
+                  <Flex.Item alignSelf={title ? 'end' : 'start'}>
+                    {dismissButtonComponent}
+                  </Flex.Item>
+                )}
+              </Flex>
+              {title && (
+                <Box marginBottom={2}>
+                  <ToastMessage
+                    text={isMessageTextNode ? undefined : messageTextElement}
+                    textElement={isMessageTextNode ? messageTextElement : undefined}
+                    textColor={textColor}
+                  />
+                </Box>
               )}
             </Flex.Item>
-          )}
-          {primaryAction && (
-            <Flex.Item>
-              {primaryAction.role === 'link' ? (
-                <CallToAction
-                  accessibilityLabel={primaryAction.accessibilityLabel}
-                  color="red"
-                  href={primaryAction.href}
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  rel={primaryAction?.rel}
-                  role="link"
-                  size="sm"
-                  target={primaryAction?.target}
-                />
-              ) : (
-                <CallToAction
-                  accessibilityLabel={primaryAction.accessibilityLabel}
-                  color="red"
-                  label={primaryAction.label}
-                  onClick={primaryAction.onClick}
-                  role="button"
-                  size="sm"
-                />
+          </Flex>
+          <Flex direction="row" alignSelf="end" gap={4}>
+            <ButtonGroup>
+              {secondaryAction && (
+                <Flex.Item>
+                  {secondaryAction.role === 'link' ? (
+                    <CallToAction
+                      accessibilityLabel={secondaryAction.accessibilityLabel}
+                      color="gray"
+                      href={secondaryAction.href}
+                      label={secondaryAction.label}
+                      onClick={secondaryAction.onClick}
+                      rel={secondaryAction?.rel}
+                      role="link"
+                      size="sm"
+                      target={secondaryAction?.target}
+                    />
+                  ) : (
+                    <CallToAction
+                      accessibilityLabel={secondaryAction.accessibilityLabel}
+                      color="gray"
+                      label={secondaryAction.label}
+                      onClick={secondaryAction.onClick}
+                      role="button"
+                      size="sm"
+                    />
+                  )}
+                </Flex.Item>
               )}
-            </Flex.Item>
-          )}
-        </ButtonGroup>
-        {!isMobileDevice && !!onDismiss && (
-          <Flex.Item alignSelf="center">{dismissButtonComponent}</Flex.Item>
-        )}
-      </Flex>
-    </Box>
+              {primaryAction && (
+                <Flex.Item>
+                  {primaryAction.role === 'link' ? (
+                    <CallToAction
+                      accessibilityLabel={primaryAction.accessibilityLabel}
+                      color="red"
+                      href={primaryAction.href}
+                      label={primaryAction.label}
+                      onClick={primaryAction.onClick}
+                      rel={primaryAction?.rel}
+                      role="link"
+                      size="sm"
+                      target={primaryAction?.target}
+                    />
+                  ) : (
+                    <CallToAction
+                      accessibilityLabel={primaryAction.accessibilityLabel}
+                      color="red"
+                      label={primaryAction.label}
+                      onClick={primaryAction.onClick}
+                      role="button"
+                      size="sm"
+                    />
+                  )}
+                </Flex.Item>
+              )}
+            </ButtonGroup>
+          </Flex>
+        </Box>
+      </Box>
+    </Fragment>
   );
 }

--- a/packages/gestalt/src/__snapshots__/BannerOverlay.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/BannerOverlay.test.js.snap
@@ -1,293 +1,594 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<BannerOverlay /> Text + Image + Button 1`] = `
-<div
-  className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
-  style={
-    Object {
-      "bottom": "unset",
-      "left": "50%",
-      "maxWidth": 900,
-      "position": "fixed",
-      "top": 0,
-      "transform": "translateX(-50%)",
-      "width": "100%",
-    }
-  }
->
+Array [
   <div
-    className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+    className="box smDisplayFlex xsDisplayNone"
   >
     <div
-      className="FlexItem selfCenter"
+      className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 900,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
     >
       <div
-        aria-hidden={true}
-        className="box"
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
       >
         <div
-          className="Mask rounding2 willChangeTransform"
-          style={
-            Object {
-              "height": 32,
-              "width": 32,
-            }
-          }
+          className="FlexItem selfCenter"
         >
           <div
-            className="box relative"
-            style={
-              Object {
-                "backgroundColor": "transparent",
-                "paddingBottom": "100%",
-              }
-            }
+            aria-hidden={true}
+            className="box"
           >
-            <img
-              alt=""
-              className="img"
-              fetchpriority="auto"
-              loading="auto"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-            />
+            <div
+              className="Mask rounding2 willChangeTransform"
+              style={
+                Object {
+                  "height": 32,
+                  "width": 32,
+                }
+              }
+            >
+              <div
+                className="box relative"
+                style={
+                  Object {
+                    "backgroundColor": "transparent",
+                    "paddingBottom": "100%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className="img"
+                  fetchpriority="auto"
+                  loading="auto"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="FlexItem flexGrow"
+        >
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Text, image and button
+            </div>
+          </div>
+          <span
+            className="textColorOverrideLight"
+          >
+            <span
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Saved to
+               
+              <a
+                className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyPress={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                rel=""
+                target={null}
+              >
+                Home decor
+              </a>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="box smDisplayNone xsDisplayFlex"
+  >
+    <div
+      className="box default fit fixed justifyCenter paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionColumn xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 348,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
+    >
+      <div
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+      >
+        <div
+          className="FlexItem selfBaseline"
+        >
+          <div
+            aria-hidden={true}
+            className="box"
+          >
+            <div
+              className="Mask rounding2 willChangeTransform"
+              style={
+                Object {
+                  "height": 32,
+                  "width": 32,
+                }
+              }
+            >
+              <div
+                className="box relative"
+                style={
+                  Object {
+                    "backgroundColor": "transparent",
+                    "paddingBottom": "100%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className="img"
+                  fetchpriority="auto"
+                  loading="auto"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="FlexItem flexGrow"
+        >
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Text, image and button
+            </div>
+          </div>
+          <div
+            className="box marginBottom2"
+          >
+            <span
+              className="textColorOverrideLight"
+            >
+              <span
+                className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+              >
+                Saved to
+                 
+                <a
+                  className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
+                  href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  target={null}
+                >
+                  Home decor
+                </a>
+              </span>
+            </span>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="FlexItem flexGrow"
-    >
       <div
-        className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+        className="Flex rowGap4 columnGap4 selfEnd xsDirectionRow"
       >
         <div
-          className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+          className="FlexItem"
         >
-          Text, image and button
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
         </div>
       </div>
-      <div
-        className="box marginBottom0"
-      >
-        <span
-          className="textColorOverrideLight"
-        >
-          <span
-            className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
-          >
-            Saved to
-             
-            <a
-              className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
-              href="https://www.pinterest.com/search/pins/?q=home%20decor"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              rel=""
-              target={null}
-            >
-              Home decor
-            </a>
-          </span>
-        </span>
-      </div>
     </div>
-  </div>
-  <div
-    className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
-  >
-    <div
-      className="FlexItem"
-    >
-      <div
-        className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
-      />
-    </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<BannerOverlay /> Text + Image 1`] = `
-<div
-  className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
-  style={
-    Object {
-      "bottom": "unset",
-      "left": "50%",
-      "maxWidth": 900,
-      "position": "fixed",
-      "top": 0,
-      "transform": "translateX(-50%)",
-      "width": "100%",
-    }
-  }
->
+Array [
   <div
-    className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+    className="box smDisplayFlex xsDisplayNone"
   >
     <div
-      className="FlexItem selfCenter"
+      className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 900,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
     >
       <div
-        aria-hidden={true}
-        className="box"
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
       >
         <div
-          className="Mask rounding2 willChangeTransform"
-          style={
-            Object {
-              "height": 32,
-              "width": 32,
-            }
-          }
+          className="FlexItem selfCenter"
         >
           <div
-            className="box relative"
-            style={
-              Object {
-                "backgroundColor": "transparent",
-                "paddingBottom": "100%",
-              }
-            }
+            aria-hidden={true}
+            className="box"
           >
-            <img
-              alt=""
-              className="img"
-              fetchpriority="auto"
-              loading="auto"
-              onError={[Function]}
-              onLoad={[Function]}
-              src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
-            />
+            <div
+              className="Mask rounding2 willChangeTransform"
+              style={
+                Object {
+                  "height": 32,
+                  "width": 32,
+                }
+              }
+            >
+              <div
+                className="box relative"
+                style={
+                  Object {
+                    "backgroundColor": "transparent",
+                    "paddingBottom": "100%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className="img"
+                  fetchpriority="auto"
+                  loading="auto"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="FlexItem flexGrow"
+        >
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Text and Image
+            </div>
+          </div>
+          <span
+            className="textColorOverrideLight"
+          >
+            <span
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Saved to
+               
+              <a
+                className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
+                href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyPress={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                rel=""
+                target={null}
+              >
+                Home decor
+              </a>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    className="box smDisplayNone xsDisplayFlex"
+  >
+    <div
+      className="box default fit fixed justifyCenter paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionColumn xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 348,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
+    >
+      <div
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+      >
+        <div
+          className="FlexItem selfBaseline"
+        >
+          <div
+            aria-hidden={true}
+            className="box"
+          >
+            <div
+              className="Mask rounding2 willChangeTransform"
+              style={
+                Object {
+                  "height": 32,
+                  "width": 32,
+                }
+              }
+            >
+              <div
+                className="box relative"
+                style={
+                  Object {
+                    "backgroundColor": "transparent",
+                    "paddingBottom": "100%",
+                  }
+                }
+              >
+                <img
+                  alt=""
+                  className="img"
+                  fetchpriority="auto"
+                  loading="auto"
+                  onError={[Function]}
+                  onLoad={[Function]}
+                  src="https://i.pinimg.com/474x/b2/55/ed/b255edbf773ffb3985394e6efb9d2a49.jpg"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="FlexItem flexGrow"
+        >
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Text and Image
+            </div>
+          </div>
+          <div
+            className="box marginBottom2"
+          >
+            <span
+              className="textColorOverrideLight"
+            >
+              <span
+                className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+              >
+                Saved to
+                 
+                <a
+                  className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
+                  href="https://www.pinterest.com/search/pins/?q=home%20decor"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyPress={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  rel=""
+                  target={null}
+                >
+                  Home decor
+                </a>
+              </span>
+            </span>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="FlexItem flexGrow"
-    >
       <div
-        className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+        className="Flex rowGap4 columnGap4 selfEnd xsDirectionRow"
       >
         <div
-          className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+          className="FlexItem"
         >
-          Text and Image
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
         </div>
       </div>
-      <div
-        className="box marginBottom0"
-      >
-        <span
-          className="textColorOverrideLight"
-        >
-          <span
-            className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
-          >
-            Saved to
-             
-            <a
-              className="link hideOutline tapTransition rounding0 inlineBlock noUnderline hoverUnderline accessibilityOutline"
-              href="https://www.pinterest.com/search/pins/?q=home%20decor"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onKeyPress={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              rel=""
-              target={null}
-            >
-              Home decor
-            </a>
-          </span>
-        </span>
-      </div>
     </div>
-  </div>
-  <div
-    className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
-  >
-    <div
-      className="FlexItem"
-    >
-      <div
-        className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
-      />
-    </div>
-  </div>
-</div>
+  </div>,
+]
 `;
 
 exports[`<BannerOverlay /> Text Only 1`] = `
-<div
-  className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
-  style={
-    Object {
-      "bottom": "unset",
-      "left": "50%",
-      "maxWidth": 900,
-      "position": "fixed",
-      "top": 0,
-      "transform": "translateX(-50%)",
-      "width": "100%",
-    }
-  }
->
+Array [
   <div
-    className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+    className="box smDisplayFlex xsDisplayNone"
   >
     <div
-      className="FlexItem flexGrow"
+      className="box contentCenter default fit fixed justifyBetween paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionRow xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 900,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
     >
       <div
-        className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
       >
         <div
-          className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+          className="FlexItem flexGrow"
         >
-          Profile
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Profile
+            </div>
+          </div>
+          <span
+            className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal lineClamp"
+            style={
+              Object {
+                "WebkitLineClamp": 2,
+              }
+            }
+          >
+            Same great profile, slightly new look. Learn more?
+          </span>
         </div>
       </div>
       <div
-        className="box marginBottom0"
+        className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
       >
-        <span
-          className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal lineClamp"
-          style={
-            Object {
-              "WebkitLineClamp": 2,
-            }
-          }
+        <div
+          className="FlexItem"
         >
-          Same great profile, slightly new look. Learn more?
-        </span>
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
+        </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
-    className="Flex rowGap4 columnGap4 selfCenter xsDirectionRow"
+    className="box smDisplayNone xsDisplayFlex"
   >
     <div
-      className="FlexItem"
+      className="box default fit fixed justifyCenter paddingX4 paddingY3 rounding4 shadow smPaddingY4 xsDirectionColumn xsDisplayFlex"
+      style={
+        Object {
+          "bottom": "unset",
+          "left": "50%",
+          "maxWidth": 348,
+          "position": "fixed",
+          "top": 0,
+          "transform": "translateX(-50%)",
+          "width": "calc(100% - 32px)",
+        }
+      }
     >
       <div
-        className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
-      />
+        className="Flex rowGap4 columnGap4 xsDirectionRow xsItemsCenter"
+      >
+        <div
+          className="FlexItem flexGrow"
+        >
+          <div
+            className="Flex rowGap0 columnGap0 justifyBetween xsDirectionRow"
+          >
+            <div
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightSemiBold"
+            >
+              Profile
+            </div>
+          </div>
+          <div
+            className="box marginBottom2"
+          >
+            <span
+              className="Text fontSize300 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              style={
+                Object {
+                  "WebkitLineClamp": 2,
+                }
+              }
+            >
+              Same great profile, slightly new look. Learn more?
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="Flex rowGap4 columnGap4 selfEnd xsDirectionRow"
+      >
+        <div
+          className="FlexItem"
+        >
+          <div
+            className="box flexWrap marginBottomN1 marginEndN1 marginStartN1 marginTopN1 xsDisplayFlex"
+          />
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+  </div>,
+]
 `;


### PR DESCRIPTION
### Summary

This is a follow-up to BannerOverlay component creation, fixing issues with small screens on desktop not being responsive as intended.




#### What changed?

On small desktop screens, the banner is going to mantain margins against the edges of the screen even if it becomes smaller than 900px, and on small breakpoints, the mobile variant is going to be used for desktop.

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/1653b487-c3ee-4a86-9cf3-06b036f6269d)


#### Why?

To prevent issues with rendering the CTAs on small desktop viewports.