### PR TITLE
Docs: fix spacing in Badge example

### DIFF
--- a/docs/examples/badge/variantsType.js
+++ b/docs/examples/badge/variantsType.js
@@ -24,11 +24,10 @@ export default function Example(): ReactNode {
             <Table.Cell>
               <Flex direction="column" gap={2}>
                 <Text size="300">
-                  Ads & Campaigns
-                  <Badge text="New" type="info" />
+                  Ads & Campaigns <Badge text="New" type="info" />
                 </Text>
                 <Text size="300">
-                  Ads & Campaigns
+                  Ads & Campaigns{' '}
                   <Badge
                     text="New"
                     type="info"


### PR DESCRIPTION
Adding spacing here:
![Screenshot 2024-01-18 at 1 03 33 PM](https://github.com/pinterest/gestalt/assets/12059539/db713706-1193-4eb6-b723-670ae958a0dc)
