### PR TITLE
Textfield, RadioGroup, SearchField:   implement background color tokens in form fields and some code cleanups 

### DIFF
--- a/docs/pages/foundations/design_tokens/component_tokens.js
+++ b/docs/pages/foundations/design_tokens/component_tokens.js
@@ -57,6 +57,7 @@ const components = [
   'badge',
   'box',
   'button',
+  'formfield',
   'overlay',
   'tag',
   'tableofcontents',

--- a/docs/pages/foundations/iconography/library.js
+++ b/docs/pages/foundations/iconography/library.js
@@ -145,11 +145,8 @@ export default function IconPage(): ReactNode {
   const [inputValue, setInputValue] = useState<void | string>();
   const [sortedAlphabetical, setSortedAlphabetical] = useState(true);
 
-  const handleOnChange = ({
+  const handleOnChange: $ElementType<React$ElementConfig<typeof SearchField>, 'onChange'> = ({
     value,
-  }: {
-    syntheticEvent: SyntheticEvent<HTMLInputElement>,
-    value: string,
   }) => {
     setInputValue(value);
     setSuggestedOptions(

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,6 +1,6 @@
 This file is updated manually
 
-## 142.5.0 https://github.com/pinterest/gestalt/pull/3432
+## 142.5.0 https://github.com/pinterest/gestalt/pull/3434
 
 ### MINOR
 

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,5 +1,22 @@
 This file is updated manually
 
+## 142.5.0 https://github.com/pinterest/gestalt/pull/3432
+
+### MINOR
+
+NEW
+
+| name                                | light   | dark    |
+| ----------------------------------- | ------- | ------- |
+| color-background-formfield-primary  | #fff    | #030303 |
+| color-background-formfield-disabled | #efefef | #404040 |
+
+#### Why
+
+Tokenize FormField component background colors
+
+#### Breaking change notes
+
 ## 142.4.0 https://github.com/pinterest/gestalt/pull/3432
 
 ### MINOR

--- a/packages/gestalt-design-tokens/tokens/color/component.json
+++ b/packages/gestalt-design-tokens/tokens/color/component.json
@@ -346,6 +346,18 @@
           }
         }
       },
+      "formfield": {
+        "primary": {
+          "value": "#fff",
+          "darkValue": "#030303",
+          "comment": "Formfield default background color"
+        },
+        "disabled": {
+          "value": "#efefef",
+          "darkValue": "#404040",
+          "comment": "Formfield disabled background color"
+        }
+      },
       "overlay": {
         "value": "{color.background.default.value}",
         "darkValue": "{color.background.elevation.floating.darkValue}",

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1698,7 +1698,7 @@ interface RadioGroupRadioButtonProps {
 interface SearchFieldProps {
   accessibilityLabel: string;
   id: string;
-  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { value: string }>;
+  onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement | HTMLButtonElement>, { value: string }>;
   accessibilityClearButtonLabel?: string | undefined;
   autoComplete?: 'on' | 'off' | 'username' | 'name' | undefined;
   errorMessage?: string | undefined;

--- a/packages/gestalt/src/BannerOverlay.css
+++ b/packages/gestalt/src/BannerOverlay.css
@@ -13,6 +13,6 @@
   composes: p0 from "./Whitespace.css";
   composes: paddingX0 from "./boxWhitespace.css";
   composes: paddingY0 from "./boxWhitespace.css";
-  composes: transparent from "./Colors.css";
+  background-color: var(--color-transparent);
   text-wrap: nowrap;
 }

--- a/packages/gestalt/src/IconButton.css
+++ b/packages/gestalt/src/IconButton.css
@@ -2,7 +2,7 @@
   composes: block from "./Layout.css";
   composes: noBorder from "./Borders.css";
   composes: p0 from "./Whitespace.css";
-  background: transparent;
+  background-color: var(--color-transparent);
 }
 
 .parentButton {
@@ -10,7 +10,7 @@
   composes: p0 from "./Whitespace.css";
   composes: paddingX0 from "./boxWhitespace.css";
   composes: paddingY0 from "./boxWhitespace.css";
-  composes: transparent from "./Colors.css";
+  background-color: var(--color-transparent);
 }
 
 .parentButton:focus,

--- a/packages/gestalt/src/RadioButton.css
+++ b/packages/gestalt/src/RadioButton.css
@@ -47,11 +47,11 @@
 }
 
 .BgDisabled {
-  composes: lightGrayBg from "./Colors.css";
+  background-color: var(---color-background-formfield-disabled);
 }
 
 .BgEnabled {
-  composes: whiteBg from "./Colors.css";
+  background-color: var(--color-background-formfield-default);
 }
 
 .InputEnabled {

--- a/packages/gestalt/src/RadioButton.css
+++ b/packages/gestalt/src/RadioButton.css
@@ -51,7 +51,7 @@
 }
 
 .BgEnabled {
-  background-color: var(--color-background-formfield-default);
+  background-color: var(--color-background-formfield-primary);
 }
 
 .InputEnabled {

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -3,11 +3,11 @@
   composes: border pill sizeLg from "./Borders.css";
   composes: borderBox from "./Layout.css";
   composes: darkGray from "./Colors.css";
-  composes: whiteBg from "./Colors.css";
   composes: Text from "./Text.css";
   composes: fontSize300 from "./Typography.css";
   composes: xsCol12 from "./Column.css";
   appearance: none;
+  background-color: var(--color-background-formfield-primary);
   min-width: 180px;
   padding: var(--space-200) calc(var(--space-800) + var(--space-200));
 }
@@ -20,7 +20,7 @@
 }
 
 .input:focus {
-  background-color: var(--g-colorGray0);
+  background-color: var(--color-background-formfield-primary);
   cursor: text;
 }
 
@@ -47,20 +47,11 @@ html[dir="rtl"] .inputActive {
 
 .clear {
   composes: marginEnd2 from "./boxWhitespace.css";
-  composes: noBorder pill from "./Borders.css";
   composes: paddingX1 from "./boxWhitespace.css";
   composes: paddingY1 from "./boxWhitespace.css";
-  composes: pointer from "./Cursor.css";
-  composes: transparent from "./Colors.css";
-  composes: accessibilityOutline from "./Focus.css";
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-}
-
-.clear:hover {
-  background-color: var(--g-colorGray100);
-  border-radius: 50%;
 }
 
 html:not([dir="rtl"]) .clear {

--- a/packages/gestalt/src/SearchField.css
+++ b/packages/gestalt/src/SearchField.css
@@ -20,7 +20,6 @@
 }
 
 .input:focus {
-  background-color: var(--color-background-formfield-primary);
   cursor: text;
 }
 

--- a/packages/gestalt/src/SearchField.js
+++ b/packages/gestalt/src/SearchField.js
@@ -10,6 +10,7 @@ import {
 import classnames from 'classnames';
 import Box from './Box';
 import Icon from './Icon';
+import IconButton from './IconButton';
 import layout from './Layout.css';
 import styles from './SearchField.css';
 import formElement from './shared/FormElement.css';
@@ -55,14 +56,14 @@ type Props = {
    */
   onChange: ({
     value: string,
-    syntheticEvent: SyntheticEvent<HTMLInputElement>,
+    event: SyntheticEvent<HTMLInputElement | HTMLButtonElement>,
   }) => void,
   /**
    *
    */
   onFocus?: ({
     value: string,
-    syntheticEvent: SyntheticEvent<HTMLInputElement>,
+    event: SyntheticEvent<HTMLInputElement>,
   }) => void,
   /**
    * Secondary callback for keyboard events. Possible uses include validation, form submission, etc.
@@ -127,7 +128,7 @@ const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
   const handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
     onChange({
       value: event.currentTarget.value,
-      syntheticEvent: event,
+      event,
     });
   };
 
@@ -140,14 +141,9 @@ const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
     if (onFocus) {
       onFocus({
         value: event.currentTarget.value,
-        syntheticEvent: event,
+        event,
       });
     }
-  };
-
-  const handleClear = (event: SyntheticEvent<HTMLInputElement>) => {
-    inputRef?.current?.focus();
-    onChange({ value: '', syntheticEvent: event });
   };
 
   const handleBlur = (event: SyntheticKeyboardEvent<HTMLInputElement>) => {
@@ -176,9 +172,6 @@ const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
     },
     errorMessage ? formElement.errored : formElement.normal,
   );
-
-  const clearButtonSize = size === 'lg' ? 24 : 20;
-  const clearIconSize = size === 'lg' ? 12 : 10;
 
   return (
     <span>
@@ -227,24 +220,20 @@ const SearchFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = fo
         />
 
         {hasValue && (
-          <button className={styles.clear} onClick={handleClear} type="button">
-            <Box
-              alignItems="center"
-              color={focused ? 'selected' : 'transparent'}
-              display="flex"
-              height={clearButtonSize}
-              justifyContent="center"
-              rounding="circle"
-              width={clearButtonSize}
-            >
-              <Icon
-                accessibilityLabel={accessibilityClearButtonLabel || ''}
-                color={focused ? 'inverse' : 'default'}
-                icon="cancel"
-                size={clearIconSize}
-              />
-            </Box>
-          </button>
+          <div className={styles.clear}>
+            <IconButton
+              accessibilityLabel={accessibilityClearButtonLabel || ''}
+              icon="cancel"
+              size="xs"
+              padding={size === 'md' ? 1 : undefined}
+              bgColor="transparent"
+              selected={focused}
+              onClick={({ event }) => {
+                inputRef?.current?.focus();
+                onChange({ value: '', event });
+              }}
+            />
+          </div>
         )}
       </Box>
       {errorMessage && <FormErrorMessage id={`${id}-error`} text={errorMessage} />}

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -124,6 +124,8 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-background-button-semitransparentdark-active: #e0e0e0;
   --color-background-button-disabled-default: #4a4a4a;
   --color-background-button-selected-default: #e9e9e9;
+  --color-background-formfield-primary: #030303;
+  --color-background-formfield-disabled: #404040;
   --color-background-overlay: #2b2b2b;
   --color-background-tag-primary-default: #767676;
   --color-background-tag-primary-hover: #535353;
@@ -286,6 +288,8 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-formfield-primary: #ffffff;
+  --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
   --color-background-tag-primary-default: #e9e9e9;
   --color-background-tag-primary-hover: #e2e2e2;
@@ -448,6 +452,8 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-formfield-primary: #ffffff;
+  --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
   --color-background-tag-primary-default: #e9e9e9;
   --color-background-tag-primary-hover: #e2e2e2;
@@ -610,6 +616,8 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-formfield-primary: #ffffff;
+  --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
   --color-background-tag-primary-default: #e9e9e9;
   --color-background-tag-primary-hover: #e2e2e2;
@@ -773,6 +781,8 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-background-button-semitransparentdark-active: #e0e0e0;
   --color-background-button-disabled-default: #4a4a4a;
   --color-background-button-selected-default: #e9e9e9;
+  --color-background-formfield-primary: #030303;
+  --color-background-formfield-disabled: #404040;
   --color-background-overlay: #2b2b2b;
   --color-background-tag-primary-default: #767676;
   --color-background-tag-primary-hover: #535353;

--- a/packages/gestalt/src/shared/FormElement.css
+++ b/packages/gestalt/src/shared/FormElement.css
@@ -29,13 +29,13 @@
 
 .enabled {
   composes: darkGray from "../Colors.css";
-  composes: whiteBg from "../Colors.css";
+  background-color: var(--color-background-formfield-default);
 }
 
 .disabled {
   composes: gray from "../Colors.css";
-  composes: lightGrayBg from "../Colors.css";
   composes: borderColorLightGrayDisabled from "../Borders.css";
+  background-color: var(---color-background-formfield-disabled);
 }
 
 .unstyled {

--- a/packages/gestalt/src/shared/FormElement.css
+++ b/packages/gestalt/src/shared/FormElement.css
@@ -29,7 +29,7 @@
 
 .enabled {
   composes: darkGray from "../Colors.css";
-  background-color: var(--color-background-formfield-default);
+  background-color: var(--color-background-formfield-primary);
 }
 
 .disabled {


### PR DESCRIPTION
## Breaking change

Run

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=SearchField
--prop=onChange
```
or

```
yarn codemod detectManualReplacement ~/path/to/your/code
--component=SearchField
--prop=onFocus
```


`onChange: ({   value: string,   syntheticEvent: SyntheticEvent<HTMLInputElement>, }) => void
`
to 

`onChange: ({   value: string,   event: SyntheticEvent<HTMLInputElement | HTMLButtonElement>, }) => void
`

```
onFocus?: ({
  syntheticEvent: SyntheticKeyboardEvent<HTMLInputElement>,
  value: string,
}) => void
```

to 

```
onFocus?: ({
    event: SyntheticKeyboardEvent<HTMLInputElement>,
    value: string,
  }) => void
```




### Summary

#### What changed?

Textfield:   implement background color tokens in form fields and some code cleanups 


### MINOR

NEW

| name                                | light   | dark    |
| ----------------------------------- | ------- | ------- |
| color-background-formfield-primary  | #fff    | #030303 |
| color-background-formfield-disabled | #efefef | #404040 |

#### Why

Tokenize FormField component background colors

#### Breaking change notes
