### PR TITLE
Docs: remove preview deploy links

### DIFF
--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -326,7 +326,7 @@ When building a Dropdown, we might want to render different combinations of subc
           name="Mobile"
           description={`Dropdown requires [DeviceTypeProvider](/web/utilities/devicetypeprovider) to enable its mobile user interface. The example below shows the mobile platform UI and its implementation.
 
-SheetMobile has animation. To learn more about Dropdown.Link´s \`mobileOnDismissStart\`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). \`mobileOnDismissStart\` is the equivalent of \`onDismissStart\` in SheetMobile.
+SheetMobile has animation. To learn more about Dropdown.Link´s \`mobileOnDismissStart\`, see the [animation variant in SheetMobile](/web/sheetmobile#Animation). \`mobileOnDismissStart\` is the equivalent of \`onDismissStart\` in SheetMobile.
 `}
         >
           <MainSection.Card

--- a/docs/pages/web/sheetmobile.js
+++ b/docs/pages/web/sheetmobile.js
@@ -353,7 +353,7 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#She
             type="do"
             description={`
 - Keep headings short and clear
-- Use Sentence case for headings per our [Pinterest writing standards](https://deploy-preview-2794--gestalt.netlify.app/foundations/content_standards/formatting)
+- Use Sentence case for headings per our [Pinterest writing standards](/foundations/content_standards/formatting)
 `}
           />
           <MainSection.Card

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -36,7 +36,7 @@ type Props = {
    */
   isExternal?: boolean,
   /**
-   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://deploy-preview-2879--gestalt.netlify.app/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
+   * Callback fired when clicked (pressed and released) with a mouse or keyboard. See [GlobalEventsHandlerProvider](https://gestalt.pinterest.systems/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation. To learn more about `mobileOnDismissStart`, see the [animation variant in SheetMobile](https://gestalt.pinterest.systems/web/sheetmobile#Animation). `mobileOnDismissStart` is the equivalent of `onDismissStart` in SheetMobile.
    */
   onClick?: ({
     event: SyntheticMouseEvent<HTMLAnchorElement> | SyntheticKeyboardEvent<HTMLAnchorElement>,


### PR DESCRIPTION
Found a few stray references to Netlify preview deploys instead of our actual domain