### PR TITLE
Docs: fix broken links

### DIFF
--- a/docs/pages/web/datefield.js
+++ b/docs/pages/web/datefield.js
@@ -243,7 +243,7 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onR
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[DatePicker](/DatePicker)**
+**[DatePicker](/web/datepicker)**
 Use DatePicker if the user is allowed to pick a date from a calendar popup.
     `}
         />

--- a/docs/pages/web/daterange.js
+++ b/docs/pages/web/daterange.js
@@ -145,7 +145,7 @@ export default function DatePickerPage({
             title="When not to use"
             description={`
 - When users need to select one specific day. Use [DatePicker](/web/datepicker) instead
-- When users need to input a date value with a numeric keyboard, for example when adding a birthday date. Use [DateField](/datefield) instead
+- When users need to input a date value with a numeric keyboard, for example when adding a birthday date. Use [DateField](/web/datefield) instead
 `}
           />
         </MainSection.Subsection>

--- a/docs/pages/web/numberfield.js
+++ b/docs/pages/web/numberfield.js
@@ -335,7 +335,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="NumberField can have different sizes. The default size is medium (40px). The large size is 48px. For a dense variant, use the `sm` (32px) variant."
+          description="NumberField can have different sizes. The default size is `md` (40px). The `lg` size is 48px. For a dense variant, use the `sm` (32px) value."
           title="Size"
         >
           <MainSection.Card

--- a/docs/pages/web/tableofcontents.js
+++ b/docs/pages/web/tableofcontents.js
@@ -167,7 +167,7 @@ export default function TableOfContentsPage({
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[SideNavigation](/web/SideNavigation)**
+**[SideNavigation](/web/sidenavigation)**
 SideNavigation is start-aligned and arranged vertically. It is used to navigate between page urls or sections when you have too many menu items to fit in horizontal [Tabs](/web/tabs).
 
 **[Tabs](/web/tabs)**

--- a/docs/pages/web/textfield.js
+++ b/docs/pages/web/textfield.js
@@ -470,7 +470,7 @@ The first example shows an empty Textfield with \`maxLength\` set to 20 characte
         </MainSection.Subsection>
         <MainSection.Subsection
           title="Size"
-          description="TextField can have different sizes. The default size is medium (40px). The large size is 48px. For a dense variant, use the `sm` (32px) variant."
+          description="TextField can have different sizes. The default size is `md` (40px). The `lg` size is 48px. For a dense variant, use the `sm` (32px) value."
         >
           <MainSection.Card
             sandpackExample={<SandpackExample name="TextField Sizes" code={textFieldSizes} />}

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -141,7 +141,7 @@ type Props = {
    */
   selectedOption?: OptionType,
   /**
-   * Sets the size of the ComboBox: sm:'32px', md: 40px, lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/ComboBox#Size) for more details.
+   * Sets the size of ComboBox: sm: 32px, md: 40px, lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/combobox#Size) for more details.
    */
   size?: Size,
   /**

--- a/packages/gestalt/src/List.js
+++ b/packages/gestalt/src/List.js
@@ -25,7 +25,7 @@ type Props = {
    */
   spacing?: 'regular' | 'condensed',
   /**
-   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [Text sizes variant](https://gestalt.pinterest.systems/web/List#Size) for more details.
+   *The sizes are based on our [font-size design tokens](https://gestalt.pinterest.systems/foundations/design_tokens#Font-size). See the [text sizes variant](https://gestalt.pinterest.systems/web/list#Size) for more details.
    */
   size?: Size,
   /**

--- a/packages/gestalt/src/NumberField.js
+++ b/packages/gestalt/src/NumberField.js
@@ -107,7 +107,7 @@ type Props = {
    */
   ref?: Element<'input'>, // eslint-disable-line react/no-unused-prop-types
   /**
-   * Sets the size of the NumberField: sm:'32px', md: 40px (default), lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/NumberField#Size) for more details.
+   * Sets the size of NumberField: sm: 32px, md: 40px (default), lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/numberfield#Size) for more details.
    */
   size?: 'sm' | 'md' | 'lg',
   /**

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -117,7 +117,7 @@ type Props = {
    */
   type?: Type,
   /**
-   * Sets the size of the TextField: sm:'32px', md: 40px (default), lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/TextField#Size) for more details.
+   * Sets the size of TextField: sm: 32px, md: 40px (default), lg: 48px. See the [size variant](https://gestalt.pinterest.systems/web/textfield#Size) for more details.
    */
   size?: 'sm' | 'md' | 'lg',
   /**

--- a/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
+++ b/packages/gestalt/src/contexts/GlobalEventsHandlerProvider.js
@@ -58,7 +58,7 @@ type Props = {
     }) => void,
   },
   /**
-   * Handlers consumed by [RadioGroup](https://gestalt.pinterest.systems/web/RadioGroup).
+   * Handlers consumed by [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup).
    */
   radioGroupHandlers?: { onRender?: () => void },
 };


### PR DESCRIPTION
# How to find broken links

Navigate to [Algolia's crawler](https://crawler.algolia.com/admin/crawlers/1b084526-6b1b-4fe6-be0e-c4de54b9f65c/overview). (If you're not auth'd for this, let me know.) The dashboard will show you the results from the most recent crawl:

![Screenshot 2024-01-22 at 1 02 12 PM](https://github.com/pinterest/gestalt/assets/12059539/4b2f1031-5864-414a-975d-b4ff4d683245)
We're interested in that "Monitoring" section. Notice that there are 9 Ignored URLs. That's not good — that should only ever be one (because we redirect from `/` to `/home`). Let's click "View in Monitoring" to check it out.

![Screenshot 2024-01-22 at 1 03 09 PM](https://github.com/pinterest/gestalt/assets/12059539/9cab8457-3fb7-4f41-8b4b-d747b814c7c8)
The Monitoring view shows us that there are 2 redirects and 7 404s. Again, more than we should have (just a single redirect entry). Click the right chevron to dig in…

![Screenshot 2024-01-22 at 1 03 58 PM](https://github.com/pinterest/gestalt/assets/12059539/acc7dd65-8760-46ec-abd0-6fc6c6c152af)
Ok, we see the one `/` redirect we expect. Check out that DatePicker one…that URL is missing the `/web` path part, so is clearly wrong. Let's find out where that's happening. Click the magnifying glass icon button on that row…

![Screenshot 2024-01-22 at 1 04 30 PM](https://github.com/pinterest/gestalt/assets/12059539/d16d21d4-e0ac-4adb-88dd-b4105600c44a)
We can see the URL that was hit, and the URL it was redirected to. If we scroll to the bottom of that view…

![Screenshot 2024-01-22 at 1 05 20 PM](https://github.com/pinterest/gestalt/assets/12059539/15ace408-66d1-4c61-b0c1-40fbac41c57b)
…we can see the URL where the bad link was found. So let's pop open the docs page for DateField and search for "/DatePicker". Boom! [There's our bad URL](https://github.com/pinterest/gestalt/blob/d47836967e1a3624648efdcb8f0a42dcac9ef61a/docs/pages/web/datefield.js#L246), down in the Related section.

Repeat these steps for all other redirects and 404s. Once this PR is merged and the changes are live in the docs, re-run the crawler to make sure there aren't any remaining bad URLs.