### PR TITLE
Docs: Update year_in_review_2023.js

### DIFF
--- a/docs/pages/year_in_review_2023.js
+++ b/docs/pages/year_in_review_2023.js
@@ -501,7 +501,7 @@ export default function YearInReview2023(): ReactNode {
                     >
                       overlay banners
                     </Link>
-                    —pick the one best suited for you! You want typescript support? We have it!
+                    —pick the one best suited for you! You want TypesScript support? We have it!
                   </Text>
                   <Text size="400">
                     We also addressed requests from our enterprise and internal tools customers and
@@ -751,7 +751,7 @@ export default function YearInReview2023(): ReactNode {
                     <Box marginBottom={12}>
                       <Text color="default" size="400">
                         It&apos;s a good sign when, after saying last year was the year, we have to
-                        come back and say, “actually this was the year!” Iit was a lot of hard work
+                        come back and say, “actually this was the year!” It was a lot of hard work
                         that was sometimes exhausting. But it also felt great to improve the design
                         system so that our customers can make Pinterest the home of positivity and
                         inspiration. We&apos;re ready to keep it going for another year so that, in


### PR DESCRIPTION
### Summary
Fixed a couple of typos.

#### What changed?
typescript to TypeScript
<img width="708" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/cef98604-0ecb-45b0-a1f5-9f86deaddc61">

Iit to "It"
<img width="1357" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/c66e6614-bfd1-482f-83d0-dde57f21100d">


#### Why?

Typos needed to be fixed.

### Links


### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers)
