### PR TITLE
SideNavigation: Add a label property to onExpand 

### DIFF
--- a/docs/examples/sidenavigation/displayExpanded.js
+++ b/docs/examples/sidenavigation/displayExpanded.js
@@ -8,15 +8,13 @@ export default function Example(): ReactNode {
     'Classic Christmas',
   ]);
 
-  const handleOnExpand =
-    (name: string) =>
-    ({ expanded }: { expanded: boolean }) => {
-      if (expanded) {
-        setExpandedElements([...expandedElements, name]);
-      } else {
-        setExpandedElements(expandedElements.filter((value) => value !== name));
-      }
-    };
+  const handleOnExpand = ({ label, expanded }: { label: string, expanded: boolean }) => {
+    if (expanded) {
+      setExpandedElements([...expandedElements, label]);
+    } else {
+      setExpandedElements(expandedElements.filter((value) => value !== label));
+    }
+  };
 
   return (
     <Box height={362} width={280} overflow="scroll">
@@ -26,7 +24,7 @@ export default function Example(): ReactNode {
           icon="people"
           display="expandable"
           expanded={expandedElements.includes('Christmas')}
-          onExpand={handleOnExpand('Christmas')}
+          onExpand={handleOnExpand}
         >
           <SideNavigation.NestedItem
             href="#"
@@ -37,7 +35,7 @@ export default function Example(): ReactNode {
             label="Classic Christmas"
             display="expandable"
             expanded={expandedElements.includes('Classic Christmas')}
-            onExpand={handleOnExpand('Classic Christmas')}
+            onExpand={handleOnExpand}
           >
             <SideNavigation.NestedItem
               href="#"

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1848,7 +1848,7 @@ interface SideNavigationGroupProps {
   expanded?: boolean;
   icon?: Icons | undefined;
   notificationAccessibilityLabel?: string | undefined;
-  onExpand: (args: { expanded: boolean }) => void;
+  onExpand: (args: { label:string, expanded: boolean }) => void;
   primaryAction?: PrimaryActionType | undefined;
 }
 

--- a/packages/gestalt/src/SideNavigationGroup.js
+++ b/packages/gestalt/src/SideNavigationGroup.js
@@ -60,7 +60,7 @@ export type Props = {
   /**
    * Callback fired when the expand button component is clicked and the component is controlled.This functionality is not supported in mobile.
    */
-  onExpand?: ({ expanded: boolean }) => void,
+  onExpand?: ({ label: string, expanded: boolean }) => void,
   /**
    * The primary action for each group. See the [primary action variant](https://gestalt.pinterest.systems/web/sidenavigation#Primary-action) to learn more.
    */
@@ -195,7 +195,7 @@ export default function SideNavigationGroup({
                   return !value;
                 });
               } else {
-                onExpand?.({ expanded: !isExpanded });
+                onExpand?.({ label, expanded: !isExpanded });
               }
             }}
           >

--- a/packages/gestalt/src/SideNavigationNestedGroup.js
+++ b/packages/gestalt/src/SideNavigationNestedGroup.js
@@ -26,7 +26,7 @@ type Props = {
   /**
    * Callback fired when the expand button component is clicked and the component is controlled. This functionality is not supported in mobile.
    */
-  onExpand?: ({ expanded: boolean }) => void,
+  onExpand?: ({ label: string, expanded: boolean }) => void,
 };
 
 /**


### PR DESCRIPTION
Adding an extra prop to remove hard-coding of label names.

Right now, we just pass back the boolean value of expanded are now. But SideNavigations can also be defined statically, meaning there's no good way to pass the label name or an identifier when handling the expand operation.

### Summary
Changes:
```
 onExpand: (args: { expanded: boolean }) => void;
 ```
 
 to
 
```
 onExpand: (args: { label:string, expanded: boolean }) => void;
 ```

And folks can use a generic method like this to maintain state. They don't need to maintain an array outside.
``` jsx
  const handleOnExpand = ({ label, expanded }: { label: string, expanded: boolean }) => {
    if (expanded) {
      setExpandedElements([...expandedElements, label]);
    } else {
      setExpandedElements(expandedElements.filter((value) => value !== label));
    }
  };
  
<SideNavigationGroup label="content" onExpand={handleOnExpand} ... />
```



### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
