### PR TITLE
Tokens: update color token documentation

### DIFF
--- a/docs/docs-components/ColorPalette.js
+++ b/docs/docs-components/ColorPalette.js
@@ -12,25 +12,34 @@ type Props = {
 function ColorPalette({ name, tokenId }: Props): ReactNode {
   const tokenNumbers = [0, 50, 100, 200, 300, 400, 500, 550, 600, 700, 800, 900];
   const colorId = `${tokenId}-${name.toLowerCase()}`;
+
+  const isTransparent = tokenId === 'transparent';
+
   return (
     <Box marginTop={8} marginBottom={8}>
       <Text weight="bold">
         {name} ({tokenId})
       </Text>
-      <Box marginTop={2}>
-        {tokenNumbers.map((number) => {
-          const textColor = number > 400 ? 'light' : 'dark';
-          const colorVariableName = `color-${colorId}-${number}`;
-          return tokens[colorVariableName] ? (
-            <ColorTile
-              fullTokenName={colorVariableName}
-              description={`${number}`}
-              number={number}
-              textColor={textColor}
-            />
-          ) : null;
-        })}
-      </Box>
+      {isTransparent ? (
+        <Box marginTop={2}>
+          <ColorTile fullTokenName="color-transparent" description="" number={0} />
+        </Box>
+      ) : (
+        <Box marginTop={2}>
+          {tokenNumbers.map((number) => {
+            const textColor = number > 400 ? 'light' : 'dark';
+            const colorVariableName = `color-${colorId}-${number}`;
+            return tokens[colorVariableName] ? (
+              <ColorTile
+                fullTokenName={colorVariableName}
+                description={`${number}`}
+                number={number}
+                textColor={textColor}
+              />
+            ) : null;
+          })}
+        </Box>
+      )}
     </Box>
   );
 }

--- a/docs/docs-components/ColorTile.js
+++ b/docs/docs-components/ColorTile.js
@@ -12,8 +12,13 @@ type Props = {
 };
 
 function ColorTile({ description, fullTokenName, number = 400, textColor }: Props): ReactNode {
+  const isTransparent = fullTokenName === 'color-transparent';
   const newTextColor = textColor || (number > 400 ? 'light' : 'dark');
-  const borderNeeded = fullTokenName?.includes('white') || fullTokenName?.includes('inverse');
+  const borderNeeded =
+    fullTokenName?.includes('white') ||
+    fullTokenName?.includes('black') ||
+    fullTokenName?.includes('inverse') ||
+    isTransparent;
   const { name: colorSchemeName } = useColorScheme();
 
   return (

--- a/docs/pages/foundations/color/palette.js
+++ b/docs/pages/foundations/color/palette.js
@@ -110,7 +110,11 @@ export default function ColorPage(): ReactNode {
               description="Roboflow 200"
               number={200}
             />
-            <ColorTile fullTokenName="color-white-mochimalist-0" description="Mochimalist 0" />
+            <ColorTile
+              fullTokenName="color-white-mochimalist-0"
+              description="Mochimalist 0"
+              number={0}
+            />
           </ColorSchemeCard>
           <ColorSchemeCard colorScheme="dark">
             <ColorTile

--- a/docs/pages/foundations/color/palette.js
+++ b/docs/pages/foundations/color/palette.js
@@ -24,6 +24,8 @@ const neutrals = [
   { name: 'Cosmicore', id: 'black', textColor: 'light' },
 ];
 
+const transparent = [{ name: '', id: 'transparent', textColor: 'dark' }];
+
 type ColorCardProps = {
   children: ReactNode,
   colorScheme: 'light' | 'dark',
@@ -108,11 +110,7 @@ export default function ColorPage(): ReactNode {
               description="Roboflow 200"
               number={200}
             />
-            <ColorTile
-              fullTokenName="color-white-mochimalist-0"
-              description="Mochimalist 0"
-              number={0}
-            />
+            <ColorTile fullTokenName="color-white-mochimalist-0" description="Mochimalist 0" />
           </ColorSchemeCard>
           <ColorSchemeCard colorScheme="dark">
             <ColorTile
@@ -149,6 +147,22 @@ export default function ColorPage(): ReactNode {
         </Flex>
       </MainSection>
       <MainSection
+        name="Reserved colors"
+        description="The 450 colors are primarily reserved for Brand usage as they are among the least accessible colors. This set works best within larger brand moments, and is not commonly used for functional color pairings. While Pushpin 450 is our hero, primary product color, please only use other 450 colors when absolutely necessary while maintaining accessibility."
+      >
+        <Flex direction="column">
+          {colors.map(({ id, name, textColor }) => (
+            <ColorTile
+              key={name}
+              fullTokenName={`color-${id}-${name.toLowerCase()}-450`}
+              description={`${name} 450`}
+              textColor={textColor}
+            />
+          ))}
+        </Flex>
+      </MainSection>
+
+      <MainSection
         name="Extended palette"
         description={`
         The extended color palette displays all the available shades and tints of each color in the palette. The colors are named and numbered for easy reference. The usage of these colors varies depending on the product needs, but they come in handy for illustrations, communicating status, and brand moments.
@@ -156,7 +170,7 @@ export default function ColorPage(): ReactNode {
         We aim to meet [WCAG 2.1 AA accessibility standards](https://www.w3.org/TR/WCAG21/), and in order to ensure accessible contrast for color pairings, we require our \`darkGray\` [Text](/web/text) color to be used for any colors 400 and below. For 500 and above, we recommend using \`white\`.
         `}
       >
-        <MainSection.Subsection title="Colors">
+        <MainSection.Subsection title="Colors" description="Pinterest name (common name)">
           <Flex
             gap={{
               row: 12,
@@ -169,42 +183,36 @@ export default function ColorPage(): ReactNode {
             ))}
           </Flex>
         </MainSection.Subsection>
-
-        <MainSection.Subsection title="Neutrals">
+        <MainSection.Subsection title="Neutrals" description="Pinterest name (common name)">
           <Flex direction="column">
             {neutrals.map(({ id, name }) => (
               <ColorPalette key={name} name={name} tokenId={id} />
             ))}
           </Flex>
         </MainSection.Subsection>
-
-        <MainSection.Subsection
-          title="Reserved"
-          description="The 450 colors are primarily reserved for Brand usage as they are among the least accessible colors. This set works best within larger brand moments, and is not commonly used for functional color pairings. While Pushpin 450 is our hero, primary product color, please only use other 450 colors when absolutely necessary while maintaining accessibility."
-        >
+        <MainSection.Subsection title="Transparent" description="(common name)">
           <Flex direction="column">
-            {colors.map(({ id, name, textColor }) => (
-              <ColorTile
-                key={name}
-                fullTokenName={`color-${id}-${name.toLowerCase()}-450`}
-                description={`${name} 450`}
-                textColor={textColor}
-              />
+            {transparent.map(({ id, name }) => (
+              <ColorPalette key={name} name={name} tokenId={id} />
             ))}
           </Flex>
         </MainSection.Subsection>
-      </MainSection>
-      <MainSection
-        name="Colors in code"
-        description={`
-       All colors in this palette are available through [design tokens](https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099) and follow the naming pattern of \`color-{common_name}-{pinterest_name}-{number}\`. For example:
+        <MainSection.Subsection
+          title="Colors in code"
+          description={`
+       The full extended palette of colors (colors, neutrals, and transparent) are the foundational elements of our color token system or base tokens. Base tokens are the lowest level tokens, which map directly to a value. Base tokens would likely be internal only and used to build our [semantic design tokens](/foundations/design_tokens).
+
+       The full extended palette is available through design tokens and follow the naming pattern of \`color-{common_name}-{pinterest_name}-{number}\`. For example:
 
        - JavaScript  \`$color-pink-flaminglow-400\`
-       - CSS  \`var(--color-pink-flaminglow-400)\`
+       - CSS \`var(--color-pink-flaminglow-400)\`
+
+       The transparent color is just \`color-transparent\`.
 
        Using colors that are not available through our [semantic design tokens](/foundations/design_tokens) and components directly is considered an anti-pattern and should be avoided whenever possible. If it's absolutely necessary, a [hack on Box](/get_started/developers/hacking_gestalt#Box's-dangerouslySetInlineStyle) can be used.
       `}
-      />
+        />
+      </MainSection>
     </Page>
   );
 }

--- a/docs/pages/foundations/color/palette.js
+++ b/docs/pages/foundations/color/palette.js
@@ -204,7 +204,7 @@ export default function ColorPage(): ReactNode {
         <MainSection.Subsection
           title="Colors in code"
           description={`
-       The full extended palette of colors (colors, neutrals, and transparent) are the foundational elements of our color token system or base tokens. Base tokens are the lowest level tokens, which map directly to a value. Base tokens would likely be internal only and used to build our [semantic design tokens](/foundations/design_tokens).
+       The full extended palette of colors (colors, neutrals, and transparent) are the foundational elements of our color system or base color tokens. Base tokens are the lowest level tokens, which map directly to a value. Base tokens would likely be internal only and used to build our [semantic design tokens](/foundations/design_tokens).
 
        The full extended palette is available through design tokens and follow the naming pattern of \`color-{common_name}-{pinterest_name}-{number}\`. For example:
 

--- a/docs/pages/foundations/design_tokens.js
+++ b/docs/pages/foundations/design_tokens.js
@@ -124,7 +124,11 @@ export default function DesignTokensPage(): ReactNode {
     <Page title="Design tokens guidelines">
       <PageHeader
         name="Design tokens"
-        description="Design tokens represent the values used within a design system to construct layouts and components, such as spacing and color. Because the tokens are an abstraction, the underlying value can change in different scenarios without affecting the designer or developer experience. [Learn more about Design Tokens](https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099)."
+        description={`
+Design tokens represent the values used within a design system to construct layouts and components, such as spacing and color. Because the tokens are an abstraction, the underlying value can change in different scenarios without affecting the designer or developer experience. [Learn more about Design Tokens](https://uxdesign.cc/design-tokens-cheatsheet-927fc1404099).
+
+The design color tokens on this page, those that with \`$color-\` are alias (or semantic tokens) as they give semantic usage information through their name. They point to Gestalt's base color tokens (hence the name "alias"). To learm more about the complete set of Gestalt's base color tokens, read our [extended color palette section](http://localhost:8888/foundations/color/palette#Extended-palette)
+        `}
         type="guidelines"
       />
       <MainSection name="Token values">


### PR DESCRIPTION
Tokens: update color token documentation to include transparent and improve how base colors are explain and linked to concepts such as extended palette and semantic tokens.

BEFORE
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/18a69495-92c3-489a-9e12-2dd37c2a3ce0)


AFTER
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/ea361a8f-f232-4516-9ebc-63e7ed91b4a6)