### PR TITLE
ColorSchemeProvider, Avatar, Tag, TextField: deprecate legacy colors from provider + tokenize background and border colors

### DIFF
--- a/docs/docs-components/Checkerboard.js
+++ b/docs/docs-components/Checkerboard.js
@@ -3,8 +3,11 @@ import { type Node as ReactNode } from 'react';
 import { Box, useColorScheme } from 'gestalt';
 
 export default function Checkerboard(): ReactNode {
-  const { colorGray300 } = useColorScheme();
-  const colorGray300Encoded = colorGray300.replace('#', '%23');
+  const { name: colorSchemeName } = useColorScheme();
+  const color =
+    colorSchemeName === 'lightMode'
+      ? 'var(--color-background-dark)'
+      : '#efefef'.replace('#', '%23');
   return (
     <Box
       height="100%"
@@ -14,8 +17,8 @@ export default function Checkerboard(): ReactNode {
           backgroundImage: `
           url('data:image/svg+xml;utf8,
             <svg preserveAspectRatio="none"  viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
-              <rect x="0" y="0" width="5" height="5" fill-opacity="0.1" fill="${colorGray300Encoded}" />
-              <rect x="5" y="5" width="5" height="5" fill-opacity="0.1" fill="${colorGray300Encoded}" />
+              <rect x="0" y="0" width="5" height="5" fill-opacity="0.1" fill="${color}" />
+              <rect x="5" y="5" width="5" height="5" fill-opacity="0.1" fill="${color}" />
               <rect x="5" y="0" width="5" height="5" fill-opacity="0.1" fill="transparent" />
               <rect x="0" y="5" width="5" height="5" fill-opacity="0.1" fill="transparent" />
             </svg>

--- a/docs/docs-components/Checkerboard.js
+++ b/docs/docs-components/Checkerboard.js
@@ -3,7 +3,7 @@ import { type Node as ReactNode } from 'react';
 import { Box, useColorScheme } from 'gestalt';
 
 export default function Checkerboard(): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const color =
     colorSchemeName === 'lightMode'
       ? 'var(--color-background-dark)'

--- a/docs/docs-components/ColorTile.js
+++ b/docs/docs-components/ColorTile.js
@@ -19,7 +19,7 @@ function ColorTile({ description, fullTokenName, number = 400, textColor }: Prop
     fullTokenName?.includes('black') ||
     fullTokenName?.includes('inverse') ||
     isTransparent;
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
 
   return (
     <Box

--- a/docs/docs-components/PatternBarFill.js
+++ b/docs/docs-components/PatternBarFill.js
@@ -19,7 +19,7 @@ type DataVisualizationColors =
   | '12';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
     colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]

--- a/docs/docs-components/PatternBarFill.js
+++ b/docs/docs-components/PatternBarFill.js
@@ -19,9 +19,9 @@ type DataVisualizationColors =
   | '12';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name } = useColorScheme();
+  const { name: colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
-    name === 'lightMode'
+    colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]
       : darkColorDesignTokens[`color-data-visualization-${vizColor}`];
 };

--- a/docs/docs-components/PatternLineMarker.js
+++ b/docs/docs-components/PatternLineMarker.js
@@ -19,7 +19,7 @@ type DataVisualizationColors =
   | '12';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
     colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]

--- a/docs/docs-components/PatternLineMarker.js
+++ b/docs/docs-components/PatternLineMarker.js
@@ -19,9 +19,9 @@ type DataVisualizationColors =
   | '12';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name } = useColorScheme();
+  const { name: colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
-    name === 'lightMode'
+    colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]
       : darkColorDesignTokens[`color-data-visualization-${vizColor}`];
 };

--- a/packages/gestalt-charts/src/ChartGraph.js
+++ b/packages/gestalt-charts/src/ChartGraph.js
@@ -272,7 +272,7 @@ function ChartGraph({
   // HOOKS
   const hexColor = useHexColor();
   const patterns = usePatterns();
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const { accessibilityLabelPrefixText } = useDefaultLabel('ChartGraph');
 
   // ASSERTIONS

--- a/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
+++ b/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
@@ -36,7 +36,7 @@ type Props = {
 function LegendIcon({ payloadData }: Props): ReactNode {
   const { decal: showVisualPattern } = useChartContext();
   const isAccessible = showVisualPattern === 'visualPattern';
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
 
   if (payloadData.referenceArea === 'default') {
     const dimension = 16;

--- a/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
+++ b/packages/gestalt-charts/src/ChartGraph/LegendIcon.js
@@ -36,7 +36,7 @@ type Props = {
 function LegendIcon({ payloadData }: Props): ReactNode {
   const { decal: showVisualPattern } = useChartContext();
   const isAccessible = showVisualPattern === 'visualPattern';
-  const { name } = useColorScheme();
+  const { name: colorSchemeName } = useColorScheme();
 
   if (payloadData.referenceArea === 'default') {
     const dimension = 16;
@@ -53,7 +53,7 @@ function LegendIcon({ payloadData }: Props): ReactNode {
     );
   }
 
-  const source = name === 'lightMode' ? lightColorDesignTokens : darkColorDesignTokens;
+  const source = colorSchemeName === 'lightMode' ? lightColorDesignTokens : darkColorDesignTokens;
   const colorMap = Object.entries({
     '01': source['color-data-visualization-01'],
     '02': source['color-data-visualization-02'],

--- a/packages/gestalt-charts/src/ChartGraph/usePatterns.js
+++ b/packages/gestalt-charts/src/ChartGraph/usePatterns.js
@@ -6,7 +6,7 @@ import lightColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-li
 import { type DataVisualizationColors } from './types';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
     colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]

--- a/packages/gestalt-charts/src/ChartGraph/usePatterns.js
+++ b/packages/gestalt-charts/src/ChartGraph/usePatterns.js
@@ -6,9 +6,9 @@ import lightColorDesignTokens from 'gestalt-design-tokens/dist/json/variables-li
 import { type DataVisualizationColors } from './types';
 
 export const useHexColor: () => (DataVisualizationColors) => string = () => {
-  const { name } = useColorScheme();
+  const { name: colorSchemeName } = useColorScheme();
   return (vizColor: DataVisualizationColors) =>
-    name === 'lightMode'
+    colorSchemeName === 'lightMode'
       ? lightColorDesignTokens[`color-data-visualization-${vizColor}`]
       : darkColorDesignTokens[`color-data-visualization-${vizColor}`];
 };

--- a/packages/gestalt-datepicker/src/DateField.css
+++ b/packages/gestalt-datepicker/src/DateField.css
@@ -68,7 +68,7 @@
 }
 
 .formElementErrored {
-  border-color: var(--color-border-error);
+  border-color: var(--color-border-formfield-error-default);
   outline: none;
 }
 
@@ -77,7 +77,7 @@
 }
 
 .formElementErrored:hover:not(:focus) {
-  border-color: var(--g-colorRed100Hovered);
+  border-color: var(--color-border-formfield-error-hover);
 }
 
 .formElementEnabled {

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -1,5 +1,27 @@
 This file is updated manually
 
+## 144.0.0 https://github.com/pinterest/gestalt/pull/3439
+
+### MINOR
+
+NEW
+
+| name                                 | light                    | dark    |
+| ------------------------------------ | ------------------------ | ------- |
+| color-background-avatar              | #efefef                  | #404040 |
+| color-border-avatar                  | #fff                     | #030303 |
+| color-border-formfield-error-default | color.border.error.value | #212121 |
+| color-border-formfield-error-hover   | #ad081b                  | #cf001f |
+| color-border-tag-disabled            | #767676                  | #ababab |
+
+#### Why
+
+Tokenize Avatar, Tag, and formfield background and border colors
+
+#### Breaking change notes
+
+--
+
 ## 143.1.0 https://github.com/pinterest/gestalt/pull/3438
 
 ### MINOR

--- a/packages/gestalt-design-tokens/CHANGELOG.md
+++ b/packages/gestalt-design-tokens/CHANGELOG.md
@@ -8,7 +8,7 @@ NEW
 
 | name                                 | light                    | dark    |
 | ------------------------------------ | ------------------------ | ------- |
-| color-background-avatar              | #efefef                  | #404040 |
+| color-background-avatar-placeholder  | #efefef                  | #404040 |
 | color-border-avatar                  | #fff                     | #030303 |
 | color-border-formfield-error-default | color.border.error.value | #212121 |
 | color-border-formfield-error-hover   | #ad081b                  | #cf001f |

--- a/packages/gestalt-design-tokens/tokens/color/component.json
+++ b/packages/gestalt-design-tokens/tokens/color/component.json
@@ -2,9 +2,11 @@
   "color": {
     "background": {
       "avatar": {
-        "value": "#efefef",
-        "darkValue": "#404040",
-        "comment": "Avatar component background color."
+        "placeholder": {
+          "value": "#efefef",
+          "darkValue": "#404040",
+          "comment": "Avatar component placeholder background color."
+        }
       },
       "badge": {
         "neutral": {

--- a/packages/gestalt-design-tokens/tokens/color/component.json
+++ b/packages/gestalt-design-tokens/tokens/color/component.json
@@ -1,6 +1,11 @@
 {
   "color": {
     "background": {
+      "avatar": {
+        "value": "#efefef",
+        "darkValue": "#404040",
+        "comment": "Avatar component background color."
+      },
       "badge": {
         "neutral": {
           "value": "{color.background.tertiary.base.value}",
@@ -540,6 +545,34 @@
           "value": "#efefef",
           "darkValue": "#404040",
           "comment": "TileData disabled background color"
+        }
+      }
+    },
+    "border": {
+      "avatar": {
+        "value": "#fff",
+        "darkValue": "#030303",
+        "comment": "Avatar component outline border color."
+      },
+      "formfield": {
+        "error": {
+          "default": {
+            "value": "{color.border.error.value}",
+            "darkValue": "{color.border.error.darkValue}",
+            "comment": "Error formfield border color."
+          },
+          "hover": {
+            "value": "#ad081b",
+            "darkValue": "#cf001f",
+            "comment": "Error formfield border color on hover."
+          }
+        }
+      },
+      "tag": {
+        "disabled": {
+          "value": "#767676",
+          "darkValue": "#ababab",
+          "comment": "Tag component disabled border color."
         }
       }
     }

--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -3068,16 +3068,5 @@ export function useDefaultLabel(componentName: string): { [k: string]: string };
  * Undocumented
  */
 export function useColorScheme(): {
-  name: string;
-  colorRed100Hovered: string;
-  colorGray0: string;
-  colorGray50: string;
-  colorGray100: string;
-  colorGray100Active: string;
-  colorGray200: string;
-  colorGray300: string;
-  colorGray400: string;
-  colorTransparentGray60: string;
-  colorTransparentGray100: string;
-  [tokenName: string]: string;
+  name: 'lightMode' | 'darkMode';
 };

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -72,7 +72,7 @@ export default function Accordion({
   size = 'lg',
   type = 'info',
 }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   const { gap, padding, rounding } = applyModuleDensityStyle(size);

--- a/packages/gestalt/src/AccordionExpandable.js
+++ b/packages/gestalt/src/AccordionExpandable.js
@@ -84,7 +84,7 @@ export default function AccordionExpandable({
     accessibilityExpandLabel: defaultAccessibilityExpandLabel,
   } = useDefaultLabelContext('Accordion');
 
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   const { rounding } = applyModuleDensityStyle(size);

--- a/packages/gestalt/src/ActivationCard.js
+++ b/packages/gestalt/src/ActivationCard.js
@@ -240,7 +240,7 @@ export default function ActivationCard({
   const isCompleted = status === 'complete';
   const { accessibilityDismissButtonLabel } = useDefaultLabelContext('ActivationCard');
 
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   return (

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -2,7 +2,6 @@
 import { type Node as ReactNode, useState } from 'react';
 import DefaultAvatar from './Avatar/DefaultAvatar';
 import Box from './Box';
-import { useColorScheme } from './contexts/ColorSchemeProvider';
 import Icon from './Icon';
 import Image from './Image';
 import Mask from './Mask';
@@ -52,7 +51,6 @@ type Props = {
 
 function Avatar(props: Props): ReactNode {
   const [isImageLoaded, setIsImageLoaded] = useState(true);
-  const { colorGray0, colorGray100 } = useColorScheme();
   const { accessibilityLabel, name, outline, size = 'fit', src, verified } = props;
   const width = size === 'fit' ? '100%' : sizes[size];
   const height = size === 'fit' ? '' : sizes[size];
@@ -65,7 +63,7 @@ function Avatar(props: Props): ReactNode {
         ? {
             dangerouslySetInlineStyle: {
               __style: {
-                boxShadow: `0 0 0 1px ${colorGray0}`,
+                boxShadow: `0 0 0 1px var(--color-border-avatar)`,
               },
             },
           }
@@ -80,7 +78,7 @@ function Avatar(props: Props): ReactNode {
         <Mask rounding="circle" wash>
           <Image
             alt={accessibilityLabel ?? name}
-            color={colorGray100}
+            color="var(--color-border-avatar)"
             naturalHeight={1}
             naturalWidth={1}
             src={src}

--- a/packages/gestalt/src/Avatar.js
+++ b/packages/gestalt/src/Avatar.js
@@ -78,7 +78,7 @@ function Avatar(props: Props): ReactNode {
         <Mask rounding="circle" wash>
           <Image
             alt={accessibilityLabel ?? name}
-            color="var(--color-border-avatar)"
+            color="var(--color-background-avatar-placeholder)"
             naturalHeight={1}
             naturalWidth={1}
             src={src}

--- a/packages/gestalt/src/Avatar/Foundation.js
+++ b/packages/gestalt/src/Avatar/Foundation.js
@@ -4,7 +4,6 @@ import classnames from 'classnames';
 import avatarStyles from '../AvatarGroup.css';
 import Box from '../Box';
 import colors from '../Colors.css';
-import { useColorScheme } from '../contexts/ColorSchemeProvider';
 import styles from '../Icon.css';
 import icons from '../icons/index';
 import typography from '../Typography.css';
@@ -14,8 +13,6 @@ const ICON_SIZE_RATIO = (20 / 48) * 100; // For pixel perfect icon button, we us
 type ResponsiveFitSizeBoxProps = { children: ReactNode, outline: boolean };
 
 function ResponsiveFitSizeBox({ children, outline }: ResponsiveFitSizeBoxProps): ReactNode {
-  const { colorGray0 } = useColorScheme();
-
   return (
     <Box
       color="secondary"
@@ -23,7 +20,7 @@ function ResponsiveFitSizeBox({ children, outline }: ResponsiveFitSizeBoxProps):
         __style: {
           // When specifying a padding by percentage, it's always based on the width of the parent container so we get a property that's equal to the width.s
           paddingBottom: '100%',
-          boxShadow: outline ? `0 0 0 1px ${colorGray0}` : undefined,
+          boxShadow: outline ? '0 0 0 1px var(--color-border-avatar)' : undefined,
         },
       }}
       position="relative"
@@ -64,8 +61,6 @@ export default function AvatarFoundation({
   translate,
   content = 'text',
 }: Props): ReactNode {
-  const { colorGray300 } = useColorScheme();
-
   const cs = classnames(styles.icon, colors.darkGray);
 
   return (
@@ -81,7 +76,7 @@ export default function AvatarFoundation({
           {title ? <title>{title}</title> : null}
           <text
             fontSize={fontSize}
-            fill={colorGray300}
+            fill="var(--color-text-default)"
             dy="0.35em"
             textAnchor={textAnchor}
             className={[

--- a/packages/gestalt/src/BannerOverlay.js
+++ b/packages/gestalt/src/BannerOverlay.js
@@ -129,7 +129,7 @@ export default function BannerOverlay({
   thumbnail,
   zIndex,
 }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   const isMobileDevice = useDeviceType() === 'mobile';

--- a/packages/gestalt/src/BannerUpsell.js
+++ b/packages/gestalt/src/BannerUpsell.js
@@ -148,7 +148,7 @@ export default function BannerUpsell({
   const responsiveMinWidth = useResponsiveMinWidth();
   const { accessibilityDismissButtonLabel } = useDefaultLabelContext('BannerUpsell');
   const hasActions = Boolean(primaryAction || secondaryAction);
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   let messageElement: Element<'span'> | Element<typeof Text>;

--- a/packages/gestalt/src/Button.js
+++ b/packages/gestalt/src/Button.js
@@ -200,7 +200,7 @@ const ButtonWithForwardRef: AbstractComponent<Props, HTMLButtonElement> = forwar
     width: innerRef?.current?.clientWidth,
   });
 
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
   const isDarkMode = colorSchemeName === 'darkMode';
   const isDarkModeRed = isDarkMode && color === 'red';

--- a/packages/gestalt/src/ButtonLink.js
+++ b/packages/gestalt/src/ButtonLink.js
@@ -136,7 +136,7 @@ const ButtonLinkWithForwardRef: AbstractComponent<ButtonProps, HTMLAnchorElement
 
   const { accessibilityNewTabLabel } = useDefaultLabelContext('Link');
 
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   // We need to make a few exceptions for accessibility reasons in darkMode for red buttons
   const isDarkMode = colorSchemeName === 'darkMode';
   const isDarkModeRed = isDarkMode && color === 'red';

--- a/packages/gestalt/src/Colors.css
+++ b/packages/gestalt/src/Colors.css
@@ -6,12 +6,12 @@
   --g-colorGray200: #767676;
   --g-colorGray300: #111;
   --g-colorGray400: #000;
-  --g-colorRed100Hovered: #ad081b;
   --g-colorTransparentGray60: rgb(0 0 0 / 0.06);
-  --g-colorTransparentGray100: rgb(0 0 0 / 0.1);
 }
 
 /** Colors Design Token **/
+
+/* semantic background colors */
 
 .default {
   background-color: var(--color-background-default);
@@ -133,32 +133,32 @@
 
 /** LEGACY CUSTOM COLORS **/
 
-/** text **/
-
-.lightGray {
-  color: var(--g-colorGray100);
+.whiteBg {
+  background-color: var(--g-colorGray0);
 }
 
 .whiteElevated {
   color: var(--g-colorGray50);
 }
 
-.darkGray {
-  color: var(--g-colorGray300);
+.lightGray {
+  color: var(--g-colorGray100);
+}
+
+.lightGrayBg {
+  background-color: var(--g-colorGray100);
 }
 
 .gray {
   color: var(--g-colorGray200);
 }
 
-/** background **/
-
-.whiteBg {
-  background-color: var(--g-colorGray0);
+.grayBg {
+  background-color: var(--g-colorGray200);
 }
 
-.lightGrayBg {
-  background-color: var(--g-colorGray100);
+.darkGray {
+  color: var(--g-colorGray300);
 }
 
 .darkGrayBg {
@@ -167,8 +167,4 @@
 
 .blackBg {
   background-color: var(--g-colorGray400);
-}
-
-.grayBg {
-  background-color: var(--g-colorGray200);
 }

--- a/packages/gestalt/src/HelpButton.js
+++ b/packages/gestalt/src/HelpButton.js
@@ -106,7 +106,7 @@ export default function HelpButton({
   const [focused, setFocused] = useState(false);
   // Define where the focused content stays
   const [innerModalFocus, setInnerModalFocus] = useState(false);
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const popoverId = useId();
   const { tooltipMessage } = useDefaultLabelContext('HelpButton');
 

--- a/packages/gestalt/src/List/Message.js
+++ b/packages/gestalt/src/List/Message.js
@@ -12,7 +12,7 @@ type Props = {
 };
 
 export default function ListText({ size, text }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
 
   // Flow shuold catch if text is missing. In case Flow is not enabled and text is missing, the errors are not that helpful. This surfaces the problem more explicitly.
   if (!text) {

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -135,7 +135,7 @@ export default function PopoverEducational({
   size = 'sm',
   zIndex,
 }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   if (!anchor) {

--- a/packages/gestalt/src/Shared/ToastSubcomponents.js
+++ b/packages/gestalt/src/Shared/ToastSubcomponents.js
@@ -169,7 +169,7 @@ export function ToastTypeThumbnail({
 }: {
   type: 'default' | 'success' | 'error' | 'progress',
 }): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const {
     accessibilityIconSuccessLabel,
     accessibilityIconErrorLabel,

--- a/packages/gestalt/src/Tag.js
+++ b/packages/gestalt/src/Tag.js
@@ -2,7 +2,6 @@
 import { type Node as ReactNode } from 'react';
 import classnames from 'classnames';
 import Box from './Box';
-import { useColorScheme } from './contexts/ColorSchemeProvider';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
 import focusStyles from './Focus.css';
 import Icon from './Icon';
@@ -107,8 +106,6 @@ export default function Tag({
   text,
   type = 'default',
 }: Props): ReactNode {
-  const { colorGray200 } = useColorScheme();
-
   const hasIcon = ['error', 'warning'].includes(type);
 
   const bgColor = backgroundColorByType[type];
@@ -146,7 +143,8 @@ export default function Tag({
       aria-disabled={disabled}
       color={bgColor}
       dangerouslySetInlineStyle={{
-        __style: disabled && !hasIcon ? { border: `solid 1px ${colorGray200}` } : {},
+        __style:
+          disabled && !hasIcon ? { border: 'solid 1px var(--color-border-tag-disabled)' } : {},
       }}
       display="inlineBlock"
       height={height}

--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -135,7 +135,7 @@ export default function TagData({
   const { accessibilityRemoveIconLabel: accessibilityRemoveIconLabelDefault } =
     useDefaultLabelContext('TagData');
 
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const borderColor = getDataVisualizationColor(colorSchemeName, color);
   const bgColor = getDataVisualizationColor(colorSchemeName, color, { lighten: true });
   const fgColor = disabled ? 'subtle' : 'default';

--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -135,9 +135,9 @@ export default function TagData({
   const { accessibilityRemoveIconLabel: accessibilityRemoveIconLabelDefault } =
     useDefaultLabelContext('TagData');
 
-  const { name } = useColorScheme();
-  const borderColor = getDataVisualizationColor(name, color);
-  const bgColor = getDataVisualizationColor(name, color, { lighten: true });
+  const { name: colorSchemeName } = useColorScheme();
+  const borderColor = getDataVisualizationColor(colorSchemeName, color);
+  const bgColor = getDataVisualizationColor(colorSchemeName, color, { lighten: true });
   const fgColor = disabled ? 'subtle' : 'default';
 
   const colorStyles: { borderColor?: string, backgroundColor?: string } = {

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -118,7 +118,7 @@ export default function TileData({
   trendSentiment,
   value,
 }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const borderColor = getDataVisualizationColor(colorSchemeName, color);
 
   const colorStyles: { borderColor?: string, backgroundColor?: string } = {

--- a/packages/gestalt/src/TileData.js
+++ b/packages/gestalt/src/TileData.js
@@ -118,8 +118,8 @@ export default function TileData({
   trendSentiment,
   value,
 }: Props): ReactNode {
-  const { name } = useColorScheme();
-  const borderColor = getDataVisualizationColor(name, color);
+  const { name: colorSchemeName } = useColorScheme();
+  const borderColor = getDataVisualizationColor(colorSchemeName, color);
 
   const colorStyles: { borderColor?: string, backgroundColor?: string } = {
     borderColor,

--- a/packages/gestalt/src/Toast.js
+++ b/packages/gestalt/src/Toast.js
@@ -132,7 +132,7 @@ export default function Toast({
   thumbnail,
   type = 'default',
 }: Props): ReactNode {
-  const { name: colorSchemeName } = useColorScheme();
+  const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
 
   const responsiveMinWidth = useResponsiveMinWidth();

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -121,7 +121,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -204,7 +204,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -250,7 +250,7 @@ exports[`Avatar renders the correct size - md 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -296,7 +296,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -342,7 +342,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -388,7 +388,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }
@@ -434,7 +434,7 @@ exports[`Avatar renders the correct src 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "var(--color-border-avatar)",
+          "backgroundColor": "var(--color-background-avatar-placeholder)",
           "paddingBottom": "100%",
         }
       }

--- a/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Avatar.test.js.snap
@@ -6,7 +6,7 @@ exports[`Avatar renders an outline 1`] = `
   data-test-id="gestalt-avatar-svg"
   style={
     Object {
-      "boxShadow": "0 0 0 1px #fff",
+      "boxShadow": "0 0 0 1px var(--color-border-avatar)",
       "height": "",
       "width": "100%",
     }
@@ -37,7 +37,7 @@ exports[`Avatar renders an outline 1`] = `
         <text
           className="antialiased sansSerif fontWeightSemiBold "
           dy="0.35em"
-          fill="#111"
+          fill="var(--color-text-default)"
           fontSize="40px"
           textAnchor="middle"
         >
@@ -85,7 +85,7 @@ exports[`Avatar renders multi-byte character initial 1`] = `
         <text
           className="antialiased sansSerif fontWeightSemiBold "
           dy="0.35em"
-          fill="#111"
+          fill="var(--color-text-default)"
           fontSize="40px"
           textAnchor="middle"
         >
@@ -121,7 +121,7 @@ exports[`Avatar renders the checkmark on verified default 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -204,7 +204,7 @@ exports[`Avatar renders the correct size - lg 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -250,7 +250,7 @@ exports[`Avatar renders the correct size - md 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -296,7 +296,7 @@ exports[`Avatar renders the correct size - sm 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -342,7 +342,7 @@ exports[`Avatar renders the correct size - xl 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -388,7 +388,7 @@ exports[`Avatar renders the correct size - xs 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -434,7 +434,7 @@ exports[`Avatar renders the correct src 1`] = `
       className="box relative"
       style={
         Object {
-          "backgroundColor": "#efefef",
+          "backgroundColor": "var(--color-border-avatar)",
           "paddingBottom": "100%",
         }
       }
@@ -492,7 +492,7 @@ exports[`Avatar renders the verified icon 1`] = `
         <text
           className="antialiased sansSerif fontWeightSemiBold "
           dy="0.35em"
-          fill="#111"
+          fill="var(--color-text-default)"
           fontSize="40px"
           textAnchor="middle"
         >
@@ -574,7 +574,7 @@ exports[`Avatar renders with an empty name shows default icon 1`] = `
         <text
           className="antialiased sansSerif fontWeightSemiBold "
           dy="0.35em"
-          fill="#111"
+          fill="var(--color-text-default)"
           fontSize="40px"
           textAnchor="middle"
         />

--- a/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/AvatarGroup.jsdom.test.js.snap
@@ -25,14 +25,14 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"
@@ -64,7 +64,7 @@ exports[`AvatarGroup renders AvatarGroup button with addCollaborators button 1`]
             >
               <div
                 class="box circle relative secondary"
-                style="padding-bottom: 100%; box-shadow: 0 0 0 1px #fff;"
+                style="padding-bottom: 100%; box-shadow: 0 0 0 1px var(--color-border-avatar);"
               >
                 <div
                   class="absolute bottom0 box justifyCenter left0 right0 top0 xsDisplayFlex"
@@ -128,14 +128,14 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
                 <div
                   class="box circle relative"
                   data-test-id="gestalt-avatar-svg"
-                  style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                  style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
                 >
                   <div
                     class="Mask circle willChangeTransform"
                   >
                     <div
                       class="box relative"
-                      style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                      style="padding-bottom: 100%;"
                     >
                       <img
                         alt="Keerthi"
@@ -167,7 +167,7 @@ exports[`AvatarGroup renders AvatarGroup link with addCollaborators button 1`] =
               >
                 <div
                   class="box circle relative secondary"
-                  style="padding-bottom: 100%; box-shadow: 0 0 0 1px #fff;"
+                  style="padding-bottom: 100%; box-shadow: 0 0 0 1px var(--color-border-avatar);"
                 >
                   <div
                     class="absolute bottom0 box justifyCenter left0 right0 top0 xsDisplayFlex"
@@ -226,14 +226,14 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"
@@ -266,14 +266,14 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"
@@ -305,7 +305,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
             >
               <div
                 class="box circle relative secondary"
-                style="padding-bottom: 100%; box-shadow: 0 0 0 1px #fff;"
+                style="padding-bottom: 100%; box-shadow: 0 0 0 1px var(--color-border-avatar);"
               >
                 <div
                   class="absolute bottom0 box justifyCenter left0 right0 top0 xsDisplayFlex"
@@ -320,7 +320,7 @@ exports[`AvatarGroup renders display-only AvatarGroup with counter 1`] = `
                     <text
                       class="antialiased sansSerif fontWeightSemiBold "
                       dy="0.35em"
-                      fill="#111"
+                      fill="var(--color-text-default)"
                       font-size="40px"
                       text-anchor="middle"
                     >
@@ -364,7 +364,7 @@ exports[`AvatarGroup renders display-only AvatarGroup without image 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
               >
                 <div
                   class="box circle relative secondary"
@@ -386,7 +386,7 @@ exports[`AvatarGroup renders display-only AvatarGroup without image 1`] = `
                       <text
                         class="antialiased sansSerif fontWeightSemiBold "
                         dy="0.35em"
-                        fill="#111"
+                        fill="var(--color-text-default)"
                         font-size="40px"
                         text-anchor="middle"
                       >
@@ -438,14 +438,14 @@ exports[`AvatarGroup renders fit display-only AvatarGroup with image 1`] = `
                 <div
                   class="box circle relative"
                   data-test-id="gestalt-avatar-svg"
-                  style="box-shadow: 0 0 0 1px #fff; width: 100%;"
+                  style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 100%;"
                 >
                   <div
                     class="Mask circle willChangeTransform"
                   >
                     <div
                       class="box relative"
-                      style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                      style="padding-bottom: 100%;"
                     >
                       <img
                         alt="Keerthi"
@@ -496,14 +496,14 @@ exports[`AvatarGroup renders md display-only AvatarGroup with image 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 48px; height: 48px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 48px; height: 48px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"
@@ -553,14 +553,14 @@ exports[`AvatarGroup renders sm display-only AvatarGroup with image 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 32px; height: 32px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 32px; height: 32px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"
@@ -610,14 +610,14 @@ exports[`AvatarGroup renders xs display-only AvatarGroup with image 1`] = `
               <div
                 class="box circle relative"
                 data-test-id="gestalt-avatar-svg"
-                style="box-shadow: 0 0 0 1px #fff; width: 24px; height: 24px;"
+                style="box-shadow: 0 0 0 1px var(--color-border-avatar); width: 24px; height: 24px;"
               >
                 <div
                   class="Mask circle willChangeTransform"
                 >
                   <div
                     class="box relative"
-                    style="background-color: rgb(239, 239, 239); padding-bottom: 100%;"
+                    style="padding-bottom: 100%;"
                   >
                     <img
                       alt="Keerthi"

--- a/packages/gestalt/src/__snapshots__/Tag.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Tag.test.js.snap
@@ -138,7 +138,7 @@ exports[`Tag renders a disabled tag 1`] = `
   className="box paddingX2 paddingY1 relative rounding2 secondary xsDisplayInlineBlock"
   style={
     Object {
-      "border": "solid 1px #767676",
+      "border": "solid 1px var(--color-border-tag-disabled)",
       "height": 32,
       "maxWidth": 300,
     }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -16,7 +16,7 @@ import layoutStyles from '../Layout.css';
 export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
 export type Theme = {
-  name: 'lightMode' | 'darkMode',
+  colorSchemeName: 'lightMode' | 'darkMode',
   colorGray0: string,
   colorGray50: string,
   colorGray100: string,
@@ -29,7 +29,7 @@ export type Theme = {
 };
 
 const lightModeTheme = {
-  name: 'lightMode',
+  colorSchemeName: 'lightMode',
   colorGray0: '#fff',
   colorGray50: '#fff',
   colorGray100: '#efefef',
@@ -41,7 +41,7 @@ const lightModeTheme = {
 };
 
 const darkModeTheme = {
-  name: 'darkMode',
+  colorSchemeName: 'darkMode',
   colorGray0: '#030303',
   colorGray50: '#212121',
   colorGray100: '#404040',
@@ -66,7 +66,7 @@ const themeToStyles = (theme: {
   colorGray400: string,
   colorGray50: string,
   colorTransparentGray60: string,
-  name: string,
+  colorSchemeName: 'lightMode' | 'darkMode',
 }) => {
   let styles = '';
   Object.keys(theme).forEach((key) => {
@@ -74,12 +74,12 @@ const themeToStyles = (theme: {
       styles += `  --g-${key}: ${theme[key]};\n`;
     }
   });
-  if (theme.name === 'darkMode') {
+  if (theme.colorSchemeName === 'darkMode') {
     Object.keys(darkColorDesignTokens).forEach((key) => {
       styles += `  --${key}: ${darkColorDesignTokens[key]};\n`;
     });
   }
-  if (theme.name === 'lightMode') {
+  if (theme.colorSchemeName === 'lightMode') {
     Object.keys(lightColorDesignTokens).forEach((key) => {
       styles += `  --${key}: ${lightColorDesignTokens[key]};\n`;
     });
@@ -172,8 +172,8 @@ ${themeToStyles(theme)} }`,
 }
 
 export function useColorScheme(): {
-  name: 'lightMode' | 'darkMode',
+  colorSchemeName: 'lightMode' | 'darkMode',
 } {
-  const { name } = useContext(ThemeContext);
-  return { name };
+  const { colorSchemeName } = useContext(ThemeContext);
+  return { colorSchemeName };
 }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.js
@@ -17,7 +17,6 @@ export type ColorScheme = 'light' | 'dark' | 'userPreference';
 
 export type Theme = {
   name: 'lightMode' | 'darkMode',
-  colorRed100Hovered: string,
   colorGray0: string,
   colorGray50: string,
   colorGray100: string,
@@ -26,13 +25,11 @@ export type Theme = {
   colorGray300: string,
   colorGray400: string,
   colorTransparentGray60: string,
-  colorTransparentGray100: string,
   [tokenName: string]: string,
 };
 
 const lightModeTheme = {
   name: 'lightMode',
-  colorRed100Hovered: '#ad081b',
   colorGray0: '#fff',
   colorGray50: '#fff',
   colorGray100: '#efefef',
@@ -41,12 +38,10 @@ const lightModeTheme = {
   colorGray300: '#111',
   colorGray400: '#000',
   colorTransparentGray60: 'rgb(0 0 0 / 0.06)',
-  colorTransparentGray100: 'rgb(0 0 0 / 0.1)',
 };
 
 const darkModeTheme = {
   name: 'darkMode',
-  colorRed100Hovered: '#cf001f',
   colorGray0: '#030303',
   colorGray50: '#212121',
   colorGray100: '#404040',
@@ -55,7 +50,6 @@ const darkModeTheme = {
   colorGray300: '#efefef',
   colorGray400: '#fff',
   colorTransparentGray60: 'rgb(250 250 250 / 0.5)',
-  colorTransparentGray100: 'rgb(250 250 250 / 0.6)',
 };
 
 const ThemeContext: Context<Theme> = createContext<Theme>(lightModeTheme);
@@ -71,8 +65,6 @@ const themeToStyles = (theme: {
   colorGray300: string,
   colorGray400: string,
   colorGray50: string,
-  colorRed100Hovered: string,
-  colorTransparentGray100: string,
   colorTransparentGray60: string,
   name: string,
 }) => {
@@ -179,7 +171,9 @@ ${themeToStyles(theme)} }`,
   );
 }
 
-export function useColorScheme(): Theme {
-  const theme = useContext(ThemeContext);
-  return theme || lightModeTheme;
+export function useColorScheme(): {
+  name: 'lightMode' | 'darkMode',
+} {
+  const { name } = useContext(ThemeContext);
+  return { name };
 }

--- a/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
+++ b/packages/gestalt/src/contexts/ColorSchemeProvider.jsdom.test.js
@@ -4,7 +4,7 @@ import ColorSchemeProvider, { useColorScheme } from './ColorSchemeProvider';
 
 function ThemeAwareComponent() {
   const theme = useColorScheme();
-  return <div>{theme.name}</div>;
+  return <div>{theme.colorSchemeName}</div>;
 }
 
 describe('ColorSchemeProvider', () => {

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -3,7 +3,6 @@
 exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = `
 <style>
   :root {
-  --g-colorRed100Hovered: #cf001f;
   --g-colorGray0: #030303;
   --g-colorGray50: #212121;
   --g-colorGray100: #404040;
@@ -12,7 +11,6 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --g-colorGray300: #efefef;
   --g-colorGray400: #fff;
   --g-colorTransparentGray60: rgb(250 250 250 / 0.5);
-  --g-colorTransparentGray100: rgb(250 250 250 / 0.6);
   --color-data-visualization-10: #007A72;
   --color-data-visualization-11: #f76593;
   --color-data-visualization-12: #ffc58f;
@@ -71,6 +69,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
+  --color-background-avatar: #404040;
   --color-background-badge-neutral: #cdcdcd;
   --color-background-badge-info-default: #75bfff;
   --color-background-badge-info-hover: #abdbff;
@@ -161,6 +160,10 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-border-container: #767676;
   --color-border-default: #cdcdcd;
   --color-border-error: #f47171;
+  --color-border-avatar: #030303;
+  --color-border-formfield-error-default: #f47171;
+  --color-border-formfield-error-hover: #cf001f;
+  --color-border-tag-disabled: #ababab;
   --elevation-floating: none;
   --elevation-raised-top: 0 0.5px 0 #f9f9f9;
   --elevation-raised-bottom: 0 -0.5px 0 #f9f9f9;
@@ -172,7 +175,6 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
 exports[`ColorSchemeProvider renders styling for light mode when no color scheme specified 1`] = `
 <style>
   :root {
-  --g-colorRed100Hovered: #ad081b;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -181,7 +183,6 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --g-colorGray300: #111;
   --g-colorGray400: #000;
   --g-colorTransparentGray60: rgb(0 0 0 / 0.06);
-  --g-colorTransparentGray100: rgb(0 0 0 / 0.1);
   --color-data-visualization-10: #005062;
   --color-data-visualization-11: #de2c62;
   --color-data-visualization-12: #660e00;
@@ -240,6 +241,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
+  --color-background-avatar: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -330,6 +332,10 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-border-container: #cdcdcd;
   --color-border-default: #767676;
   --color-border-error: #cc0000;
+  --color-border-avatar: #ffffff;
+  --color-border-formfield-error-default: #cc0000;
+  --color-border-formfield-error-hover: #ad081b;
+  --color-border-tag-disabled: #767676;
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
@@ -341,7 +347,6 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
 exports[`ColorSchemeProvider renders styling for light mode when specified 1`] = `
 <style>
   :root {
-  --g-colorRed100Hovered: #ad081b;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -350,7 +355,6 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --g-colorGray300: #111;
   --g-colorGray400: #000;
   --g-colorTransparentGray60: rgb(0 0 0 / 0.06);
-  --g-colorTransparentGray100: rgb(0 0 0 / 0.1);
   --color-data-visualization-10: #005062;
   --color-data-visualization-11: #de2c62;
   --color-data-visualization-12: #660e00;
@@ -409,6 +413,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
+  --color-background-avatar: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -499,6 +504,10 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-border-container: #cdcdcd;
   --color-border-default: #767676;
   --color-border-error: #cc0000;
+  --color-border-avatar: #ffffff;
+  --color-border-formfield-error-default: #cc0000;
+  --color-border-formfield-error-hover: #ad081b;
+  --color-border-tag-disabled: #767676;
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
@@ -510,7 +519,6 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
 exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`] = `
 <style>
   .__gestaltThemetestId {
-  --g-colorRed100Hovered: #ad081b;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -519,7 +527,6 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --g-colorGray300: #111;
   --g-colorGray400: #000;
   --g-colorTransparentGray60: rgb(0 0 0 / 0.06);
-  --g-colorTransparentGray100: rgb(0 0 0 / 0.1);
   --color-data-visualization-10: #005062;
   --color-data-visualization-11: #de2c62;
   --color-data-visualization-12: #660e00;
@@ -578,6 +585,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
+  --color-background-avatar: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -668,6 +676,10 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-border-container: #cdcdcd;
   --color-border-default: #767676;
   --color-border-error: #cc0000;
+  --color-border-avatar: #ffffff;
+  --color-border-formfield-error-default: #cc0000;
+  --color-border-formfield-error-hover: #ad081b;
+  --color-border-tag-disabled: #767676;
   --elevation-floating: 0 0 8px rgb(0 0 0 / 0.10);
   --elevation-raised-top: 0 2px 8px rgb(0 0 0 / 0.12);
   --elevation-raised-bottom: 0 -2px 8px rgb(0 0 0 / 0.12);
@@ -680,7 +692,6 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
 <style>
   @media(prefers-color-scheme: dark) {
   :root {
-  --g-colorRed100Hovered: #cf001f;
   --g-colorGray0: #030303;
   --g-colorGray50: #212121;
   --g-colorGray100: #404040;
@@ -689,7 +700,6 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --g-colorGray300: #efefef;
   --g-colorGray400: #fff;
   --g-colorTransparentGray60: rgb(250 250 250 / 0.5);
-  --g-colorTransparentGray100: rgb(250 250 250 / 0.6);
   --color-data-visualization-10: #007A72;
   --color-data-visualization-11: #f76593;
   --color-data-visualization-12: #ffc58f;
@@ -748,6 +758,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
+  --color-background-avatar: #404040;
   --color-background-badge-neutral: #cdcdcd;
   --color-background-badge-info-default: #75bfff;
   --color-background-badge-info-hover: #abdbff;
@@ -838,6 +849,10 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-border-container: #767676;
   --color-border-default: #cdcdcd;
   --color-border-error: #f47171;
+  --color-border-avatar: #030303;
+  --color-border-formfield-error-default: #f47171;
+  --color-border-formfield-error-hover: #cf001f;
+  --color-border-tag-disabled: #ababab;
   --elevation-floating: none;
   --elevation-raised-top: 0 0.5px 0 #f9f9f9;
   --elevation-raised-bottom: 0 -0.5px 0 #f9f9f9;

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = `
 <style>
   :root {
+  --g-colorSchemeName: darkMode;
   --g-colorGray0: #030303;
   --g-colorGray50: #212121;
   --g-colorGray100: #404040;
@@ -175,6 +176,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
 exports[`ColorSchemeProvider renders styling for light mode when no color scheme specified 1`] = `
 <style>
   :root {
+  --g-colorSchemeName: lightMode;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -347,6 +349,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
 exports[`ColorSchemeProvider renders styling for light mode when specified 1`] = `
 <style>
   :root {
+  --g-colorSchemeName: lightMode;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -519,6 +522,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
 exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`] = `
 <style>
   .__gestaltThemetestId {
+  --g-colorSchemeName: lightMode;
   --g-colorGray0: #fff;
   --g-colorGray50: #fff;
   --g-colorGray100: #efefef;
@@ -692,6 +696,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
 <style>
   @media(prefers-color-scheme: dark) {
   :root {
+  --g-colorSchemeName: darkMode;
   --g-colorGray0: #030303;
   --g-colorGray50: #212121;
   --g-colorGray100: #404040;

--- a/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
+++ b/packages/gestalt/src/contexts/__snapshots__/ColorSchemeProvider.jsdom.test.js.snap
@@ -70,7 +70,7 @@ exports[`ColorSchemeProvider renders styling for dark mode when specified 1`] = 
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
-  --color-background-avatar: #404040;
+  --color-background-avatar-placeholder: #404040;
   --color-background-badge-neutral: #cdcdcd;
   --color-background-badge-info-default: #75bfff;
   --color-background-badge-info-hover: #abdbff;
@@ -243,7 +243,7 @@ exports[`ColorSchemeProvider renders styling for light mode when no color scheme
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
-  --color-background-avatar: #efefef;
+  --color-background-avatar-placeholder: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -416,7 +416,7 @@ exports[`ColorSchemeProvider renders styling for light mode when specified 1`] =
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
-  --color-background-avatar: #efefef;
+  --color-background-avatar-placeholder: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -589,7 +589,7 @@ exports[`ColorSchemeProvider renders styling with a custom class if has an id 1`
   --color-background-elevation-accent: #f1f1f1;
   --color-background-elevation-floating: rgba(0, 0, 0, 0);
   --color-background-elevation-raised: rgba(0, 0, 0, 0);
-  --color-background-avatar: #efefef;
+  --color-background-avatar-placeholder: #efefef;
   --color-background-badge-neutral: #767676;
   --color-background-badge-info-default: #0074e8;
   --color-background-badge-info-hover: #005fcb;
@@ -763,7 +763,7 @@ exports[`ColorSchemeProvider renders styling with media query when userPreferenc
   --color-background-elevation-accent: #191919;
   --color-background-elevation-floating: #2b2b2b;
   --color-background-elevation-raised: #4a4a4a;
-  --color-background-avatar: #404040;
+  --color-background-avatar-placeholder: #404040;
   --color-background-badge-neutral: #cdcdcd;
   --color-background-badge-info-default: #75bfff;
   --color-background-badge-info-hover: #abdbff;

--- a/packages/gestalt/src/shared/FormElement.css
+++ b/packages/gestalt/src/shared/FormElement.css
@@ -15,7 +15,7 @@
 }
 
 .errored {
-  composes: borderColorRed from "../Borders.css";
+  border-color: var(--color-border-formfield-error-default);
   outline: none;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .errored:hover:not(:focus) {
-  border-color: var(--g-colorRed100Hovered);
+  border-color: var(--color-border-formfield-error-hover);
 }
 
 .enabled {


### PR DESCRIPTION
### Breaking change

Replace 

`  const { name } = useColorScheme();
`
with

`  const { colorSchemeName } = useColorScheme();
`

Look for useColorScheme and replace all color instances with custom colors.


#### What changed?

ColorSchemeProvider, Avatar, Tag, Textfield: deprecate legacy colors from provider + tokenize background and border colors



