### PR TITLE
ComboBox, Dropdown, HelpButton: Disable internal Popover portal

### DIFF
--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -509,7 +509,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
             onKeyDown={handleKeyDown}
             idealDirection="down"
             onDismiss={handleOnDismiss}
-            positionRelativeToAnchor={false}
+            disablePortal
             size="flexible"
             key={isInExperiment ? undefined : suggestedOptions.length}
             shouldFocus={false}

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -509,6 +509,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
             onKeyDown={handleKeyDown}
             idealDirection="down"
             onDismiss={handleOnDismiss}
+            positionRelativeToAnchor={false}
             disablePortal
             size="flexible"
             key={isInExperiment ? undefined : suggestedOptions.length}

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -288,6 +288,7 @@ export default function Dropdown({
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={isWithinFixedContainer}
+      disablePortal={isInExperiment}
       role="menu"
       shouldFocus
       size="xl"

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -288,7 +288,7 @@ export default function Dropdown({
       idealDirection={idealDirection}
       onDismiss={onDismiss}
       positionRelativeToAnchor={isWithinFixedContainer}
-      disablePortal={isInExperiment}
+      disablePortal
       role="menu"
       shouldFocus
       size="xl"

--- a/packages/gestalt/src/HelpButton.js
+++ b/packages/gestalt/src/HelpButton.js
@@ -194,6 +194,7 @@ export default function HelpButton({
       onKeyDown={handlePopoverKeyDown}
       idealDirection={idealDirection}
       positionRelativeToAnchor={isWithinFixedContainer}
+      disablePortal
     >
       <Box padding={5} rounding={4} height="auto">
         {/*

--- a/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
+++ b/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
@@ -90,6 +90,7 @@ export default function ConfirmationPopover({
       idealDirection="down"
       onDismiss={() => onDismiss()}
       positionRelativeToAnchor
+      disablePortal
       role="dialog"
       size="md"
     >


### PR DESCRIPTION
### Summary

Popover v2 has built-in portalling feature. But it doesn't support z-index yet.
ComboBox, Dropdown and HelpButton control portalling themselves with Layer which supports z-index.

Basically here we were having 2 nested React.Portals. (Floating UI) Popover's internal portal is conflicting with Gestalt Layer and rendering itself outside of Layer (which leaves Layer empty and useless). That's why Layer's zIndex prop has no effect on the rendered Popover, as it would be in a different Portal.

This confusion will be eliminated as soon as the legacy Popover code is removed. The purpose of introducing internal Portal for Popover was to deprecate using Layer + Popover combination for internal usages.

#### Why?

Bug was reported in [Slack](https://pinterest.slack.com/archives/C13KLG5P0/p1708465918425379)

### Links

- [Popover TDD](https://docs.google.com/document/d/1GPzNVK9X-A06PgOh5Ha3ncRFb27Cxl0RRBckauFRaZ8/edit?usp=sharing)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
