### PR TITLE
Tokens: change color-text-subtle &  color-text-icon-subtle  value to match Figma + Token changelog

### DIFF
--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,0 +1,24 @@
+This file is updated manually
+
+## 134.0.0 https://github.com/pinterest/gestalt/pull/3394
+
+### Major
+
+| name                   | old value                     | new value                     |
+| ---------------------- | ----------------------------- | ----------------------------- |
+| color-text-subtle      | color.gray.roboflow.550.value | color.gray.roboflow.500.value |
+| color-text-icon-subtle | color.gray.roboflow.550.value | color.gray.roboflow.500.value |
+
+Before
+![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/dcda2b20-e1ba-476c-8b5c-41271cafb84c)
+
+After
+![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/8621a8a1-0d71-4ea0-9d64-423ba166b9b5)
+
+#### Why
+
+Reconcile with Figma values
+
+#### Breaking change notes
+
+It might break visual snapshots

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -7,7 +7,7 @@
         "comment": "Default text color"
       },
       "subtle": {
-        "value": "{color.gray.roboflow.550.value}",
+        "value": "{color.gray.roboflow.500.value}",
         "darkValue": "{color.gray.roboflow.400.value}",
         "comment": "Secondary, subtle text color"
       },

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -61,7 +61,7 @@
           "comment": "Default color for icons"
         },
         "subtle": {
-          "value": "{color.gray.roboflow.550.value}",
+          "value": "{color.gray.roboflow.500.value}",
           "darkValue": "{color.gray.roboflow.400.value}",
           "comment": "Subtle, secondary color for icons"
         },

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -155,7 +155,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --g-colorDataVisualization08: #400387;
   --g-colorDataVisualization09: #f2681f;
   --color-text-default: #111111;
-  --color-text-subtle: #5f5f5f;
+  --color-text-subtle: #767676;
   --color-text-success: #005f3e;
   --color-text-disabled: #a5a5a5;
   --color-text-error: #cc0000;
@@ -164,7 +164,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-text-shopping: #0074e8;
   --color-text-link: #004ba9;
   --color-text-icon-default: #111111;
-  --color-text-icon-subtle: #5f5f5f;
+  --color-text-icon-subtle: #767676;
   --color-text-icon-success: #005f3e;
   --color-text-icon-disabled: #a5a5a5;
   --color-text-icon-error: #cc0000;
@@ -266,7 +266,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --g-colorDataVisualization08: #400387;
   --g-colorDataVisualization09: #f2681f;
   --color-text-default: #111111;
-  --color-text-subtle: #5f5f5f;
+  --color-text-subtle: #767676;
   --color-text-success: #005f3e;
   --color-text-disabled: #a5a5a5;
   --color-text-error: #cc0000;
@@ -275,7 +275,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-text-shopping: #0074e8;
   --color-text-link: #004ba9;
   --color-text-icon-default: #111111;
-  --color-text-icon-subtle: #5f5f5f;
+  --color-text-icon-subtle: #767676;
   --color-text-icon-success: #005f3e;
   --color-text-icon-disabled: #a5a5a5;
   --color-text-icon-error: #cc0000;
@@ -377,7 +377,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --g-colorDataVisualization08: #400387;
   --g-colorDataVisualization09: #f2681f;
   --color-text-default: #111111;
-  --color-text-subtle: #5f5f5f;
+  --color-text-subtle: #767676;
   --color-text-success: #005f3e;
   --color-text-disabled: #a5a5a5;
   --color-text-error: #cc0000;
@@ -386,7 +386,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-text-shopping: #0074e8;
   --color-text-link: #004ba9;
   --color-text-icon-default: #111111;
-  --color-text-icon-subtle: #5f5f5f;
+  --color-text-icon-subtle: #767676;
   --color-text-icon-success: #005f3e;
   --color-text-icon-disabled: #a5a5a5;
   --color-text-icon-error: #cc0000;


### PR DESCRIPTION
Changelog: [packages/gestalt-design-tokens/CHANGELOG](https://github.com/pinterest/gestalt/blob/master/packages/gestalt-design-tokens/CHANGELOG.md)

### Major

| name                   | old value                     | new value                     |
| ---------------------- | ----------------------------- | ----------------------------- |
| color-text-subtle      | color.gray.roboflow.550.value | color.gray.roboflow.500.value |
| color-text-icon-subtle | color.gray.roboflow.550.value | color.gray.roboflow.500.value |

Before 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/dcda2b20-e1ba-476c-8b5c-41271cafb84c)

After
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/8621a8a1-0d71-4ea0-9d64-423ba166b9b5)

#### Why

Reconcile with Figma values

#### Breaking change notes

It might break visual snapshots

