### PR TITLE
Internal: upgrade netlify-cli to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "jscodeshift": "^0.11.0",
     "lint-staged": "^10.4.0",
     "lottie-react": "^2.3.1",
-    "netlify-cli": "^6.15.0",
+    "netlify-cli": "^7.1.0",
     "nodemon": "^2.0.12",
     "postcss": "^8.4.31",
     "postcss-modules": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,7 +2999,7 @@
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
 
-"@netlify/build@^18.22.0":
+"@netlify/build@^18.25.2":
   version "18.25.2"
   resolved "https://registry.yarnpkg.com/@netlify/build/-/build-18.25.2.tgz#7cdc8eb4579b0567c1ff51e72ef8ec2fe652c8f2"
   integrity sha512-y51FdO3wz9X1BMDKRzKLLGLFXdsLrjYfWg9dCXZtcL16mB7zcAjbd+0L2kH++zGQeadhxUOT8EOe2uVHFxdR2Q==
@@ -13871,12 +13871,12 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
 
-netlify-cli@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-6.15.0.tgz#43d1e75046c1782ea2503356500a4235a11110f1"
-  integrity sha512-40r0FZC4vj3qddfTJ536sCO9geCzv15dmGJKEZCQknu12j46RB9AXvy+PUHyXQZQrkZvUnFYsdR6zlgwz7ofyQ==
+netlify-cli@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/netlify-cli/-/netlify-cli-7.1.0.tgz#49823c0bb7fef9b469e8377ee3bec2a7f54cb933"
+  integrity sha512-89pIezDEAt8OcTU17Z1SfGMNVvlWXw3/5/tZAWe3y15VmzWn0MjwxJK3VU/FbiOGIpdKBFZT6CcBGZgo2r6w/g==
   dependencies:
-    "@netlify/build" "^18.22.0"
+    "@netlify/build" "^18.25.2"
     "@netlify/config" "^15.8.2"
     "@netlify/framework-info" "^5.11.0"
     "@netlify/local-functions-proxy" "^1.1.1"


### PR DESCRIPTION
Addressing [this](https://github.com/pinterest/gestalt/security/dependabot/83) high severity Dependabot alert

We need to upgrade to the latest version of `netlify-cli`, if possible

Previous upgrades:
2.x.x --> 3.x.x: #3362
3.x.x --> 4.x.x: #3364
4.x.x --> 6.x.x: #3366 