### PR TITLE
AvatarGroup: Update addCollaborators icon from 'add' to 'add-person'

### DIFF
--- a/packages/gestalt/src/Avatar/Foundation.js
+++ b/packages/gestalt/src/Avatar/Foundation.js
@@ -106,7 +106,7 @@ export default function AvatarFoundation({
           xmlns="http://www.w3.org/2000/svg"
         >
           <title>Icon</title>
-          <path d={icons.add} />
+          <path d={icons['person-add']} />
         </svg>
       ) : null}
     </ResponsiveFitSizeBox>


### PR DESCRIPTION
Before:
<img width="173" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/0e901b8f-42c3-4f8c-8a9d-7354a97112b6">

After:
<img width="178" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/c7902d11-6512-4c61-b453-cfa8220c4f7a">

## Pull Request Template

### Summary
Changing the icon used for `addCollaborators` prop on AvatarGroup

#### What changed?

At a high level, what changes does this PR introduce?

Changing the icon for add-collaborators.

#### Why?

Improved user comprehension