### PR TITLE
Internal: add displayName to all top-level components

### DIFF
--- a/packages/gestalt-charts/src/ChartGraph.js
+++ b/packages/gestalt-charts/src/ChartGraph.js
@@ -543,4 +543,6 @@ function ChartGraph({
 
 ChartGraph.LegendIcon = LegendIcon;
 
+ChartGraph.displayName = 'ChartGraph';
+
 export default ChartGraph;

--- a/packages/gestalt-datepicker/src/DateRange.js
+++ b/packages/gestalt-datepicker/src/DateRange.js
@@ -292,4 +292,6 @@ function DateRange({
   );
 }
 
+DateRange.displayName = 'DateRange';
+
 export default DateRange;

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -104,4 +104,6 @@ export default function Accordion({
   );
 }
 
+Accordion.displayName = 'Accordion';
+
 Accordion.Expandable = AccordionExpandable;

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -291,3 +291,5 @@ export default function ActivationCard({
     </Box>
   );
 }
+
+ActivationCard.displayName = 'ActivationCard';

--- a/packages/gestalt/src/Badge.js
+++ b/packages/gestalt/src/Badge.js
@@ -108,3 +108,5 @@ export default function Badge({
     badgeComponent
   );
 }
+
+Badge.displayName = 'Badge';

--- a/packages/gestalt/src/BannerOverlay.js
+++ b/packages/gestalt/src/BannerOverlay.js
@@ -442,3 +442,5 @@ export default function BannerOverlay({
     </Fragment>
   );
 }
+
+BannerOverlay.displayName = 'BannerOverlay';

--- a/packages/gestalt/src/BannerUpsell.js
+++ b/packages/gestalt/src/BannerUpsell.js
@@ -284,3 +284,5 @@ export default function BannerUpsell({
 }
 
 BannerUpsell.Form = BannerUpsellForm;
+
+BannerUpsell.displayName = 'BannerUpsell';

--- a/packages/gestalt/src/ButtonGroup.js
+++ b/packages/gestalt/src/ButtonGroup.js
@@ -31,4 +31,6 @@ function ButtonGroup({ children }: Props): ReactNode {
   );
 }
 
+ButtonGroup.displayName = 'ButtonGroup';
+
 export default ButtonGroup;

--- a/packages/gestalt/src/Callout.js
+++ b/packages/gestalt/src/Callout.js
@@ -286,3 +286,5 @@ export default function Callout({
     </Box>
   );
 }
+
+Callout.displayName = 'Callout';

--- a/packages/gestalt/src/Collage.js
+++ b/packages/gestalt/src/Collage.js
@@ -212,3 +212,5 @@ export default function Collage(props: Props): ReactNode {
     />
   );
 }
+
+Collage.displayName = 'Collage';

--- a/packages/gestalt/src/Column.js
+++ b/packages/gestalt/src/Column.js
@@ -46,3 +46,5 @@ export default function Column(props: ColumnProps): ReactNode {
   );
   return <div className={cs}>{children}</div>;
 }
+
+Column.displayName = 'Column';

--- a/packages/gestalt/src/Container.js
+++ b/packages/gestalt/src/Container.js
@@ -24,3 +24,5 @@ export default function Container({ children }: Props): ReactNode {
     </Box>
   );
 }
+
+Container.displayName = 'Container';

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -78,3 +78,5 @@ export default function Datapoint({
     />
   );
 }
+
+Datapoint.displayName = 'Datapoint';

--- a/packages/gestalt/src/Divider.js
+++ b/packages/gestalt/src/Divider.js
@@ -13,3 +13,5 @@ import styles from './Divider.css';
 export default function Divider({}: {}): ReactNode {
   return <hr className={styles.divider} />;
 }
+
+Divider.displayName = 'Divider';

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -318,3 +318,5 @@ export default function Dropdown({
 Dropdown.Item = DropdownItem;
 Dropdown.Link = DropdownLink;
 Dropdown.Section = DropdownSection;
+
+Dropdown.displayName = 'Dropdown';

--- a/packages/gestalt/src/Fieldset.js
+++ b/packages/gestalt/src/Fieldset.js
@@ -74,3 +74,5 @@ export default function Fieldset({
     </fieldset>
   );
 }
+
+Fieldset.displayName = 'Fieldset';

--- a/packages/gestalt/src/Heading.js
+++ b/packages/gestalt/src/Heading.js
@@ -127,3 +127,5 @@ export default function Heading({
 
   return createElement(headingLevel === 'none' ? 'div' : `h${headingLevel}`, newProps, children);
 }
+
+Heading.displayName = 'Heading';

--- a/packages/gestalt/src/Label.js
+++ b/packages/gestalt/src/Label.js
@@ -23,3 +23,5 @@ type Props = {
 export default function Label({ children, htmlFor }: Props): ReactNode {
   return <InternalLabel htmlFor={htmlFor}>{children}</InternalLabel>;
 }
+
+Label.displayName = 'Label';

--- a/packages/gestalt/src/Layer.js
+++ b/packages/gestalt/src/Layer.js
@@ -87,3 +87,5 @@ export default function Layer({ children, zIndex: zIndexIndexable }: Props): Por
   // After useEffect, we render the children into the portal container node outside the DOM hierarchy
   return createPortal(children, portalContainer.current);
 }
+
+Layer.displayName = 'Layer';

--- a/packages/gestalt/src/Letterbox.js
+++ b/packages/gestalt/src/Letterbox.js
@@ -72,3 +72,5 @@ export default function Letterbox({
     </Mask>
   );
 }
+
+Letterbox.displayName = 'Letterbox';

--- a/packages/gestalt/src/Mask.js
+++ b/packages/gestalt/src/Mask.js
@@ -59,3 +59,5 @@ export default function Mask({
     </div>
   );
 }
+
+Mask.displayName = 'Mask';

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -166,6 +166,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
     virtualize: false,
   };
 
+  static displayName: ?string = 'Masonry';
+
   constructor(props: Props<T>) {
     super(props);
 

--- a/packages/gestalt/src/Modal.js
+++ b/packages/gestalt/src/Modal.js
@@ -253,3 +253,5 @@ export default function Modal({
     </StopScrollBehavior>
   );
 }
+
+Modal.displayName = 'Modal';

--- a/packages/gestalt/src/ModalAlert.js
+++ b/packages/gestalt/src/ModalAlert.js
@@ -134,3 +134,5 @@ export default function ModalAlert({
     </DeviceTypeProvider>
   );
 }
+
+ModalAlert.displayName = 'ModalAlert';

--- a/packages/gestalt/src/PageHeader.js
+++ b/packages/gestalt/src/PageHeader.js
@@ -203,3 +203,5 @@ export default function PageHeader({
     </div>
   );
 }
+
+PageHeader.displayName = 'PageHeader';

--- a/packages/gestalt/src/Pog.js
+++ b/packages/gestalt/src/Pog.js
@@ -149,3 +149,5 @@ export default function Pog({
     </div>
   );
 }
+
+Pog.displayName = 'Pog';

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -174,3 +174,5 @@ export default function Popover({
     </InternalPopover>
   );
 }
+
+Popover.displayName = 'Popover';

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -233,3 +233,5 @@ export default function PopoverEducational({
     </Box>
   );
 }
+
+PopoverEducational.displayName = 'PopoverEducational';

--- a/packages/gestalt/src/Pulsar.js
+++ b/packages/gestalt/src/Pulsar.js
@@ -41,3 +41,5 @@ export default function Pulsar({ paused, size = 136 }: Props): ReactNode {
     </Box>
   );
 }
+
+Pulsar.displayName = 'Pulsar';

--- a/packages/gestalt/src/SegmentedControl.js
+++ b/packages/gestalt/src/SegmentedControl.js
@@ -148,3 +148,5 @@ export default function SegmentedControl({
     </div>
   );
 }
+
+SegmentedControl.displayName = 'SegmentedControl';

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -178,4 +178,6 @@ function SelectList({
 SelectList.Option = SelectListOption;
 SelectList.Group = SelectListGroup;
 
+SelectList.displayName = 'SelectList';
+
 export default SelectList;

--- a/packages/gestalt/src/SideNavigation.js
+++ b/packages/gestalt/src/SideNavigation.js
@@ -154,3 +154,5 @@ SideNavigation.NestedItem = SideNavigationNestedItem;
 
 SideNavigation.Group = SideNavigationGroup;
 SideNavigation.NestedGroup = SideNavigationNestedGroup;
+
+SideNavigation.displayName = 'SideNavigation';

--- a/packages/gestalt/src/SlimBanner.js
+++ b/packages/gestalt/src/SlimBanner.js
@@ -275,3 +275,5 @@ export default function SlimBanner({
     </Box>
   );
 }
+
+SlimBanner.displayName = 'SlimBanner';

--- a/packages/gestalt/src/Spinner.js
+++ b/packages/gestalt/src/Spinner.js
@@ -63,3 +63,5 @@ export default function Spinner({
     <div />
   );
 }
+
+Spinner.displayName = 'Spinner';

--- a/packages/gestalt/src/Status.js
+++ b/packages/gestalt/src/Status.js
@@ -101,3 +101,5 @@ export default function Status({ accessibilityLabel, subtext, title, type }: Pro
     </Flex>
   );
 }
+
+Status.displayName = 'Status';

--- a/packages/gestalt/src/Sticky.js
+++ b/packages/gestalt/src/Sticky.js
@@ -70,3 +70,5 @@ export default function Sticky({
     </div>
   );
 }
+
+Sticky.displayName = 'Sticky';

--- a/packages/gestalt/src/Switch.js
+++ b/packages/gestalt/src/Switch.js
@@ -95,3 +95,5 @@ export default function Switch({
     </div>
   );
 }
+
+Switch.displayName = 'Switch';

--- a/packages/gestalt/src/Table.js
+++ b/packages/gestalt/src/Table.js
@@ -110,19 +110,13 @@ export default function Table({
 }
 
 Table.Body = TableBody;
-
 Table.Cell = TableCell;
-
 Table.Footer = TableFooter;
-
 Table.Header = TableHeader;
-
 Table.HeaderCell = TableHeaderCell;
-
 Table.Row = TableRow;
-
+Table.RowDrawer = TableRowDrawer;
+Table.RowExpandable = TableRowExpandable;
 Table.SortableHeaderCell = TableSortableHeaderCell;
 
-Table.RowExpandable = TableRowExpandable;
-
-Table.RowDrawer = TableRowDrawer;
+Table.displayName = 'Table';

--- a/packages/gestalt/src/TableOfContents.js
+++ b/packages/gestalt/src/TableOfContents.js
@@ -50,3 +50,5 @@ export default function TableOfContents({ accessibilityLabel, title, children }:
 }
 
 TableOfContents.Item = TableOfContentsItem;
+
+TableOfContents.displayName = 'TableOfContents';

--- a/packages/gestalt/src/Tabs.js
+++ b/packages/gestalt/src/Tabs.js
@@ -252,3 +252,5 @@ export default function Tabs({
     </Flex>
   );
 }
+
+Tabs.displayName = 'Tabs';

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -191,3 +191,5 @@ export default function Tag({
     </Box>
   );
 }
+
+Tag.displayName = 'Tag';

--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -259,3 +259,5 @@ export default function TagData({
     </Box>
   );
 }
+
+TagData.displayName = 'TagData';

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -185,3 +185,5 @@ export default function TileData({
     </MaybeTooltip>
   );
 }
+
+TileData.displayName = 'TileData';

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -270,3 +270,5 @@ export default function Toast({
     </div>
   );
 }
+
+Toast.displayName = 'Toast';

--- a/packages/gestalt/src/Video.js
+++ b/packages/gestalt/src/Video.js
@@ -304,6 +304,8 @@ export default class Video extends PureComponent<Props, State> {
 
   player: ?HTMLDivElement;
 
+  static displayName: ?string = 'Video';
+
   static defaultProps: {
     startTime: number,
     disableRemotePlayback: boolean,

--- a/packages/gestalt/src/WashAnimated.js
+++ b/packages/gestalt/src/WashAnimated.js
@@ -67,3 +67,5 @@ export default function WashAnimated({
     </Box>
   );
 }
+
+WashAnimated.displayName = 'WashAnimated';


### PR DESCRIPTION
As part of tracking adoption for Visual Refresh, we need a way to identify Gestalt components in prod code. This is possible if the component has an explicitly-set `displayName` property. This PRs adds `displayName`s to all top-level components. We can address sub-components in a future PR if tracking their usage is necessary.