### PR TITLE
Internal: fixes for no-unused-vars suppressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -80,6 +80,7 @@ module.exports = {
     'no-await-in-loop': OFF,
     'no-constant-condition': ERROR,
     'no-return-await': OFF,
+    'no-unused-vars': [ERROR, { 'args': 'after-used', 'argsIgnorePattern': '^_' }],
     'prefer-arrow-callback': OFF,
     'react-hooks/exhaustive-deps': ERROR,
     'react-hooks/rules-of-hooks': ERROR,

--- a/docs/pages/foundations/international_design/icon_localization.js
+++ b/docs/pages/foundations/international_design/icon_localization.js
@@ -1,7 +1,6 @@
 // @flow strict
 import React, { type Node as ReactNode } from 'react';
-// eslint-disable-next-line no-unused-vars
-import { Box, Callout, Flex, Heading, Icon, Image, Mask, Table, Text } from 'gestalt';
+import { Box, Image } from 'gestalt';
 import MainSection from '../../../docs-components/MainSection';
 import Page from '../../../docs-components/Page';
 import PageHeader from '../../../docs-components/PageHeader';

--- a/docs/pages/foundations/international_design/rtl_guidelines/iconography.js
+++ b/docs/pages/foundations/international_design/rtl_guidelines/iconography.js
@@ -1,7 +1,6 @@
 // @flow strict
 import React, { type Node as ReactNode } from 'react';
-// eslint-disable-next-line no-unused-vars
-import { Box, Callout, Flex, Heading, Icon, Image, Mask, Table, Text } from 'gestalt';
+import { Box, Flex, Heading, Icon, Image, Mask, Table, Text } from 'gestalt';
 import { DOCS_COPY_MAX_WIDTH_PX } from '../../../../docs-components/consts';
 import MainSection from '../../../../docs-components/MainSection';
 import Markdown from '../../../../docs-components/Markdown';

--- a/docs/pages/foundations/international_design/rtl_guidelines/layout_and_text_direction.js
+++ b/docs/pages/foundations/international_design/rtl_guidelines/layout_and_text_direction.js
@@ -1,7 +1,6 @@
 // @flow strict
 import React, { type Node as ReactNode } from 'react';
-// eslint-disable-next-line no-unused-vars
-import { Box, Callout, Flex, Heading, Image, Mask, Text } from 'gestalt';
+import { Box, Image, Mask } from 'gestalt';
 import { DOCS_COPY_MAX_WIDTH_PX } from '../../../../docs-components/consts';
 import MainSection from '../../../../docs-components/MainSection';
 import Markdown from '../../../../docs-components/Markdown';

--- a/docs/pages/foundations/international_design/rtl_guidelines/typography.js
+++ b/docs/pages/foundations/international_design/rtl_guidelines/typography.js
@@ -1,7 +1,6 @@
 // @flow strict
 import React, { type Node as ReactNode } from 'react';
-// eslint-disable-next-line no-unused-vars
-import { Box, Callout, Flex, Heading, Image, Mask, Text } from 'gestalt';
+import { Box, Callout, Flex, Image, Mask, Text } from 'gestalt';
 import { DOCS_COPY_MAX_WIDTH_PX } from '../../../../docs-components/consts';
 import MainSection from '../../../../docs-components/MainSection';
 import Page from '../../../../docs-components/Page';

--- a/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
+++ b/packages/eslint-plugin-gestalt/src/button-icon-restrictions.js
@@ -38,8 +38,7 @@ const rule: ESLintRule = {
     // $FlowFixMe[missing-local-annot]
     function getAttribute(node, attributeName: string) {
       return Object.entries(node.attributes).find(
-        // eslint-disable-next-line no-unused-vars
-        ([key, value]) => value && value.name && value.name.name === attributeName,
+        ([_key, value]) => value && value.name && value.name.name === attributeName,
       );
     }
 

--- a/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
+++ b/packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright.js
@@ -55,10 +55,9 @@ const rule: ESLintRule = {
           return;
         }
 
-        const isMarginLeftRightAttribute = Object.entries(
-          node.attributes,
-          // eslint-disable-next-line no-unused-vars
-        ).find(([key, value]) => disallowedProps.includes(value && value.name && value.name.name));
+        const isMarginLeftRightAttribute = Object.entries(node.attributes).find(([_key, value]) =>
+          disallowedProps.includes(value && value.name && value.name.name),
+        );
 
         // No marginLeft or marginRight attributes on Box
         if (isMarginLeftRightAttribute) {

--- a/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
+++ b/packages/eslint-plugin-gestalt/src/no-medium-formfields.js
@@ -48,8 +48,7 @@ const rule: ESLintRule = {
         }
 
         const sizeAttribute = Object.entries(node.attributes).find(
-          // eslint-disable-next-line no-unused-vars
-          ([key, value]) => value && value.name && value.name.name === 'size',
+          ([_key, value]) => value && value.name && value.name.name === 'size',
         );
 
         // No size defined or size is not "lg"

--- a/packages/eslint-plugin-gestalt/src/no-role-link-components.js
+++ b/packages/eslint-plugin-gestalt/src/no-role-link-components.js
@@ -45,8 +45,7 @@ const rule: ESLintRule = {
         }
 
         const isRoleLink = Object.entries(node.attributes).find(
-          // eslint-disable-next-line no-unused-vars
-          ([key, value]) =>
+          ([_key, value]) =>
             value &&
             value.name &&
             value.name.name === 'role' &&

--- a/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
+++ b/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
@@ -99,7 +99,7 @@ function LegendIcon({ payloadData }: Props): ReactNode {
     return (
       <svg width="14" height="14" viewBox="0 0 12 12">
         <rect x={4} style={{ fill: 'transparent' }} height={3} width={1} y={8} />
-        <GraphPoint active={false} color={colorPoint} cx={7} cy={7} />
+        <GraphPoint color={colorPoint} cx={7} cy={7} />
         <rect x={4} style={{ fill: 'transparent' }} height={3} width={1} y={8} />
       </svg>
     );

--- a/packages/gestalt-charts/src/ChartGraph/renderGraphPoint.js
+++ b/packages/gestalt-charts/src/ChartGraph/renderGraphPoint.js
@@ -3,17 +3,14 @@ import { type Node as ReactNode } from 'react';
 import { type DataVisualizationColors } from './types';
 import { useHexColor } from './usePatterns';
 
-type Props = {
+type Props = {|
   noReposition?: boolean,
-  active: boolean,
   color: DataVisualizationColors,
   cx: number,
   cy: number,
-};
+|};
 
-export function GraphPoint(props: Props): ReactNode {
-  // eslint-disable-next-line no-unused-vars
-  const { color, cx, cy, active, noReposition = false } = props;
+export function GraphPoint({ color, cx, cy, noReposition = false }: Props): ReactNode {
   const hexColor = useHexColor();
 
   const decalDotCoordCorrection = {
@@ -63,13 +60,7 @@ const renderGraphPoint: ({
     cy: number,
     ...
   }) => ReactNode = ({ cx, cy }) => (
-    <GraphPoint
-      key={props.color + cy + cx}
-      color={props.color}
-      cy={cy}
-      cx={cx}
-      active={props.active}
-    />
+    <GraphPoint key={props.color + cy + cx} color={props.color} cy={cy} cx={cx} />
   );
 
   return renderPoint;

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.js
@@ -3,6 +3,11 @@ import { type Node as ReactNode, useCallback } from 'react';
 import { Box, Flex, Text } from 'gestalt';
 import LegendIcon from './LegendIcon';
 
+type ReferenceAreaSummaryItem = {|
+  label: string,
+  style?: 'default',
+|};
+
 export default function useDefaultLegend({
   isHorizontalBiaxialLayout,
   isVerticalBiaxialLayout,
@@ -18,10 +23,7 @@ export default function useDefaultLegend({
   height: number,
   labelMap: ?{ [string]: string },
   setLegendHeight: (number) => void,
-  referenceAreaSummary: null | $ReadOnlyArray<{
-    label: string,
-    style?: 'default',
-  }>,
+  referenceAreaSummary: null | $ReadOnlyArray<ReferenceAreaSummaryItem>,
 }): ({
   payload: $ReadOnlyArray<{
     payload: {
@@ -59,9 +61,7 @@ export default function useDefaultLegend({
       );
 
       const referenceAreas =
-        // TO DO FIX
-        // eslint-disable-next-line no-unused-vars
-        referenceAreaSummary?.map(({ style, label }: { style?: 'default', label: string }) => (
+        referenceAreaSummary?.map(({ label }: ReferenceAreaSummaryItem) => (
           <Flex key={label} gap={{ row: 2, column: 0 }}>
             <LegendIcon payloadData={{ referenceArea: 'default', isLegend: true }} />
             <Text size="200">{label}</Text>

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.js
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.js
@@ -168,8 +168,6 @@ type CustomDateFieldProps = {
 
 function CustomDateField({
   inputRef: externalInputRef,
-  slots,
-  slotProps,
   ...textFieldProps
 }: CustomDateFieldProps): ReactNode {
   return (


### PR DESCRIPTION
A number of `no-unused-vars` suppressions had crept into the codebase. They almost all fell into a couple of buckets:
- copypasta on mobile docs pages
- unused keys when mapping over `Object.entries`

I tweaked the lint rule config to better support the latter of these, making two changes:
- `'args': 'after-used'`: for functions with positional arguments, unused args _before_ used args are ignored. Only unused args _after_ the used args will throw an error. See the [eslint docs](https://eslint.org/docs/latest/rules/no-unused-vars#args-after-used) for more details.
- `'argsIgnorePattern': '^_'`: Unfortunately the previous change doesn't help with most of our existing issues (the `Object.entries` errors). For code like
  ```js
  ([key, value]) => value && value.name && value.name.name === 'size'
  ```
the function actually only has a single arg, which is then being destructured as an array. The unused "arg" within that array is still considered an error, even though it shouldn't be. So this config allows us to rename `key` --> `_key` and it's then ignored by the rule. (Don't abuse this, please!)