### PR TITLE
Popover: Add `hideWhenReferenceHidden` prop

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   "grunt.autoDetect": "off",
   "javascript.validate.enable": false,
   "npm.packageManager": "yarn",
-  "typescript.validate.enable": true
+  "typescript.validate.enable": true,
+  "testing.openTesting": "neverOpen"
 }

--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -22,7 +22,7 @@ const enabledExperiments = {
     'web_gestalt_popover_v2_popovereducational',
     'mweb_gestalt_popover_v2_popovereducational',
   ],
-  Tooltip: ['web_gestalt_popover_v2_tooltip', 'mweb_gestalt_popover_v2_tooltip'],
+  Tooltip: ['web_gestalt_tooltip_v2', 'mweb_gestalt_tooltip_v2'],
 };
 
 type Experiment = { anyEnabled: boolean, group: string };

--- a/docs/examples/popover/main.js
+++ b/docs/examples/popover/main.js
@@ -45,6 +45,7 @@ export default function Example(): ReactNode {
           idealDirection="forceDown"
           onDismiss={() => setOpen(false)}
           size="xl"
+          disablePortal={false}
           showDismissButton
         >
           <Box width={300}>

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -151,6 +151,12 @@ type Props = {
    * An object representing the zIndex value of the ComboBox list box. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
+  /**
+   * *EXPERIMENTAL:* Whether to hide ComboBox when reference element gets out of viewport.
+   */
+  hideWhenReferenceHidden?: boolean,
+  // Whether to trap focus inside ComboBox when opened.
+  __disableFocusTrap?: boolean,
 };
 
 /**
@@ -188,6 +194,8 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
     selectedOption,
     tags,
     zIndex,
+    hideWhenReferenceHidden = true,
+    __disableFocusTrap,
   }: Props,
   ref,
 ): ReactNode {
@@ -507,6 +515,8 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
             shouldFocus={false}
             role="dialog"
             color="white"
+            hideWhenReferenceHidden={hideWhenReferenceHidden}
+            disableFocusTrap={__disableFocusTrap}
           >
             <Box
               aria-expanded={showOptionsList}

--- a/packages/gestalt/src/ComboBox.jsdom.test.js
+++ b/packages/gestalt/src/ComboBox.jsdom.test.js
@@ -114,6 +114,8 @@ describe('ComboBox', () => {
         selectedOption={selectedOption}
         size={size}
         tags={tags}
+        hideWhenReferenceHidden={false} // Disabling as Popover uses IntersectionObserver which is not supported by testing-library
+        __disableFocusTrap // Disabling for testing purposes as focus trap makes other elements inaccessible
       />,
     );
   describe('Uncontrolled ComboBox', () => {
@@ -169,20 +171,19 @@ describe('ComboBox', () => {
 
       await userEvent.type(screen.getByLabelText(LABEL), input1);
 
-      // The element is hidden as Popover uses IntersectionObserver which is not supported by testing-library
-      expect(screen.getAllByRole('option', { hidden: true }).length).toBe(
+      expect(screen.getAllByRole('option').length).toBe(
         PRONOUNS.filter((x) => x.includes(input1)).length,
       );
 
       await userEvent.type(screen.getByDisplayValue(input1), input2);
 
-      expect(screen.getAllByRole('option', { hidden: true }).length).toBe(
+      expect(screen.getAllByRole('option').length).toBe(
         PRONOUNS.filter((x) => x.includes(input1 + input2)).length,
       );
 
       await userEvent.type(screen.getByDisplayValue(input1 + input2), input3);
 
-      expect(screen.getAllByRole('option', { hidden: true }).length).toBe(
+      expect(screen.getAllByRole('option').length).toBe(
         PRONOUNS.filter((x) => x.includes(input1)).length,
       );
     });
@@ -242,7 +243,7 @@ describe('ComboBox', () => {
       await userEvent.tab();
 
       // The element is hidden as Popover uses IntersectionObserver which is not supported by testing-library
-      await userEvent.type(screen.getByRole('button', { name: CLEAR, hidden: true }), ENTER);
+      await userEvent.type(screen.getByRole('button', { name: CLEAR }), ENTER);
 
       expect(screen.getByDisplayValue(EMPTY_STRING)).toBeVisible();
 
@@ -252,7 +253,7 @@ describe('ComboBox', () => {
 
       await userEvent.tab();
 
-      await userEvent.type(screen.getByRole('button', { name: CLEAR, hidden: true }), SPACE);
+      await userEvent.type(screen.getByRole('button', { name: CLEAR }), SPACE);
 
       expect(screen.getByDisplayValue(EMPTY_STRING)).toBeVisible();
     });
@@ -273,9 +274,9 @@ describe('ComboBox', () => {
       await userEvent.tab();
 
       // The element is hidden as Popover uses IntersectionObserver which is not supported by testing-library
-      expect(screen.getByRole('button', { name: CLEAR, hidden: true })).toHaveFocus();
+      expect(screen.getByRole('button', { name: CLEAR })).toHaveFocus();
 
-      fireEvent.click(screen.getByRole('button', { name: CLEAR, hidden: true }));
+      fireEvent.click(screen.getByRole('button', { name: CLEAR }));
 
       expect(screen.getByLabelText(LABEL)).toHaveFocus();
 
@@ -296,7 +297,7 @@ describe('ComboBox', () => {
       await userEvent.tab();
 
       // The element is hidden as Popover uses IntersectionObserver which is not supported by testing-library
-      expect(screen.getByRole('button', { name: CLEAR, hidden: true })).toBeVisible();
+      expect(screen.getByRole('button', { name: CLEAR })).toBeVisible();
     });
   });
 
@@ -335,7 +336,7 @@ describe('ComboBox', () => {
       fireEvent.click(screen.getByDisplayValue(input1));
 
       // The element is hidden as Popover uses IntersectionObserver which is not supported by testing-library
-      expect(screen.getByRole('button', { name: CLEAR, hidden: true })).toBeVisible();
+      expect(screen.getByRole('button', { name: CLEAR })).toBeVisible();
       expect(screen.getAllByRole('option').length).toBe(controlledOptionsLength);
       expect(screen.getByText(PRONOUNS[1])).toBeVisible();
     });

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -142,6 +142,12 @@ type Props = {
    * An object representing the zIndex value of the Dropdown menu. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
+  /**
+   * *EXPERIMENTAL:* Whether to hide Dropdown when reference element gets out of viewport.
+   */
+  hideWhenReferenceHidden?: boolean,
+  // Whether to trap focus inside Dropdown when opened.
+  __disableFocusTrap?: boolean,
 };
 
 /**
@@ -163,6 +169,8 @@ export default function Dropdown({
   maxHeight,
   mobileOnAnimationEnd,
   disableMobileUI = false,
+  hideWhenReferenceHidden = true,
+  __disableFocusTrap,
 }: Props): ReactNode {
   const [isPopoverPositioned, setIsPopoverPositioned] = useState(false);
   const deviceType = useDeviceType();
@@ -280,12 +288,14 @@ export default function Dropdown({
       id={id}
       idealDirection={idealDirection}
       onDismiss={onDismiss}
-      disablePortal={isWithinFixedContainer}
+      disablePortal
       role="menu"
       shouldFocus
       size="xl"
       onPositioned={() => setIsPopoverPositioned(true)}
       showCaret={false}
+      hideWhenReferenceHidden={hideWhenReferenceHidden}
+      disableFocusTrap={__disableFocusTrap}
     >
       <Box
         alignItems="center"

--- a/packages/gestalt/src/HelpButton.js
+++ b/packages/gestalt/src/HelpButton.js
@@ -84,6 +84,12 @@ type Props = {
    * Specifies the z-index for HelpButton's tooltip and popover to resolve any layering issues with other elements. See the [zIndex variant](https://gestalt.pinterest.systems/web/helpbutton#With-Z-index) for more details.
    */
   zIndex?: Indexable,
+  /**
+   * *EXPERIMENTAL:* Whether to hide HelpButton when reference element gets out of viewport.
+   */
+  hideWhenReferenceHidden?: boolean,
+  // Whether to trap focus inside HelpButton when opened.
+  __disableFocusTrap?: boolean,
 };
 
 /**
@@ -98,6 +104,8 @@ export default function HelpButton({
   onClick,
   text,
   zIndex,
+  hideWhenReferenceHidden = true,
+  __disableFocusTrap,
 }: Props): ReactNode {
   const tapAreaRef = useRef<null | HTMLAnchorElement | HTMLDivElement>(null);
   const textRef = useRef<null | HTMLElement>(null);
@@ -192,6 +200,8 @@ export default function HelpButton({
       role="dialog"
       color="white"
       size="sm"
+      hideWhenReferenceHidden={hideWhenReferenceHidden}
+      disableFocusTrap={__disableFocusTrap}
     >
       <Box padding={5} rounding={4} height="auto">
         {/*

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -78,13 +78,15 @@ type Props = {
    */
   scrollBoundary?: HTMLElement,
   /**
-   * *EXPERIMENTAL:* Whether to hide Popover when reference element gets out of viewport.
+   * *EXPERIMENTAL:* Whether to hide Popover when reference element gets out of viewport. Default: true
    */
   hideWhenReferenceHidden?: boolean,
   // This property can be set when `ScrollBoundaryContainer` is set to `overflow="visible"` but therefore limits the height of the Popover-based component. Some cases require
   __dangerouslySetMaxHeight?: '30vh',
   // Callback fired when Popover is correctly positioned after it's mounted.
   __onPositioned?: () => void,
+  // Whether to trap focus inside Popover when opened.
+  __disableFocusTrap?: boolean,
 };
 
 /**
@@ -114,9 +116,10 @@ export default function Popover({
   _deprecatedShowCaret = false,
   size = 'sm',
   scrollBoundary,
-  hideWhenReferenceHidden,
+  hideWhenReferenceHidden = true,
   __dangerouslySetMaxHeight,
   __onPositioned,
+  __disableFocusTrap,
 }: Props): null | ReactNode {
   const isInExperiment = useInExperiment({
     webExperimentName: 'web_gestalt_popover_v2',
@@ -166,6 +169,7 @@ export default function Popover({
       scrollBoundary={scrollBoundary}
       hideWhenReferenceHidden={hideWhenReferenceHidden}
       onPositioned={__onPositioned}
+      disableFocusTrap={__disableFocusTrap}
     >
       {children}
     </InternalPopover>

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -78,7 +78,7 @@ type Props = {
    */
   scrollBoundary?: HTMLElement,
   /**
-   * *EXPERIMENTAL:* Whether to hide Popover when reference element gets out of viewport. Default: true
+   * *EXPERIMENTAL:* Whether to hide Popover when reference element gets out of viewport.
    */
   hideWhenReferenceHidden?: boolean,
   // This property can be set when `ScrollBoundaryContainer` is set to `overflow="visible"` but therefore limits the height of the Popover-based component. Some cases require

--- a/packages/gestalt/src/Popover/Contents.js
+++ b/packages/gestalt/src/Popover/Contents.js
@@ -29,6 +29,7 @@ type Props = {
   scrollBoundary?: HTMLElement,
   hideWhenReferenceHidden?: boolean,
   onPositioned?: () => void,
+  shouldTrapFocus?: boolean,
 };
 
 export default function Contents({
@@ -46,8 +47,9 @@ export default function Contents({
   shouldFocus = true,
   onKeyDown,
   scrollBoundary,
-  hideWhenReferenceHidden = true,
+  hideWhenReferenceHidden,
   onPositioned,
+  shouldTrapFocus,
 }: Props): ReactNode {
   const caretRef = useRef<HTMLElement | null>(null);
   const idealPlacement = idealDirection ? DIRECTIONS_MAP[idealDirection] : 'top';
@@ -87,7 +89,7 @@ export default function Contents({
   }, [onKeyDown]);
 
   return (
-    <FloatingFocusManager context={context} returnFocus={false}>
+    <FloatingFocusManager context={context} modal={shouldTrapFocus ?? false}>
       <div
         ref={refs.setFloating}
         tabIndex={-1}

--- a/packages/gestalt/src/Popover/Controller.js
+++ b/packages/gestalt/src/Popover/Controller.js
@@ -32,6 +32,7 @@ type Props = {
   scrollBoundary?: HTMLElement,
   hideWhenReferenceHidden?: boolean,
   onPositioned?: () => void,
+  shouldTrapFocus?: boolean,
 };
 
 export default function Controller({
@@ -53,6 +54,7 @@ export default function Controller({
   scrollBoundary,
   hideWhenReferenceHidden,
   onPositioned,
+  shouldTrapFocus,
 }: Props): ReactNode {
   const width = typeof size === 'string' ? SIZE_WIDTH_MAP[size] : size;
 
@@ -87,6 +89,7 @@ export default function Controller({
         scrollBoundary={scrollBoundary}
         hideWhenReferenceHidden={hideWhenReferenceHidden}
         onPositioned={onPositioned}
+        shouldTrapFocus={shouldTrapFocus}
       >
         {children}
       </Contents>

--- a/packages/gestalt/src/Popover/InternalPopover.js
+++ b/packages/gestalt/src/Popover/InternalPopover.js
@@ -29,6 +29,7 @@ type Props = {
   scrollBoundary?: HTMLElement,
   hideWhenReferenceHidden?: boolean,
   onPositioned?: () => void,
+  disableFocusTrap?: boolean,
 };
 
 export default function InternalPopover({
@@ -50,6 +51,7 @@ export default function InternalPopover({
   scrollBoundary,
   hideWhenReferenceHidden,
   onPositioned,
+  disableFocusTrap,
 }: Props): null | ReactNode {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
@@ -82,6 +84,7 @@ export default function InternalPopover({
       disablePortal={disablePortal}
       hideWhenReferenceHidden={hideWhenReferenceHidden}
       onPositioned={onPositioned}
+      shouldTrapFocus={!disableFocusTrap}
     >
       {showDismissButton ? (
         <Flex direction="column">

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -114,6 +114,10 @@ type Props = {
    * An object representing the zIndex value of PopoverEducational. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable,
+  /**
+   * *EXPERIMENTAL:* Whether to hide PopoverEducational when reference element gets out of viewport.
+   */
+  hideWhenReferenceHidden?: boolean,
 };
 
 /**
@@ -134,6 +138,7 @@ export default function PopoverEducational({
   shouldFocus = false,
   size = 'sm',
   zIndex,
+  hideWhenReferenceHidden = true,
 }: Props): ReactNode {
   const { name: colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
@@ -175,6 +180,8 @@ export default function PopoverEducational({
         shouldFocus={shouldFocus}
         role={primaryAction && !children ? 'dialog' : role}
         size={size}
+        hideWhenReferenceHidden={hideWhenReferenceHidden}
+        disableFocusTrap // PopoverEducational is a part of the content and should not trap focus in itself
       >
         {children ??
           (message ? (

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -32,6 +32,10 @@ type Props = {
    * Specifies the stacking order of Tooltip along the z-axis in the current stacking context. See the [z-index](https://gestalt.pinterest.systems/web/tooltip#Z-index) variant to learn more.
    */
   zIndex?: Indexable,
+  /**
+   * *EXPERIMENTAL:* Whether to hide Tooltip when reference element gets out of viewport.
+   */
+  hideWhenReferenceHidden?: boolean,
 };
 
 /**
@@ -50,6 +54,7 @@ export default function Tooltip({
   inline,
   text,
   zIndex,
+  hideWhenReferenceHidden,
 }: Props): ReactNode {
   return (
     <InternalTooltip
@@ -59,6 +64,7 @@ export default function Tooltip({
       inline={inline}
       text={text}
       zIndex={zIndex}
+      hideWhenReferenceHidden={hideWhenReferenceHidden}
     >
       {children}
     </InternalTooltip>

--- a/packages/gestalt/src/Tooltip.js
+++ b/packages/gestalt/src/Tooltip.js
@@ -54,7 +54,7 @@ export default function Tooltip({
   inline,
   text,
   zIndex,
-  hideWhenReferenceHidden,
+  hideWhenReferenceHidden = true,
 }: Props): ReactNode {
   return (
     <InternalTooltip

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -64,6 +64,7 @@ type Props = {
   link?: ReactNode,
   text: string | $ReadOnlyArray<string>,
   zIndex?: Indexable,
+  hideWhenReferenceHidden?: boolean,
 };
 
 export default function InternalTooltip({
@@ -75,6 +76,7 @@ export default function InternalTooltip({
   inline,
   text,
   zIndex,
+  hideWhenReferenceHidden,
 }: Props): ReactNode {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { isOpen } = state;
@@ -156,6 +158,7 @@ export default function InternalTooltip({
               rounding={2}
               size={null}
               shouldFocus={false}
+              hideWhenReferenceHidden={hideWhenReferenceHidden}
             >
               <Box
                 maxWidth={180}

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.js.snap
@@ -7,13 +7,7 @@ exports[`Dropdown renders a menu of 3 items conditionally 1`] = `
     data-floating-ui-inert=""
   />
   <div
-    aria-hidden="true"
     class=""
-    data-floating-ui-inert=""
-  />
-  <div
-    data-floating-ui-portal=""
-    id=":r2:"
   >
     <div>
       <span
@@ -568,13 +562,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
     data-floating-ui-inert=""
   />
   <div
-    aria-hidden="true"
     class=""
-    data-floating-ui-inert=""
-  />
-  <div
-    data-floating-ui-portal=""
-    id=":r0:"
   >
     <div>
       <span

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -8,15 +8,6 @@ exports[`PopoverEducational renders correctly 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
@@ -81,15 +72,6 @@ exports[`PopoverEducational renders correctly 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>
@@ -101,15 +83,6 @@ exports[`PopoverEducational renders correctly with custom children 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
@@ -142,15 +115,6 @@ exports[`PopoverEducational renders correctly with custom children 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>

--- a/packages/gestalt/src/__snapshots__/PopoverEducational.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PopoverEducational.jsdom.test.js.snap
@@ -6,15 +6,6 @@ exports[`PopoverEducational renders 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
@@ -79,15 +70,6 @@ exports[`PopoverEducational renders 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Summary

- Added `hideWhenReferenceHidden` prop to Popover, Tooltip, ComboBox, Dropdown, HelpButton and PopoverEducational.
- Added internal `__disableFocusTrap` prop to Popover, ComboBox, Dropdown and HelpButton.
- Fixed double portalling issue with Dropdown. [Slack discussion](https://pinterest.slack.com/archives/C13KLG5P0/p1708465918425379).

#### What changed?

The default value of `hideWhenReferenceHidden` (true) is now passed in at the component props level. Previously it was passed at `Contents` component level. This change makes it more obvious how the components behave. The default value now also displayed in the docs.

#### Why?

`__disableFocusTrap` prop was added mainly to control the components during unit tests. By default Popover traps the focus and makes other elements inaccessible. `testing-library/react` queries do not work with inaccessible elements.

`hideWhenReferenceHidden` prop also helps to control test cases as `testing-library/react` doesn't provide actual DOM behaviors for autohide feature to work properly.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-7570)

### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
