### PR TITLE
Docs: fix alias section on mobile pages

### DIFF
--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -22,6 +22,7 @@ type Props = {
     component: boolean,
   },
   pageSourceUrl?: string,
+  platform: 'android' | 'ios' | 'web',
 };
 
 const isExternal: (string) => 'blank' | void = (href) => {
@@ -329,7 +330,12 @@ const components = {
   ),
 };
 
-export default function MarkdownPage({ children, meta, pageSourceUrl }: Props): ReactNode {
+export default function MarkdownPage({
+  children,
+  meta,
+  pageSourceUrl,
+  platform,
+}: Props): ReactNode {
   const maxWidth = meta?.fullwidth ? 'none' : `${DOCS_COPY_MAX_WIDTH_PX}px`;
 
   return (
@@ -340,6 +346,7 @@ export default function MarkdownPage({ children, meta, pageSourceUrl }: Props): 
           badge={meta.badge}
           description={meta.description}
           margin="none"
+          platform={platform}
           type={meta.component ? 'component' : 'guidelines'}
         />
         <Text>

--- a/docs/docs-components/PageHeader.js
+++ b/docs/docs-components/PageHeader.js
@@ -12,8 +12,6 @@ import Markdown from './Markdown';
 import PageHeaderQualitySummary from './PageHeaderQualitySummary';
 import { SlimBannerExperiment } from './SlimBannerExperiment';
 
-const webComponentData = getByPlatform(componentData, { platform: 'web' });
-
 const gestaltChartComponents = Object.keys(gestaltChart);
 const gestaltDatepickerComponents = Object.keys(gestaltDatepicker);
 
@@ -57,6 +55,7 @@ type Props = {
   folderName?: string,
   margin?: 'default' | 'none',
   name: string,
+  platform?: 'android' | 'ios' | 'web',
   slimBanner?: Element<typeof SlimBanner> | null,
   slimBannerExperiment?: Element<typeof SlimBannerExperiment> | null,
   type?: 'guidelines' | 'component' | 'utility',
@@ -72,6 +71,7 @@ export default function PageHeader({
   pdocsLink = false,
   margin = 'default',
   name,
+  platform,
   slimBanner = null,
   slimBannerExperiment = null,
   type = 'component',
@@ -83,7 +83,8 @@ export default function PageHeader({
     sourceLink = sourceLink.replace(/\.js$/, '');
   }
 
-  const { alias } = webComponentData.find((component) => component.name === name) ?? {};
+  const platformComponentData = getByPlatform(componentData, { platform: platform ?? 'web' });
+  const { alias } = platformComponentData.find((component) => component.name === name) ?? {};
 
   const badgeMap = {
     pilot: {

--- a/docs/pages/[...id].js
+++ b/docs/pages/[...id].js
@@ -16,6 +16,12 @@ import ErrorBoundary from '../docs-components/ErrorBoundary';
 import MarkdownPage from '../docs-components/MarkdownPage';
 import { getAllMarkdownPosts, getDocByRoute } from '../utils/mdHelper';
 
+function getPlatform(pathName: string): 'android' | 'ios' | 'web' {
+  if (pathName.startsWith('android')) return 'android';
+  if (pathName.startsWith('ios')) return 'ios';
+  return 'web';
+}
+
 type MDXRemoteSerializeResult = {
   compiledSource: string,
 
@@ -32,12 +38,13 @@ type Props = {
     component: boolean,
   },
   pageSourceUrl: string,
+  platform: 'android' | 'ios' | 'web',
 };
 
-export default function DocumentPage({ content, meta, pageSourceUrl }: Props): ReactNode {
+export default function DocumentPage({ content, meta, pageSourceUrl, platform }: Props): ReactNode {
   return (
     <ErrorBoundary>
-      <MarkdownPage meta={meta} pageSourceUrl={pageSourceUrl}>
+      <MarkdownPage meta={meta} pageSourceUrl={pageSourceUrl} platform={platform}>
         <MDXRemote {...content} />
       </MarkdownPage>
     </ErrorBoundary>
@@ -49,6 +56,7 @@ export async function getStaticProps(context: { params: { id: $ReadOnlyArray<str
     meta: { [key: string]: string },
     content: {},
     pageSourceUrl: string,
+    platform: 'android' | 'ios' | 'web',
   },
 }> {
   const { id } = context.params;
@@ -65,6 +73,7 @@ export async function getStaticProps(context: { params: { id: $ReadOnlyArray<str
       meta,
       content: mdxSource,
       pageSourceUrl: `https://github.com/pinterest/gestalt/tree/master/docs/markdown/${pathName}.md`,
+      platform: getPlatform(pathName),
     },
   };
 }


### PR DESCRIPTION
Way back in #3054, I introduced a bug where the `alias` field was hardcoded to use web component metadata. It appeared to work for most mobile components by accident — but was broken for any mobile component that didn't have a web counterpart.

This PR parses the platform for Markdown pages (e.g. all mobile docs) and passes it through to ensure we're using component metadata for the correct platform.