### PR TITLE
Docs: Make header always sticky for desktop

### DIFF
--- a/docs/docs-components/Header.js
+++ b/docs/docs-components/Header.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node as ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type Node as ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
   Badge,
@@ -15,6 +15,7 @@ import {
 } from 'gestalt';
 import { useAppContext } from './appContext';
 import trackButtonClick from './buttons/trackButtonClick';
+import { useDocsConfig } from './contexts/DocsConfigProvider';
 import DocSearch from './DocSearch';
 import { convertNamesForURL, isComponentsActiveSection } from './DocsSideNavigation';
 import GestaltLogo from './GestaltLogo';
@@ -244,27 +245,10 @@ function Header() {
   );
 }
 
-const isReducedHeight = () => typeof window !== 'undefined' && window.innerHeight < 709;
-
 export default function StickyHeader(): ReactNode {
-  const [reducedHeight, setReducedHeight] = useState(false);
+  const { isMobile } = useDocsConfig();
 
-  const handleResizeHeight = useCallback(() => {
-    if (isReducedHeight() !== reducedHeight) {
-      setReducedHeight(isReducedHeight());
-    }
-  }, [reducedHeight]);
-
-  useEffect(() => {
-    // Within a useEffect to ensure this only runs on the client, avoiding hydration mismatches
-    handleResizeHeight();
-    window.addEventListener('resize', handleResizeHeight);
-    return () => {
-      window.removeEventListener('resize', handleResizeHeight);
-    };
-  }, [handleResizeHeight]);
-
-  return reducedHeight ? (
+  return isMobile ? (
     <Header />
   ) : (
     <Sticky zIndex={PAGE_HEADER_ZINDEX} top={0}>


### PR DESCRIPTION
### Summary

Before:
![ezgif-7-df043606e6](https://github.com/pinterest/gestalt/assets/29589560/0e97cb9d-68c2-4df7-a243-07c62d436ec5)

After:
![ezgif-7-7ad460cd1e](https://github.com/pinterest/gestalt/assets/29589560/a0096af3-f476-413a-add1-0e908ad709e3)


#### What changed?

Removed old logic that controlled stickiness of the header based on window height. Replaced it with device type check.

#### Why?

The old logic was introduced here #1074 
Since the reasoning behind that change is no longer relevant, it is now removed.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
