### PR TITLE
Popover, Dropdown, ComboBox, Tooltip: Disable focus trap for Tooltip + fixed a11y in Dropdown, ComboBox

### DIFF
--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -22,7 +22,7 @@ const enabledExperiments = {
     'web_gestalt_popover_v2_popovereducational',
     'mweb_gestalt_popover_v2_popovereducational',
   ],
-  Tooltip: ['web_gestalt_popover_v2_tooltip', 'mweb_gestalt_popover_v2_tooltip'],
+  Tooltip: ['web_gestalt_tooltip_v2', 'mweb_gestalt_tooltip_v2'],
 };
 
 type Experiment = { anyEnabled: boolean, group: string };

--- a/packages/gestalt/src/Popover.js
+++ b/packages/gestalt/src/Popover.js
@@ -116,7 +116,7 @@ export default function Popover({
   _deprecatedShowCaret = false,
   size = 'sm',
   scrollBoundary,
-  hideWhenReferenceHidden,
+  hideWhenReferenceHidden = true,
   __dangerouslySetMaxHeight,
   __experimentalPopover,
   __onPositioned,

--- a/packages/gestalt/src/Popover/Contents.js
+++ b/packages/gestalt/src/Popover/Contents.js
@@ -143,10 +143,13 @@ export default function Contents({
     </div>
   );
 
-  return role === 'tooltip' ? (
-    contents
-  ) : (
-    <FloatingFocusManager context={context} returnFocus={false} modal={shouldTrapFocus ?? false}>
+  return (
+    <FloatingFocusManager
+      disabled={role === 'tooltip'}
+      context={context}
+      returnFocus={false}
+      modal={shouldTrapFocus ?? false}
+    >
       {contents}
     </FloatingFocusManager>
   );

--- a/packages/gestalt/src/Popover/Contents.js
+++ b/packages/gestalt/src/Popover/Contents.js
@@ -88,61 +88,6 @@ export default function Contents({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [onKeyDown]);
 
-  const contents = (
-    <div
-      ref={refs.setFloating}
-      tabIndex={-1}
-      className={classnames(
-        styles.container,
-        rounding === 2 && borders.rounding2,
-        rounding === 4 && borders.rounding4,
-        styles.contents,
-        styles.maxDimensions,
-        width !== null && styles.minDimensions,
-      )}
-      style={{ ...floatingStyles, visibility }}
-    >
-      {caret && (
-        <div
-          ref={caretRef}
-          className={classnames(colors[bgColorElevated], styles.caret)}
-          style={{
-            left: caretOffset?.x != null ? `${caretOffset.x}px` : '',
-            top: caretOffset?.y != null ? `${caretOffset.y}px` : '',
-            [placement]: '100%',
-          }}
-        >
-          <Caret
-            direction={SIDES_MAP[placement]}
-            height={isCaretVertical ? CARET_HEIGHT : CARET_WIDTH}
-            width={isCaretVertical ? CARET_WIDTH : CARET_HEIGHT}
-          />
-        </div>
-      )}
-
-      <div
-        aria-label={accessibilityLabel}
-        id={id}
-        role={role}
-        className={classnames(
-          border && styles.border,
-          colors[background],
-          colors[bgColorElevated],
-          rounding === 2 && borders.rounding2,
-          rounding === 4 && borders.rounding4,
-          styles.innerContents,
-          styles.maxDimensions,
-          width !== null && styles.minDimensions,
-        )}
-        style={{
-          maxWidth: width,
-        }}
-      >
-        {children}
-      </div>
-    </div>
-  );
-
   return (
     <FloatingFocusManager
       disabled={role === 'tooltip'}
@@ -150,7 +95,58 @@ export default function Contents({
       returnFocus={false}
       modal={shouldTrapFocus ?? false}
     >
-      {contents}
+      <div
+        ref={refs.setFloating}
+        tabIndex={-1}
+        className={classnames(
+          styles.container,
+          rounding === 2 && borders.rounding2,
+          rounding === 4 && borders.rounding4,
+          styles.contents,
+          styles.maxDimensions,
+          width !== null && styles.minDimensions,
+        )}
+        style={{ ...floatingStyles, visibility }}
+      >
+        {caret && (
+          <div
+            ref={caretRef}
+            className={classnames(colors[bgColorElevated], styles.caret)}
+            style={{
+              left: caretOffset?.x != null ? `${caretOffset.x}px` : '',
+              top: caretOffset?.y != null ? `${caretOffset.y}px` : '',
+              [placement]: '100%',
+            }}
+          >
+            <Caret
+              direction={SIDES_MAP[placement]}
+              height={isCaretVertical ? CARET_HEIGHT : CARET_WIDTH}
+              width={isCaretVertical ? CARET_WIDTH : CARET_HEIGHT}
+            />
+          </div>
+        )}
+
+        <div
+          aria-label={accessibilityLabel}
+          id={id}
+          role={role}
+          className={classnames(
+            border && styles.border,
+            colors[background],
+            colors[bgColorElevated],
+            rounding === 2 && borders.rounding2,
+            rounding === 4 && borders.rounding4,
+            styles.innerContents,
+            styles.maxDimensions,
+            width !== null && styles.minDimensions,
+          )}
+          style={{
+            maxWidth: width,
+          }}
+        >
+          {children}
+        </div>
+      </div>
     </FloatingFocusManager>
   );
 }

--- a/packages/gestalt/src/Popover/Contents.js
+++ b/packages/gestalt/src/Popover/Contents.js
@@ -146,7 +146,7 @@ export default function Contents({
   return role === 'tooltip' ? (
     contents
   ) : (
-    <FloatingFocusManager context={context} modal={shouldTrapFocus ?? false}>
+    <FloatingFocusManager context={context} returnFocus={false} modal={shouldTrapFocus ?? false}>
       {contents}
     </FloatingFocusManager>
   );

--- a/packages/gestalt/src/Popover/Controller.js
+++ b/packages/gestalt/src/Popover/Controller.js
@@ -32,6 +32,7 @@ type Props = {
   scrollBoundary?: HTMLElement,
   hideWhenReferenceHidden?: boolean,
   onPositioned?: () => void,
+  shouldTrapFocus?: boolean,
 };
 
 export default function Controller({
@@ -53,6 +54,7 @@ export default function Controller({
   scrollBoundary,
   hideWhenReferenceHidden,
   onPositioned,
+  shouldTrapFocus,
 }: Props): ReactNode {
   const width = typeof size === 'string' ? SIZE_WIDTH_MAP[size] : size;
 
@@ -87,6 +89,7 @@ export default function Controller({
         scrollBoundary={scrollBoundary}
         hideWhenReferenceHidden={hideWhenReferenceHidden}
         onPositioned={onPositioned}
+        shouldTrapFocus={shouldTrapFocus}
       >
         {children}
       </Contents>

--- a/packages/gestalt/src/Popover/InternalPopover.js
+++ b/packages/gestalt/src/Popover/InternalPopover.js
@@ -29,6 +29,7 @@ type Props = {
   scrollBoundary?: HTMLElement,
   hideWhenReferenceHidden?: boolean,
   onPositioned?: () => void,
+  disableFocusTrap?: boolean,
 };
 
 export default function InternalPopover({
@@ -50,6 +51,7 @@ export default function InternalPopover({
   scrollBoundary,
   hideWhenReferenceHidden,
   onPositioned,
+  disableFocusTrap = false,
 }: Props): null | ReactNode {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
@@ -82,6 +84,7 @@ export default function InternalPopover({
       disablePortal={disablePortal}
       hideWhenReferenceHidden={hideWhenReferenceHidden}
       onPositioned={onPositioned}
+      shouldTrapFocus={!disableFocusTrap}
     >
       {showDismissButton ? (
         <Flex direction="column">

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -215,6 +215,8 @@ export default function PopoverEducational({
         shouldFocus={shouldFocus}
         role={primaryAction && !children ? 'dialog' : role}
         size={size}
+        hideWhenReferenceHidden
+        disableFocusTrap
       >
         {children ??
           (message ? (

--- a/packages/gestalt/src/Tooltip/InternalTooltip.js
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.js
@@ -146,6 +146,7 @@ export default function InternalTooltip({
         <Layer zIndex={zIndex}>
           {isInExperiment ? (
             <Controller
+              role="tooltip"
               anchor={anchor}
               caret={false}
               bgColor="darkGray"
@@ -156,6 +157,7 @@ export default function InternalTooltip({
               rounding={2}
               size={null}
               shouldFocus={false}
+              hideWhenReferenceHidden
             >
               <Box
                 maxWidth={180}

--- a/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/Popover.jsdom.test.js.snap
@@ -8,15 +8,6 @@ exports[`PopoverEducational renders correctly 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
@@ -81,15 +72,6 @@ exports[`PopoverEducational renders correctly 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>
@@ -101,19 +83,10 @@ exports[`PopoverEducational renders correctly with custom children 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
-        tabindex="0"
+        tabindex="-1"
       >
         <div
           class="blue caret"
@@ -142,15 +115,6 @@ exports[`PopoverEducational renders correctly with custom children 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>

--- a/packages/gestalt/src/__snapshots__/PopoverEducational.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PopoverEducational.jsdom.test.js.snap
@@ -6,15 +6,6 @@ exports[`PopoverEducational renders 1`] = `
     class="box"
   >
     <div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
       <div
         class="container rounding4 contents maxDimensions minDimensions"
         style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
@@ -79,15 +70,6 @@ exports[`PopoverEducational renders 1`] = `
           </div>
         </div>
       </div>
-      <span
-        aria-hidden="true"
-        data-floating-ui-focus-guard=""
-        data-floating-ui-inert=""
-        data-type="inside"
-        role="button"
-        style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
-        tabindex="0"
-      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Summary

There was an overlooked case during Floating-UI integration. Tooltip didn't need FloatingFocusManager. Tooltip is not an accessible component.

Default values of new props `hideWhenReferenceHidden` and `disableFocusTrap` are now passed at the component props level. Previously the defaults set at `Contents` component level. This change makes it more obvious how the components behave. The default value now also displayed in the docs.

For the context, this is the table of components classified by accessiblity features:
![Screenshot 2024-02-22 at 16 04 01](https://github.com/pinterest/gestalt/assets/29589560/99c5e425-552f-4e7a-870d-27fc39c5a2d1)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
