### PR TITLE
ButtonLink: fix on darkmode colors + more documentation

### DIFF
--- a/docs/examples/buttonlink/colors.js
+++ b/docs/examples/buttonlink/colors.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { type Node as ReactNode } from 'react';
+import { Box, ButtonLink, Flex, Text } from 'gestalt';
+
+export default function Example(): ReactNode {
+  return (
+    <Box padding={4}>
+      <Flex height="100%" gap={6} width="100%" wrap>
+        {['gray', 'red', 'blue', 'transparent'].map((color) => (
+          <Flex gap={2} key={color} direction="column">
+            <Box
+              borderStyle="sm"
+              display="flex"
+              width={200}
+              height={200}
+              rounding={4}
+              alignItems="center"
+              justifyContent="center"
+            >
+              <ButtonLink href="" color={color} size="lg" text="Visit" iconEnd="visit" />
+            </Box>
+            <Text size="200" weight="bold">
+              color=&quot;{color}&quot;
+            </Text>
+          </Flex>
+        ))}
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/buttonlink/washColors.js
+++ b/docs/examples/buttonlink/washColors.js
@@ -1,0 +1,33 @@
+// @flow strict
+import { type Node as ReactNode } from 'react';
+import { Box, ButtonLink, Flex, Text } from 'gestalt';
+
+export default function Example(): ReactNode {
+  return (
+    <Box padding={4}>
+      <Flex height="100%" gap={6} width="100%" wrap>
+        {['semiTransparentWhite', 'transparentWhiteText', 'white'].map((color) => (
+          <Flex gap={2} key={color} direction="column">
+            <Box
+              borderStyle="sm"
+              display="flex"
+              width={200}
+              height={200}
+              rounding={4}
+              alignItems="center"
+              justifyContent="center"
+              dangerouslySetInlineStyle={{
+                __style: { backgroundImage: 'url("https://i.ibb.co/d0pQsJz/stock3.jpg")' },
+              }}
+            >
+              <ButtonLink href="" color={color} size="lg" text="Visit" iconEnd="visit" />
+            </Box>
+            <Text size="200" weight="bold">
+              color=&quot;{color}&quot;
+            </Text>
+          </Flex>
+        ))}
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/pages/web/buttonlink.js
+++ b/docs/pages/web/buttonlink.js
@@ -1,6 +1,8 @@
 // @flow strict
 import { type Node as ReactNode } from 'react';
+import { ButtonLink } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
+import CombinationNew from '../../docs-components/CombinationNew';
 import docGen, { type DocGen, type DocType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection';
@@ -10,6 +12,7 @@ import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
+import colors from '../../examples/buttonlink/colors';
 import defaultStateExample from '../../examples/buttonlink/defaultStateExample';
 import disabledStateExample from '../../examples/buttonlink/disabledStateExample';
 import iconEndExample from '../../examples/buttonlink/iconEndExample';
@@ -22,6 +25,7 @@ import placePrimaryButtonDont from '../../examples/buttonlink/placePrimaryButton
 import relAndTargetExample from '../../examples/buttonlink/relAndTargetExample';
 import showFullTextDo from '../../examples/buttonlink/showFullTextDo';
 import showFullTextDont from '../../examples/buttonlink/showFullTextDont';
+import washColors from '../../examples/buttonlink/washColors';
 
 const PREVIEW_HEIGHT = 300;
 
@@ -159,11 +163,140 @@ export default function DocsPage({ generatedDocGen }: DocType): ReactNode {
         </MainSection.Subsection>
       </MainSection>
 
-      <AccessibilitySection name={generatedDocGen?.displayName} />
+      <AccessibilitySection name={generatedDocGen?.displayName}>
+        <MainSection.Subsection
+          title="Color contrast in disabled state"
+          description={`
+Disabled Buttons do not need to pass color contrast guidelines.
+
+[From w3.org, 1.4.3 Contrast (Minimum)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html): Text or images of text that are part of an inactive user interface component, that are pure decoration, that are not visible to anyone, or that are part of a picture that contains significant other visual content, have no contrast requirement.
+
+Our current disabled ButtonLink implementation does fail to pass color contrast on accessibility integration tests. To exclude disabled buttons from the integration tests we recomment conditionally setting a \`data-test-id={ isDisabled ? "disabled-button-<name>" : undefined }\` and excluding them from the integration test.
+
+On [cypress-axe](https://www.npmjs.com/package/cypress-axe) that can be achieved with <code>cy.a11yCheck({ exclude: [['[data-test-id="disabled-button-submit"]']] })<code>`}
+        />
+      </AccessibilitySection>
 
       <LocalizationSection name={generatedDocGen?.displayName} code={localizationLabels} />
 
       <MainSection name="Variants">
+        <MainSection.Subsection
+          title="Size"
+          description={`ButtonLink is available in 3 fixed sizes. The ButtonLink text has always a fixed size of 16px:
+1. \`lg\` (48px)
+    Large is the only size that should be used on Pinner surfaces.
+2. \`md\` (40px)
+    Medium is used on more dense UI such as business surfaces or internal tools.
+3. \`sm\` (32px)
+    Small should be used sparingly and only in places where the UI is very dense.`}
+        >
+          <CombinationNew size={['sm', 'md', 'lg']}>
+            {({ size }) => (
+              <ButtonLink
+                href=""
+                accessibilityLabel={`Example size ${size}`}
+                color="red"
+                text="Visit"
+                size={size}
+              />
+            )}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Width"
+          description={`
+1. Inline (default)
+    Inline is our default ButtonLink width.  The width of an inline ButtonLink is based on the length of its text. Use in most cases where you need a ButtonLink.
+2. Full-width (\`fullWidth\`)
+    Full-width Buttons can be used in narrower content areas when the text in the ButtonLink is close to full width in the content area. This is especially common to see in components such as BannerCallout and BannerUpsell at their smaller breakpoints.`}
+        >
+          <CombinationNew fullwidth={[false, true]}>
+            {({ fullwidth }) => (
+              <ButtonLink
+                href=""
+                accessibilityLabel={`Example width ${fullwidth}`}
+                color="red"
+                text="Visit"
+                fullWidth={fullwidth}
+                size="lg"
+              />
+            )}
+          </CombinationNew>
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          title="Color on white backgrounds"
+          description={`
+1. Red (Primary)
+    High emphasis, used for primary actions.
+2. Blue (Primary in shopping context)
+    The blue ButtonLink is only intended for the shopping experience and is used for primary shopping actions.
+3. Gray (Secondary)
+    Medium emphasis, used for secondary actions.
+4. Transparent (Tertiary)
+    Low emphasis when placed on dark/image backgrounds, used for tertiary actions in that context. *Note, this treatment should be used with caution as it has potential color contrast issues.*
+`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample code={colors} name="Colors" previewHeight={500} layout="column" />
+            }
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          columns={2}
+          title="Color on color/image backgrounds"
+          description={`
+  1. White (Primary)
+      High emphasis when placed on color/image backgrounds, used for primary actions in that context.
+  2. Semi-transparent white (Secondary)
+      Medium emphasis when placed on color/image backgrounds, used for secondary actions in that context.
+`}
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={
+              <SandpackExample
+                code={washColors}
+                name="Color on color/image backgrounds"
+                previewHeight={500}
+                layout="column"
+              />
+            }
+          />
+        </MainSection.Subsection>
+        <MainSection.Subsection
+          columns={2}
+          title="States"
+          description={`
+1. Default
+    The typical state of a ButtonLink that represents it can be interacted with and is not in a selected state.
+2. Disabled
+Used to block user interaction such as hover, focus and click. Disabled Buttons are completely unreachable by a keyboard and screenreader, so do not attach Tooltips to disabled Buttons.
+ `}
+        >
+          <MainSection.Card
+            cardSize="md"
+            sandpackExample={
+              <SandpackExample
+                code={defaultStateExample}
+                name="Default state button example."
+                previewHeight={150}
+              />
+            }
+          />
+          <MainSection.Card
+            cardSize="md"
+            sandpackExample={
+              <SandpackExample
+                code={disabledStateExample}
+                name="Disabled state button example."
+                previewHeight={150}
+              />
+            }
+          />
+        </MainSection.Subsection>
+
         <MainSection.Subsection
           title="External handlers"
           description={`ButtonLink consumes external handlers from [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider).
@@ -192,37 +325,7 @@ See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#onN
             }
           />
         </MainSection.Subsection>
-        <MainSection.Subsection
-          columns={2}
-          title="States"
-          description={`
-1. Default
-    The typical state of a ButtonLink that represents it can be interacted with and is not in a selected state.
-2. Disabled
-Used to block user interaction such as hover, focus and click. Disabled Buttons are completely unreachable by a keyboard and screenreader, so do not attach Tooltips to disabled Buttons.
-`}
-        >
-          <MainSection.Card
-            cardSize="md"
-            sandpackExample={
-              <SandpackExample
-                code={defaultStateExample}
-                name="Default state ButtonLink example."
-                previewHeight={150}
-              />
-            }
-          />
-          <MainSection.Card
-            cardSize="md"
-            sandpackExample={
-              <SandpackExample
-                code={disabledStateExample}
-                name="Disabled state ButtonLink example."
-                previewHeight={150}
-              />
-            }
-          />
-        </MainSection.Subsection>
+
         <MainSection.Subsection
           title="rel and target"
           description={`
@@ -256,8 +359,8 @@ These optional props control the behavior of ButtonLink. External links commonly
       <MainSection name="Related">
         <MainSection.Subsection
           description={`
-**[Button](/web/button)**
-Use Button when an action is needed instead of a link.
+**[ButtonLink](/web/button)**
+Use ButtonLink when an action is needed instead of a link.
 
 **[ButtonGroup](/web/buttongroup)**
 When displaying multiple ButtonLinks in a layout, use ButtonGroup to ensure consistent spacing and wrapping behavior.

--- a/packages/gestalt/src/BannerUpsell.js
+++ b/packages/gestalt/src/BannerUpsell.js
@@ -44,15 +44,6 @@ function UpsellAction({ data, stacked, type }: UpsellActionProps): ReactNode {
   const color = type === 'primary' ? 'red' : 'gray';
   const { accessibilityLabel, disabled, label } = data;
 
-  const commonProps = {
-    accessibilityLabel,
-    color,
-    disabled,
-    fullWidth: true,
-    size: 'lg',
-    text: label,
-  };
-
   return (
     <Box
       display="block"
@@ -66,14 +57,27 @@ function UpsellAction({ data, stacked, type }: UpsellActionProps): ReactNode {
     >
       {data.role === 'link' ? (
         <ButtonLink
-          {...commonProps}
+          accessibilityLabel={accessibilityLabel}
+          color={color}
+          disabled={disabled}
+          fullWidth
+          size="lg"
+          text={label}
           onClick={data.onClick}
           href={data.href ?? ''}
           rel={data.rel}
           target={data.target}
         />
       ) : (
-        <Button {...commonProps} onClick={data.onClick} />
+        <Button
+          accessibilityLabel={accessibilityLabel}
+          color={color}
+          disabled={disabled}
+          fullWidth
+          size="lg"
+          text={label}
+          onClick={data.onClick}
+        />
       )}
     </Box>
   );

--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -73,7 +73,7 @@
 }
 
 .red:active {
-  background-color: var(--color-background-button-primary-act ive);
+  background-color: var(--color-background-button-primary-active);
 }
 
 .gray {

--- a/packages/gestalt/src/ButtonLink.js
+++ b/packages/gestalt/src/ButtonLink.js
@@ -140,16 +140,12 @@ const ButtonLinkWithForwardRef: AbstractComponent<ButtonProps, HTMLAnchorElement
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
   const isDarkMode = colorSchemeName === 'darkMode';
   const isDarkModeRed = isDarkMode && color === 'red';
-  const isDarkModeBlue = isDarkMode && color === 'blue';
 
-  let colorClass = color === 'transparentWhiteText' ? 'transparent' : color;
-  if (isDarkModeRed) {
-    colorClass = 'darkModeRed';
-  }
+  const colorClass = color === 'transparentWhiteText' ? 'transparent' : color;
+
   const textColor =
-    (disabled && 'subtle') ||
-    ((isDarkModeRed || isDarkModeBlue) && 'default') ||
-    DEFAULT_TEXT_COLORS[color];
+    (disabled && 'subtle') || (isDarkModeRed && 'default') || DEFAULT_TEXT_COLORS[color];
+
   const ariaLabel = getAriaLabel({
     target,
     accessibilityLabel,


### PR DESCRIPTION
### Summary

#### What changed?

ButtonLink: fix on darkmode colors + more documentation
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/35fbf22b-cdad-4eab-9395-9b9a987cf03d)

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/cd005e5d-1d0d-4e26-9c60-adcad43a0edf)


![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/9c9236bc-9ed1-4705-a9b8-6431e29c770e)

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/0e75896f-52b9-4e01-94e8-538b51c309f1)