### PR TITLE
Internal: update pull_request_template to include semver info

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,22 @@
-Thanks for creating a PR! Please follow this template and delete items/sections that are not relevant to your changes, including these instructions.
+# Pull Request Instructions
 
-Please also make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mentioning platform if relevant)`, or `{ComponentName}, {OtherComponentName}: Description (mentioning platform if relevant)` if multiple components are affected.
+Thanks for creating a PR! 🎉
+
+- Please follow this template and delete items/sections that are not relevant to your changes, _including these instructions_.
+- Make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mention platform if relevant)`. If there are changes to multiple components, use `{ComponentName}, {OtherComponentName}: Description (mention platform if relevant)`.
+- Each PR needs a [label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) indicating which [semantic version](https://semver.org/) should be applied:
+  - _Major_: Breaking changes to existing components (e.g. removing a prop, removing a prop value, removing a component).
+  - _Minor_: New components, non-breaking changes to existing components (e.g. adding a new prop, adding a new prop value).
+  - _Patch_: Bugfixes, internal refactors that don't change the component's API, most dependency upgrades, all docs updates.
+- If you're updating a dependency, please also include the `dependencies` label.
+
+## Pull Request Template
 
 ### Summary
 
 #### What changed?
 
-From a high level, what are the changes this PR introduces? (No need to recount line-by-line, we can see that.)
+At a high level, what changes does this PR introduce?
 
 #### Why?
 
@@ -24,4 +34,4 @@ What is the purpose of this PR? Please include the context around these changes 
 - [ ] Added documentation + accessibility tests
 - [ ] Verified accessibility: keyboard & screen reader interaction
 - [ ] Checked dark mode, responsiveness, and right-to-left support
-- [ ] Checked stakeholder feedback (e.g. Gestalt designers)
+- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)


### PR DESCRIPTION
There has been some confusion about semver labels, so added a note about that (with examples of valid changes for each). Also some general cleanup and copyediting.