### PR TITLE
DatePicker: tokenize colors and other internal styles 

### DIFF
--- a/docs/markdown/team_support/contributions.md
+++ b/docs/markdown/team_support/contributions.md
@@ -51,6 +51,6 @@ We always appreciate the help and contributions of other engineers across Pinter
 ## Other ways to contribute
 
 **Bugs**
-If you think you’ve found a bug with Gestalt components or documentation, first check our [Gestalt bugs dashboard](https://jira.pinadmin.com/secure/Dashboard.jspa?selectPageId=29639) to see if it’s already been reported. If it hasn’t, please file a bug within the [Bugs](https://pinch.pinadmin.cm/gestaltJiraBugs) Jira project and set the Component to ”gestalt”. We do not actively monitor GitHub issues, so the best way to file is through Jira.
+If you think you’ve found a bug with Gestalt components or documentation, first check our [Gestalt bugs dashboard](https://jira.pinadmin.com/secure/Dashboard.jspa?selectPageId=29639) to see if it’s already been reported. If it hasn’t, please file a bug within the [Bugs](https://pinch.pinadmin.com/gestaltJiraBugs) Jira project and set the Component to ”gestalt”. We do not actively monitor GitHub issues, so the best way to file is through Jira.
 **Surveys**
 The Gestalt team sends out twice-yearly surveys to the design and engineering orgs. Filling out this survey is one way to help inform our team on what is working and what is not working about out design system.

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -1,6 +1,6 @@
 .react-datepicker {
   background-color: var(--color-background-datepicker-container);
-  border-radius: var(--rounding-400);
+  border-radius: var(--rounding-datepicker-container);
   box-shadow: var(--elevation-datepicker);
   display: inline-block;
   font-family: var(--font-family-default-latin);
@@ -136,7 +136,7 @@ to prevent conflict with another CSS module */
     .react-datepicker__day--range-end
   )::before {
   background: var(--color-background-datepicker-button-hover);
-  border-radius: var(--rounding-datepicker-side-start);
+  border-radius: var(--rounding-datepicker-range-start);
   content: "";
   display: block;
   height: 100%;
@@ -182,7 +182,7 @@ to prevent conflict with another CSS module */
     .react-datepicker__day--range-start
   )::before {
   background: var(--color-background-datepicker-button-hover);
-  border-radius: var(--rounding-datepicker-side-end);
+  border-radius: var(--rounding-datepicker-range-end);
   content: "";
   display: block;
   height: 100%;

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -1,20 +1,7 @@
-:root {
-  /* transparent colors */
-  --g-color-focus: rgb(0 132 255 / 0.5);
-
-  /* border & dimensions */
-  --g-borderRadius-circle: 50%;
-  --g-borderRadius-halfCircle-End: 0 50% 50% 0;
-  --g-borderRadius-halfCircle-Start: 50% 0 0 50%;
-  --g-day-dimensions: 40px;
-  --g-focus: 0 0 0 4px var(--g-color-focus);
-}
-
 .react-datepicker {
-  background-color: var(--g-colorGray50);
-  border-radius: 16px;
-  box-shadow: 0 0 8px var(--g-colorTransparentGray100);
-  color: var(--g-colorGray300);
+  background-color: var(--color-background-datepicker-container);
+  border-radius: var(--rounding-400);
+  box-shadow: var(--elevation-datepicker);
   display: inline-block;
   font-family: var(--font-family-default-latin);
   padding: var(--space-400);
@@ -22,9 +9,9 @@
 }
 
 .react-datepicker-inline {
-  background-color: var(--g-colorGray50);
-  border-radius: 16px;
-  color: var(--g-colorGray300);
+  background-color: var(--color-background-datepicker-container);
+  border-radius: var(--rounding-400);
+  color: var(--color-text-default);
   display: inline-block;
   font-family: var(--font-family-default-latin);
   padding: var(--space-400);
@@ -32,7 +19,7 @@
 }
 
 :global ._gestalt .react-datepicker__current-month {
-  color: var(--g-colorGray300);
+  color: var(--color-text-default);
   font-size: var(--font-size-400);
   font-weight: var(--font-weight-bold);
   margin-bottom: var(--space-400);
@@ -42,38 +29,33 @@
 to prevent conflict with another CSS module */
 
 .react-datepicker__days {
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray300);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-default);
   cursor: pointer;
   display: inline-block;
-  line-height: var(--g-day-dimensions);
+  line-height: var(--space-1000);
   text-align: center;
-  width: var(--g-day-dimensions);
+  width: var(--space-1000);
 }
 
 .react-datepicker__days:focus {
-  box-shadow: var(--g-focus);
+  box-shadow: 0 0 0 4px var(--color-border-focus);
   outline: none;
 }
 
 .react-datepicker__days:hover {
-  background-color: var(--g-colorTransparentGray60);
-  color: var(--g-colorGray300);
+  background-color: var(--color-background-datepicker-button-hover);
+  color: var(--color-text-default);
 }
 
 :global ._gestalt .react-datepicker__day--highlighted {
-  background-color: var(--g-colorGray300);
-  color: var(--g-colorGray50);
+  background-color: var(--color-background-datepicker-button-selected);
+  color: var(--color-text-inverse);
 }
 
 :global ._gestalt .react-datepicker__day--disabled {
-  color: var(--g-colorGray200);
+  color: var(--color-text-disabled);
   cursor: default;
-}
-
-:global ._gestalt .react-datepicker__day--disabled:hover {
-  background-color: var(--g-colorGray50);
-  color: var(--g-colorGray200);
 }
 
 :global ._gestalt .react-datepicker__day--disabled:focus {
@@ -81,35 +63,36 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--selected {
-  background-color: var(--g-colorGray300);
-  color: var(--g-colorGray50);
+  background-color: var(--color-background-datepicker-button-selected);
+  color: var(--color-text-inverse);
 }
 
 :global ._gestalt .react-datepicker__day--selected:hover {
-  background-color: var(--g-colorTransparentGray60);
-  color: var(--g-colorGray300);
+  background-color: var(--color-background-datepicker-button-hover);
+  color: var(--color-text-dark);
 }
 
 :global ._gestalt .react-datepicker__day--in-range {
-  background-color: var(--g-colorTransparentGray60);
-  border-radius: 0;
-  color: var(--g-colorGray300);
+  background-color: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-0);
+  color: var(--color-text-default);
 }
 
 :global ._gestalt .react-datepicker__day--in-range:hover {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-circle);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-dark);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--in-range:first-child {
-  border-bottom-left-radius: var(--g-borderRadius-circle);
-  border-top-left-radius: var(--g-borderRadius-circle);
+  border-bottom-left-radius: var(--rounding-circle);
+  border-top-left-radius: var(--rounding-circle);
 }
 
 :global ._gestalt .react-datepicker__day--in-range:last-child {
-  border-bottom-right-radius: var(--g-borderRadius-circle);
-  border-top-right-radius: var(--g-borderRadius-circle);
+  border-bottom-right-radius: var(--rounding-circle);
+  border-top-right-radius: var(--rounding-circle);
 }
 
 :global
@@ -117,13 +100,13 @@ to prevent conflict with another CSS module */
   .react-datepicker__day--in-range:not(
     .react-datepicker__day--selected
   ):hover::before {
-  background: var(--g-colorTransparentGray60);
-  border-radius: 0;
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-0);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  top: 0;
+  top: var(--space-0);
   width: 100%;
 
   /* z-index required to position pseudo-elements behind parent */
@@ -131,19 +114,19 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--in-range:first-child:hover::before {
-  border-bottom-left-radius: var(--g-borderRadius-circle);
-  border-top-left-radius: var(--g-borderRadius-circle);
+  border-bottom-left-radius: var(--rounding-circle);
+  border-top-left-radius: var(--rounding-circle);
 }
 
 :global ._gestalt .react-datepicker__day--in-range:last-child:hover::before {
-  border-bottom-right-radius: var(--g-borderRadius-circle);
-  border-top-right-radius: var(--g-borderRadius-circle);
+  border-bottom-right-radius: var(--rounding-circle);
+  border-top-right-radius: var(--rounding-circle);
 }
 
 :global ._gestalt .react-datepicker__day--range-start {
-  background-color: var(--g-colorGray400);
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray50);
+  background-color: var(--color-background-datepicker-button-selected);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-inverse);
   position: relative;
 }
 
@@ -152,13 +135,13 @@ to prevent conflict with another CSS module */
   .react-datepicker__day--range-start:not(:last-child):not(
     .react-datepicker__day--range-end
   )::before {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-halfCircle-Start);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-datepicker-side-start);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  top: 0;
+  top: var(--space-0);
   width: 100%;
 
   /* z-index required to position pseudo-elements behind parent */
@@ -167,19 +150,19 @@ to prevent conflict with another CSS module */
 
 :global ._gestalt .react-datepicker__day--range-start:hover {
   background-color: inherit;
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray300);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-default);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-start:hover::after {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-circle);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-circle);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  top: 0;
+  top: var(--space-0);
   width: 100%;
 
   /* z-index required to position pseudo-elements behind parent */
@@ -187,9 +170,9 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day--range-end {
-  background-color: var(--g-colorGray400);
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray50);
+  background-color: var(--color-background-datepicker-button-selected);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-inverse);
   position: relative;
 }
 
@@ -198,13 +181,13 @@ to prevent conflict with another CSS module */
   .react-datepicker__day--range-end:not(:first-child):not(
     .react-datepicker__day--range-start
   )::before {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-halfCircle-End);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-datepicker-side-end);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  top: 0;
+  top: var(--space-0);
   width: 100%;
 
   /* z-index required to position pseudo-elements behind parent */
@@ -213,20 +196,20 @@ to prevent conflict with another CSS module */
 
 :global ._gestalt .react-datepicker__day--range-end:hover {
   background-color: inherit;
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray300);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-default);
   position: relative;
 }
 
 :global ._gestalt .react-datepicker__day--range-end:hover::after {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-circle);
-  color: var(--g-colorGray300);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-circle);
+  color: var(--color-text-default);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  top: 0;
+  top: var(--space-0);
   width: 100%;
 
   /* z-index required to position pseudo-elements behind parent */
@@ -243,7 +226,7 @@ to prevent conflict with another CSS module */
   .react-datepicker__day--selecting-range-end:not(
     .react-datepicker__day--in-range
   ):not(.react-datepicker__day--highlighted) {
-  background-color: var(--g-colorTransparentGray60);
+  background-color: var(--color-background-datepicker-button-hover);
 }
 
 :global ._gestalt .react-datepicker__day--outside-month {
@@ -251,13 +234,13 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__day-name {
-  color: var(--g-colorGray200);
+  color: var(--color-text-subtle);
   display: inline-block;
   font-size: var(--font-size-300);
-  line-height: var(--g-day-dimensions);
-  margin: 0;
+  line-height: var(--space-1000);
+  margin: var(--space-0);
   text-align: center;
-  width: var(--g-day-dimensions);
+  width: var(--space-1000);
 }
 
 :global ._gestalt .react-datepicker__day-names {
@@ -277,11 +260,11 @@ to prevent conflict with another CSS module */
 }
 
 :global ._gestalt .react-datepicker__input-container input {
-  padding-right: 38px;
+  padding-right: var(--space-900);
 }
 
 :global ._gestalt .react-datepicker__month {
-  color: var(--g-colorGray50);
+  color: var(--color-text-inverse);
   text-align: center;
 }
 
@@ -304,58 +287,58 @@ to prevent conflict with another CSS module */
   ._gestalt
   ._gestalt_daterange
   .react-datepicker__month-container:last-child {
-  margin-left: 37px;
+  margin-left: var(--space-900);
 }
 
 :global ._gestalt .react-datepicker__navigation {
   background: none;
   border: none;
-  border-radius: var(--g-borderRadius-circle);
+  border-radius: var(--rounding-circle);
   cursor: pointer;
   height: auto;
   outline: none;
   overflow: visible;
-  padding: 8px;
+  padding: var(--space-200);
   position: absolute;
-  top: 14px;
+  top: var(--space-400);
   width: auto;
   z-index: 1;
 }
 
 :global ._gestalt .react-datepicker__navigation:hover,
 :global ._gestalt .react-datepicker__navigation:focus {
-  background: var(--g-colorTransparentGray60);
+  background: var(--color-background-datepicker-button-hover);
 }
 
 :global ._gestalt .react-datepicker__navigation:active::before {
-  background: var(--g-colorTransparentGray60);
-  border-radius: var(--g-borderRadius-circle);
+  background: var(--color-background-datepicker-button-hover);
+  border-radius: var(--rounding-circle);
   content: "";
   display: block;
   height: 100%;
   position: absolute;
-  right: 0;
-  top: 0;
+  right: var(--space-0);
+  top: var(--space-0);
   width: 100%;
 }
 
 html[dir="rtl"] :global ._gestalt .react-datepicker__navigation--previous {
-  right: 8px;
+  right: var(--space-200);
 }
 
 html:not([dir="rtl"])
   :global
   ._gestalt
   .react-datepicker__navigation--previous {
-  left: 8px;
+  left: var(--space-200);
 }
 
 html[dir="rtl"] :global ._gestalt .react-datepicker__navigation--next {
-  left: 8px;
+  left: var(--space-200);
 }
 
 html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
-  right: 8px;
+  right: var(--space-200);
 }
 
 :global ._gestalt .react-datepicker__navigation--previous--disabled,
@@ -369,7 +352,7 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
 }
 
 :global ._gestalt .react-datepicker__navigation:focus {
-  box-shadow: var(--g-focus);
+  box-shadow: 0 0 0 4px var(--color-border-focus);
 }
 
 .react-datepicker-popper {
@@ -380,26 +363,26 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
 
 :global ._gestalt .react-datepicker__month-select,
 :global ._gestalt .react-datepicker__year-select {
-  background-color: var(--g-colorGray0);
+  background-color: var(--color-background-formfield-primary);
   border-color: var(--color-border-container);
-  border-radius: 16px;
+  border-radius: var(--rounding-400);
   border-style: solid;
   border-width: 2px;
   color: var(--color-text-subtle);
   cursor: pointer;
   font-family: var(--font-family-default-latin);
   font-size: var(--font-size-200);
-  height: 40px;
-  margin-bottom: 10px;
-  margin-top: 10px;
-  padding: 5px 16px; /* horizontal padding prevents it from running into arrow */
+  height: var(--space-1000);
+  margin-bottom: var(--space-200);
+  margin-top: var(--space-200);
+  padding: var(--space-100) var(--space-400); /* horizontal padding prevents it from running into arrow */
   position: relative;
   width: 100%;
 }
 
 :global ._gestalt .react-datepicker__month-select:focus,
 :global ._gestalt .react-datepicker__year-select:focus {
-  box-shadow: 0 0 0 4px rgb(0 132 255 / 0.5);
+  box-shadow: 0 0 0 4px var(--color-border-focus);
   outline: 0;
 }
 
@@ -410,7 +393,7 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
 :global ._gestalt .react-datepicker__month-dropdown-container--scroll,
 :global ._gestalt .react-datepicker__month-year-dropdown-container--scroll {
   display: inline-block;
-  margin: 0 10px;
+  margin: var(--space-0) var(--space-200);
 }
 
 /* Override the textfield container since gestalt has block not inline block */
@@ -424,14 +407,14 @@ html:not([dir="rtl"]) :global ._gestalt .react-datepicker__navigation--next {
 }
 
 html[dir="rtl"] .calendarIcon {
-  left: 0;
+  left: var(--space-0);
 }
 
 html:not([dir="rtl"]) .calendarIcon {
-  right: 0;
+  right: var(--space-0);
 }
 
 .disabled {
   cursor: default;
-  opacity: 0.5;
+  opacity: var(--opacity-300);
 }

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -24,7 +24,7 @@ Tokenize DatePicker component colors, elevation & rounding
 
 --
 
-## 143.0.0 https://github.com/pinterest/gestalt/pull/3438
+## 143.0.0 https://github.com/pinterest/gestalt/pull/3434
 
 ### MINOR
 

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,6 +1,30 @@
 This file is updated manually
 
-## 142.5.0 https://github.com/pinterest/gestalt/pull/3434
+## 143.1.0 https://github.com/pinterest/gestalt/pull/3434
+
+### MINOR
+
+NEW
+
+| name                                        | light                                                                             | dark                             |
+| ------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------- |
+| color-background-datepicker-container       | #fff                                                                              | #212121                          |
+| color-background-datepicker-button-default  | #fff                                                                              | #212121                          |
+| color-background-datepicker-button-hover    | rgba(0, 0, 0, 0.06)                                                               | rgba(250, 250, 250, 0.5)         |
+| color-background-datepicker-button-selected | #111                                                                              | #efefef                          |
+| elevation-datepicker                        | 0 0 8px rgba(0, 0, 0, 0.1)                                                        | 0 0 8px rgba(250, 250, 250, 0.6) |
+| rounding-datepicke-side-end                 | var(--rounding-circle) var(--rounding-0) var(--rounding-0) var(--rounding-circle) | NA                               |
+| rounding-datepicke-side-start               | var(--rounding-0) var(--rounding-circle) var(--rounding-circle) var(--rounding-0) | NA                               |
+
+#### Why
+
+Tokenize DatePicker component colors, elevation & rounding
+
+#### Breaking change notes
+
+--
+
+## 143.0.0 https://github.com/pinterest/gestalt/pull/3438
 
 ### MINOR
 
@@ -16,6 +40,8 @@ NEW
 Tokenize FormField component background colors
 
 #### Breaking change notes
+
+--
 
 ## 142.4.0 https://github.com/pinterest/gestalt/pull/3432
 

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -13,8 +13,8 @@ NEW
 | color-background-datepicker-button-hover    | rgba(0, 0, 0, 0.06)                                   | rgba(250, 250, 250, 0.5)         |
 | color-background-datepicker-button-selected | #111                                                  | #efefef                          |
 | elevation-datepicker                        | 0 0 8px rgba(0, 0, 0, 0.1)                            | 0 0 8px rgba(250, 250, 250, 0.6) |
-| rounding-datepicke-side-end                 | rounding-circle rounding-0 rounding-0 rounding-circle | NA                               |
-| rounding-datepicke-side-start               | rounding-0 rounding-circle rounding-circle rounding-0 | NA                               |
+| rounding-datepicker-side-end                | rounding-circle rounding-0 rounding-0 rounding-circle | NA                               |
+| rounding-datepicker-side-start              | rounding-0 rounding-circle rounding-circle rounding-0 | NA                               |
 
 #### Why
 

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,6 +1,6 @@
 This file is updated manually
 
-## 143.1.0 https://github.com/pinterest/gestalt/pull/3434
+## 143.1.0 https://github.com/pinterest/gestalt/pull/3438
 
 ### MINOR
 

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -6,15 +6,15 @@ This file is updated manually
 
 NEW
 
-| name                                        | light                                                                             | dark                             |
-| ------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------- |
-| color-background-datepicker-container       | #fff                                                                              | #212121                          |
-| color-background-datepicker-button-default  | #fff                                                                              | #212121                          |
-| color-background-datepicker-button-hover    | rgba(0, 0, 0, 0.06)                                                               | rgba(250, 250, 250, 0.5)         |
-| color-background-datepicker-button-selected | #111                                                                              | #efefef                          |
-| elevation-datepicker                        | 0 0 8px rgba(0, 0, 0, 0.1)                                                        | 0 0 8px rgba(250, 250, 250, 0.6) |
-| rounding-datepicke-side-end                 | var(--rounding-circle) var(--rounding-0) var(--rounding-0) var(--rounding-circle) | NA                               |
-| rounding-datepicke-side-start               | var(--rounding-0) var(--rounding-circle) var(--rounding-circle) var(--rounding-0) | NA                               |
+| name                                        | light                                                 | dark                             |
+| ------------------------------------------- | ----------------------------------------------------- | -------------------------------- |
+| color-background-datepicker-container       | #fff                                                  | #212121                          |
+| color-background-datepicker-button-default  | #fff                                                  | #212121                          |
+| color-background-datepicker-button-hover    | rgba(0, 0, 0, 0.06)                                   | rgba(250, 250, 250, 0.5)         |
+| color-background-datepicker-button-selected | #111                                                  | #efefef                          |
+| elevation-datepicker                        | 0 0 8px rgba(0, 0, 0, 0.1)                            | 0 0 8px rgba(250, 250, 250, 0.6) |
+| rounding-datepicke-side-end                 | rounding-circle rounding-0 rounding-0 rounding-circle | NA                               |
+| rounding-datepicke-side-start               | rounding-0 rounding-circle rounding-circle rounding-0 | NA                               |
 
 #### Why
 

--- a/packages/gestalt-design-tokens/tokens/color/alias.json
+++ b/packages/gestalt-design-tokens/tokens/color/alias.json
@@ -333,6 +333,10 @@
         "value": "{color.red.pushpin.500.value}",
         "darkValue": "{color.red.pushpin.300.value}",
         "comment": "Used to indicate an error on a contained element, like TextField or TextArea"
+      },
+      "focus": {
+        "value": "rgba(0, 132, 255, 0.5)",
+        "comment": "Used to indicate a focused state on interactive elements, like TextField or Button"
       }
     }
   }

--- a/packages/gestalt-design-tokens/tokens/color/component.json
+++ b/packages/gestalt-design-tokens/tokens/color/component.json
@@ -346,6 +346,30 @@
           }
         }
       },
+      "datepicker": {
+        "container": {
+          "value": "#fff",
+          "darkValue": "#212121",
+          "comment": "DatePicker component background color."
+        },
+        "button": {
+          "default": {
+            "value": "#fff",
+            "darkValue": "#212121",
+            "comment": "DatePicker component background color."
+          },
+          "hover": {
+            "value": "rgba(0, 0, 0, 0.06)",
+            "darkValue": "rgba(250, 250, 250, 0.5)",
+            "comment": "DatePicker button background color."
+          },
+          "selected": {
+            "value": "#111",
+            "darkValue": "#efefef",
+            "comment": "DatePicker button background color."
+          }
+        }
+      },
       "formfield": {
         "primary": {
           "value": "#fff",

--- a/packages/gestalt-design-tokens/tokens/color/component.json
+++ b/packages/gestalt-design-tokens/tokens/color/component.json
@@ -356,17 +356,17 @@
           "default": {
             "value": "#fff",
             "darkValue": "#212121",
-            "comment": "DatePicker component background color."
+            "comment": "DatePicker date selectors background color."
           },
           "hover": {
             "value": "rgba(0, 0, 0, 0.06)",
             "darkValue": "rgba(250, 250, 250, 0.5)",
-            "comment": "DatePicker button background color."
+            "comment": "DatePicker date selectors background color on hover."
           },
           "selected": {
             "value": "#111",
             "darkValue": "#efefef",
-            "comment": "DatePicker button background color."
+            "comment": "DatePicker date selectors selected background color."
           }
         }
       },

--- a/packages/gestalt-design-tokens/tokens/elevation/component.json
+++ b/packages/gestalt-design-tokens/tokens/elevation/component.json
@@ -1,0 +1,9 @@
+{
+  "elevation": {
+    "datepicker": {
+      "value": "0 0 8px rgba(0, 0, 0, 0.1)",
+      "darkValue": "0 0 8px rgba(250, 250, 250, 0.6)",
+      "comment": "DatePicker container elevation"
+    }
+  }
+}

--- a/packages/gestalt-design-tokens/tokens/rounding/component.json
+++ b/packages/gestalt-design-tokens/tokens/rounding/component.json
@@ -3,7 +3,7 @@
     "datepicker": {
       "container": {
         "value": "{rounding.400.value}",
-        "comment": "DatePicker semicircle rounding for start range selector"
+        "comment": "DatePicker calendar container rounding"
       },
       "range": {
         "start": {

--- a/packages/gestalt-design-tokens/tokens/rounding/component.json
+++ b/packages/gestalt-design-tokens/tokens/rounding/component.json
@@ -1,13 +1,21 @@
 {
   "rounding": {
     "datepicker": {
-      "side": {
+      "container": {
+        "value": "{rounding.400.value}",
+        "comment": "DatePicker semicircle rounding for start range selector"
+      },
+      "range": {
         "start": {
-          "value": "var(--rounding-circle) var(--rounding-0) var(--rounding-0) var(--rounding-circle)",
+          "value": "{rounding.circle.value} {rounding.0.value} {rounding.0.value} {rounding.circle.value}",
+          "comment": "DatePicker semicircle rounding for start range selector"
+        },
+        "middle": {
+          "value": "{rounding.0.value}",
           "comment": "DatePicker semicircle rounding for start range selector"
         },
         "end": {
-          "value": "var(--rounding-0) var(--rounding-circle) var(--rounding-circle) var(--rounding-0)",
+          "value": "{rounding.0.value} {rounding.circle.value} {rounding.circle.value} {rounding.0.value}",
           "comment": "DatePicker semicircle rounding for end range selector"
         }
       }

--- a/packages/gestalt-design-tokens/tokens/rounding/component.json
+++ b/packages/gestalt-design-tokens/tokens/rounding/component.json
@@ -1,0 +1,16 @@
+{
+  "rounding": {
+    "datepicker": {
+      "side": {
+        "start": {
+          "value": "var(--rounding-circle) var(--rounding-0) var(--rounding-0) var(--rounding-circle)",
+          "comment": "DatePicker semicircle rounding for start range selector"
+        },
+        "end": {
+          "value": "var(--rounding-0) var(--rounding-circle) var(--rounding-circle) var(--rounding-0)",
+          "comment": "DatePicker semicircle rounding for end range selector"
+        }
+      }
+    }
+  }
+}

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -124,6 +124,10 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-background-button-semitransparentdark-active: #e0e0e0;
   --color-background-button-disabled-default: #4a4a4a;
   --color-background-button-selected-default: #e9e9e9;
+  --color-background-datepicker-container: #212121;
+  --color-background-datepicker-button-default: #212121;
+  --color-background-datepicker-button-hover: rgba(250, 250, 250, 0.5);
+  --color-background-datepicker-button-selected: #efefef;
   --color-background-formfield-primary: #030303;
   --color-background-formfield-disabled: #404040;
   --color-background-overlay: #2b2b2b;
@@ -160,6 +164,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --elevation-floating: none;
   --elevation-raised-top: 0 0.5px 0 #f9f9f9;
   --elevation-raised-bottom: 0 -0.5px 0 #f9f9f9;
+  --elevation-datepicker: 0 0 8px rgba(250, 250, 250, 0.6);
  }
 </style>
 `;
@@ -288,6 +293,10 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-datepicker-container: #ffffff;
+  --color-background-datepicker-button-default: #ffffff;
+  --color-background-datepicker-button-hover: rgba(0, 0, 0, 0.06);
+  --color-background-datepicker-button-selected: #111111;
   --color-background-formfield-primary: #ffffff;
   --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
@@ -324,6 +333,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
+  --elevation-datepicker: 0 0 8px rgba(0, 0, 0, 0.1);
  }
 </style>
 `;
@@ -452,6 +462,10 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-datepicker-container: #ffffff;
+  --color-background-datepicker-button-default: #ffffff;
+  --color-background-datepicker-button-hover: rgba(0, 0, 0, 0.06);
+  --color-background-datepicker-button-selected: #111111;
   --color-background-formfield-primary: #ffffff;
   --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
@@ -488,6 +502,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
+  --elevation-datepicker: 0 0 8px rgba(0, 0, 0, 0.1);
  }
 </style>
 `;
@@ -616,6 +631,10 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-background-button-semitransparentdark-active: #1f1f1f;
   --color-background-button-disabled-default: #e9e9e9;
   --color-background-button-selected-default: #111111;
+  --color-background-datepicker-container: #ffffff;
+  --color-background-datepicker-button-default: #ffffff;
+  --color-background-datepicker-button-hover: rgba(0, 0, 0, 0.06);
+  --color-background-datepicker-button-selected: #111111;
   --color-background-formfield-primary: #ffffff;
   --color-background-formfield-disabled: #efefef;
   --color-background-overlay: #ffffff;
@@ -652,6 +671,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
+  --elevation-datepicker: 0 0 8px rgba(0, 0, 0, 0.1);
  }
 </style>
 `;
@@ -781,6 +801,10 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-background-button-semitransparentdark-active: #e0e0e0;
   --color-background-button-disabled-default: #4a4a4a;
   --color-background-button-selected-default: #e9e9e9;
+  --color-background-datepicker-container: #212121;
+  --color-background-datepicker-button-default: #212121;
+  --color-background-datepicker-button-hover: rgba(250, 250, 250, 0.5);
+  --color-background-datepicker-button-selected: #efefef;
   --color-background-formfield-primary: #030303;
   --color-background-formfield-disabled: #404040;
   --color-background-overlay: #2b2b2b;
@@ -817,6 +841,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --elevation-floating: none;
   --elevation-raised-top: 0 0.5px 0 #f9f9f9;
   --elevation-raised-bottom: 0 -0.5px 0 #f9f9f9;
+  --elevation-datepicker: 0 0 8px rgba(250, 250, 250, 0.6);
  }
 }
 </style>


### PR DESCRIPTION
#### What changed?

DatePicker: tokenize colors and other internal styles #3438


### MINOR

NEW

| name                                        | light                                                 | dark                             |
| ------------------------------------------- | ----------------------------------------------------- | -------------------------------- |
| color-background-datepicker-container       | #fff                                                  | #212121                          |
| color-background-datepicker-button-default  | #fff                                                  | #212121                          |
| color-background-datepicker-button-hover    | rgba(0, 0, 0, 0.06)                                   | rgba(250, 250, 250, 0.5)         |
| color-background-datepicker-button-selected | #111                                                  | #efefef                          |
| elevation-datepicker                        | 0 0 8px rgba(0, 0, 0, 0.1)                            | 0 0 8px rgba(250, 250, 250, 0.6) |
| rounding-datepicke-side-end                 | rounding-circle rounding-0 rounding-0 rounding-circle | NA                               |
| rounding-datepicke-side-start               | rounding-0 rounding-circle rounding-circle rounding-0 | NA                               |

#### Why

Tokenize DatePicker component colors, elevation & rounding

#### Breaking change notes

--
