### PR TITLE
RadioGroup: Add Badge prop

### DIFF
--- a/docs/examples/radiogroup/addingABadgeExample.js
+++ b/docs/examples/radiogroup/addingABadgeExample.js
@@ -1,0 +1,62 @@
+// @flow strict
+import { type Node as ReactNode, useState } from 'react';
+import { Box, RadioGroup } from 'gestalt';
+
+export default function RadioButtonBadgeExample(): ReactNode {
+  const [option, setOption] = useState('');
+
+  return (
+    <Box padding={8} height="100%" display="flex" alignItems="center" justifyContent="center">
+      <RadioGroup legend="What badge would you like?" id="badgeExample">
+        <Box display="inlineBlock">
+          <RadioGroup.RadioButton
+            id="success"
+            checked={option === 'success'}
+            label="I'd like a success badge"
+            badge={{ text: 'badge', type: 'success' }}
+            onChange={() => {
+              setOption('success');
+            }}
+            value="success"
+          />
+        </Box>
+        <Box display="inlineBlock">
+          <RadioGroup.RadioButton
+            id="info"
+            checked={option === 'info'}
+            label="I'd like a info badge"
+            badge={{ text: 'badge', type: 'info' }}
+            onChange={() => {
+              setOption('info');
+            }}
+            value="info"
+          />
+        </Box>
+        <Box display="inlineBlock">
+          <RadioGroup.RadioButton
+            id="warning"
+            checked={option === 'warning'}
+            label="I'd like a warning badge"
+            badge={{ text: 'badge', type: 'warning' }}
+            onChange={() => {
+              setOption('warning');
+            }}
+            value="warning"
+          />
+        </Box>
+        <Box display="inlineBlock">
+          <RadioGroup.RadioButton
+            id="neutral"
+            checked={option === 'neutral'}
+            label="I'd like a neutral badge"
+            badge={{ text: 'badge', type: 'neutral' }}
+            onChange={() => {
+              setOption('neutral');
+            }}
+            value="neutral"
+          />
+        </Box>
+      </RadioGroup>
+    </Box>
+  );
+}

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -8,7 +8,7 @@ import MainSection from '../../docs-components/MainSection';
 import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import SandpackExample from '../../docs-components/SandpackExample';
-import addingABadgeExample from '../../examples/radiogroup/addingABadgeExample';
+import badge from '../../examples/radiogroup/addingABadgeExample';
 import addingAPopoverExample from '../../examples/radiogroup/addingAPopoverExample';
 import directionExample from '../../examples/radiogroup/directionExample';
 import dontUseToSelectMultipleItems from '../../examples/radiogroup/dontUseToSelectMultipleItems';
@@ -290,16 +290,12 @@ export default function DocsPage({
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          title="Adding a Badge"
+          title="With Badge"
           description={`
     The \`badge\` prop can be used to add a badge to the RadioButton.
   `}
         >
-          <MainSection.Card
-            sandpackExample={
-              <SandpackExample name="Adding a popover example" code={addingABadgeExample} />
-            }
-          />
+          <MainSection.Card sandpackExample={<SandpackExample name="With Badge" code={badge} />} />
         </MainSection.Subsection>
       </MainSection>
       <MainSection name="Writing">

--- a/docs/pages/web/radiogroup.js
+++ b/docs/pages/web/radiogroup.js
@@ -8,6 +8,7 @@ import MainSection from '../../docs-components/MainSection';
 import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import SandpackExample from '../../docs-components/SandpackExample';
+import addingABadgeExample from '../../examples/radiogroup/addingABadgeExample';
 import addingAPopoverExample from '../../examples/radiogroup/addingAPopoverExample';
 import directionExample from '../../examples/radiogroup/directionExample';
 import dontUseToSelectMultipleItems from '../../examples/radiogroup/dontUseToSelectMultipleItems';
@@ -285,6 +286,18 @@ export default function DocsPage({
           <MainSection.Card
             sandpackExample={
               <SandpackExample name="Adding a popover example" code={addingAPopoverExample} />
+            }
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Adding a Badge"
+          description={`
+    The \`badge\` prop can be used to add a badge to the RadioButton.
+  `}
+        >
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample name="Adding a popover example" code={addingABadgeExample} />
             }
           />
         </MainSection.Subsection>

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type AbstractComponent, forwardRef, type Node as ReactNode, useState } from 'react';
 import classnames from 'classnames';
+import Badge from './Badge';
 import Box from './Box';
 import Flex from './Flex';
 import focusStyles from './Focus.css';
@@ -11,6 +12,11 @@ import { useRadioGroupContext } from './RadioGroup/Context';
 import FormHelperText from './shared/FormHelperText';
 import Text from './Text';
 import useFocusVisible from './useFocusVisible';
+
+type BadgeType = {
+  text: string,
+  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+};
 
 type Props = {
   /**
@@ -60,6 +66,7 @@ type Props = {
    * The value of the input.
    */
   value: string,
+  badge?: BadgeType,
 };
 
 /**
@@ -83,6 +90,7 @@ const RadioGroupButtonWithForwardRef: AbstractComponent<Props, HTMLInputElement>
     onChange,
     helperText,
     value,
+    badge,
     size = 'md',
   }: Props,
   ref,
@@ -161,21 +169,30 @@ const RadioGroupButtonWithForwardRef: AbstractComponent<Props, HTMLInputElement>
       </Box>
       {Boolean(image) && <Box paddingX={1}>{image}</Box>}
       <Flex direction="column">
-        {label && (
-          <Label htmlFor={id}>
-            {/* marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input */}
-            <Box
-              paddingX={1}
-              dangerouslySetInlineStyle={{
-                __style: { marginTop: size === 'md' ? '2px' : '-1px' },
-              }}
-            >
-              <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
-                {label}
-              </Text>
-            </Box>
-          </Label>
-        )}
+        <Flex direction="row">
+          {label && (
+            <Label htmlFor={id}>
+              {/* marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input */}
+              <Box
+                paddingX={1}
+                dangerouslySetInlineStyle={{
+                  __style: { marginTop: size === 'md' ? '2px' : '-1px' },
+                }}
+              >
+                <Text color={disabled ? 'subtle' : undefined} size={size === 'sm' ? '200' : '300'}>
+                  {label}
+                </Text>
+              </Box>
+            </Label>
+          )}
+          {badge && (
+            <Flex.Item minWidth={0} alignSelf="end">
+              <Box dangerouslySetInlineStyle={{ __style: { top: '1px' } }} position="relative">
+                <Badge text={badge.text} type={badge.type || 'info'} />
+              </Box>
+            </Flex.Item>
+          )}
+        </Flex>
         {label && helperText ? (
           <Box paddingX={1}>
             <FormHelperText id={`${id}-helperText`} text={helperText} />

--- a/packages/gestalt/src/__snapshots__/RadioGroup.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/RadioGroup.test.js.snap
@@ -46,7 +46,11 @@ exports[`RadioGroup renders 1`] = `
         </div>
         <div
           className="Flex rowGap0 columnGap0 xsDirectionColumn"
-        />
+        >
+          <div
+            className="Flex rowGap0 columnGap0 xsDirectionRow"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -99,7 +103,11 @@ exports[`RadioGroup renders a hidden legend 1`] = `
         </div>
         <div
           className="Flex rowGap0 columnGap0 xsDirectionColumn"
-        />
+        >
+          <div
+            className="Flex rowGap0 columnGap0 xsDirectionRow"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -153,7 +161,11 @@ exports[`RadioGroup renders an error 1`] = `
         </div>
         <div
           className="Flex rowGap0 columnGap0 xsDirectionColumn"
-        />
+        >
+          <div
+            className="Flex rowGap0 columnGap0 xsDirectionRow"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -250,7 +262,11 @@ exports[`RadioGroup renders in different direction 1`] = `
         </div>
         <div
           className="Flex rowGap0 columnGap0 xsDirectionColumn"
-        />
+        >
+          <div
+            className="Flex rowGap0 columnGap0 xsDirectionRow"
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Summary

#### What changed?

RadioGroup now has a prop to add a Badge next to the label.

#### Why?

To satisfy the use case where users need both a Badge and a helperText with a RadioGroup.RadioButton option, as described in the component request: https://jira.pinadmin.com/browse/GESTALT-7505

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-7505)