### PR TITLE
Tag: Change tag contents to break-all

### DIFF
--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -167,7 +167,7 @@ export default function Tag({
           </Box>
         )}
 
-        <Text color={fgColor} inline size={fontSize} lineClamp={1}>
+        <Text color={fgColor} inline size={fontSize} lineClamp={1} overflow="breakAll">
           {text}
         </Text>
 

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.js.snap
@@ -126,7 +126,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="ey / em"
                   >
                     ey / em
@@ -174,7 +174,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="he / him"
                   >
                     he / him
@@ -222,7 +222,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="ne / nem"
                   >
                     ne / nem
@@ -270,7 +270,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="she / her"
                   >
                     she / her
@@ -318,7 +318,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="they / them"
                   >
                     they / them
@@ -366,7 +366,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="ve / ver"
                   >
                     ve / ver
@@ -414,7 +414,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="xe / xem"
                   >
                     xe / xem
@@ -462,7 +462,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="xie / xem"
                   >
                     xie / xem
@@ -510,7 +510,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
                   style="height: 100%;"
                 >
                   <span
-                    class="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+                    class="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
                     title="zie / zem"
                   >
                     zie / zem

--- a/packages/gestalt/src/__snapshots__/Tag.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tag.test.js.snap
@@ -20,7 +20,7 @@ exports[`Tag clips long strings 1`] = `
     }
   >
     <span
-      className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+      className="Text fontSize200 defaultText alignStart breakAll fontWeightNormal lineClamp"
       style={
         Object {
           "WebkitLineClamp": 1,
@@ -86,7 +86,7 @@ exports[`Tag renders 1`] = `
     }
   >
     <span
-      className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+      className="Text fontSize200 defaultText alignStart breakAll fontWeightNormal lineClamp"
       style={
         Object {
           "WebkitLineClamp": 1,
@@ -153,7 +153,7 @@ exports[`Tag renders a disabled tag 1`] = `
     }
   >
     <span
-      className="Text fontSize200 subtleText alignStart breakWord fontWeightNormal lineClamp"
+      className="Text fontSize200 subtleText alignStart breakAll fontWeightNormal lineClamp"
       style={
         Object {
           "WebkitLineClamp": 1,
@@ -207,7 +207,7 @@ exports[`Tag renders a tag with a warning state 1`] = `
       </svg>
     </div>
     <span
-      className="Text fontSize200 inverseText alignStart breakWord fontWeightNormal lineClamp"
+      className="Text fontSize200 inverseText alignStart breakAll fontWeightNormal lineClamp"
       style={
         Object {
           "WebkitLineClamp": 1,
@@ -290,7 +290,7 @@ exports[`Tag renders a tag with an error state 1`] = `
       </svg>
     </div>
     <span
-      className="Text fontSize200 inverseText alignStart breakWord fontWeightNormal lineClamp"
+      className="Text fontSize200 inverseText alignStart breakAll fontWeightNormal lineClamp"
       style={
         Object {
           "WebkitLineClamp": 1,

--- a/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextArea.test.js.snap
@@ -267,7 +267,7 @@ exports[`TextArea renders tags when supplied 1`] = `
           }
         >
           <span
-            className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+            className="Text fontSize200 defaultText alignStart breakAll fontWeightNormal lineClamp"
             style={
               Object {
                 "WebkitLineClamp": 1,
@@ -334,7 +334,7 @@ exports[`TextArea renders tags when supplied 1`] = `
           }
         >
           <span
-            className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+            className="Text fontSize200 defaultText alignStart breakAll fontWeightNormal lineClamp"
             style={
               Object {
                 "WebkitLineClamp": 1,
@@ -401,7 +401,7 @@ exports[`TextArea renders tags when supplied 1`] = `
           }
         >
           <span
-            className="Text fontSize200 defaultText alignStart breakWord fontWeightNormal lineClamp"
+            className="Text fontSize200 defaultText alignStart breakAll fontWeightNormal lineClamp"
             style={
               Object {
                 "WebkitLineClamp": 1,

--- a/packages/gestalt/src/__snapshots__/TextField.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.js.snap
@@ -352,7 +352,7 @@ exports[`TextField TextField with tags 1`] = `
             }
           >
             <span
-              className="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -424,7 +424,7 @@ exports[`TextField TextField with tags 1`] = `
             }
           >
             <span
-              className="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -496,7 +496,7 @@ exports[`TextField TextField with tags 1`] = `
             }
           >
             <span
-              className="Text fontSize100 defaultText alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize100 defaultText alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,


### PR DESCRIPTION
Tag uses `break-word` by default. But tags don't have to be full sentences. So things like ids and other important data gets cut off after the first word that can fit, leaving a lot of unfilled room.


Before:
<img width="301" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/15c87b40-82be-4017-9afe-2775e598762a">

After:

<img width="302" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/9337dcd2-9132-4fa7-9acb-188a830bdc55">

## Pull Request Template

### Summary

#### What changed?

At a high level, what changes does this PR introduce?

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
