### PR TITLE
TextField: Add dataTestId prop

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -2267,6 +2267,7 @@ interface TextFieldProps {
     | 'off'
     | 'username'
     | undefined;
+  dataTestId?: string | undefined;
   disabled?: boolean | undefined;
   errorMessage?: Node | undefined;
   hasError?: boolean | undefined;

--- a/packages/gestalt/src/TextField.js
+++ b/packages/gestalt/src/TextField.js
@@ -29,6 +29,10 @@ type Props = {
    */
   disabled?: boolean,
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string,
+  /**
    * For most use cases, pass a string with a helpful error message (be sure to localize!). In certain instances it can be useful to make some text clickable; to support this, you may instead pass a React.Node to wrap text in [Link](https://gestalt.pinterest.systems/web/link) or [TapArea](https://gestalt.pinterest.systems/web/taparea).
    */
   errorMessage?: ReactNode,
@@ -139,6 +143,7 @@ const TextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forw
 >(function TextField(
   {
     autoComplete,
+    dataTestId,
     disabled = false,
     errorMessage,
     hasError = false,
@@ -202,6 +207,7 @@ const TextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forw
   return (
     <InternalTextField
       autoComplete={autoComplete}
+      dataTestId={dataTestId}
       disabled={disabled}
       errorMessage={errorMessage}
       hasError={hasError}

--- a/packages/gestalt/src/TextField/InternalTextField.js
+++ b/packages/gestalt/src/TextField/InternalTextField.js
@@ -36,6 +36,7 @@ type Props = {
   accessibilityControls?: string,
   accessibilityActiveDescendant?: string,
   autoComplete?: 'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username',
+  dataTestId?: string,
   disabled?: boolean,
   errorMessage?: ReactNode,
   hasError?: boolean,
@@ -84,6 +85,7 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
     accessibilityControls,
     accessibilityActiveDescendant,
     autoComplete,
+    dataTestId,
     disabled = false,
     errorMessage,
     hasError = false,
@@ -194,6 +196,7 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
       aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
       autoComplete={autoComplete}
       className={tags ? unstyledClasses : styledClasses}
+      data-test-id={dataTestId}
       disabled={disabled}
       enterKeyHint={mobileEnterKeyHint}
       id={id}


### PR DESCRIPTION
### Summary

#### What changed?

Added a dataTestId prop to TextField. Used #2726 as a model.

#### Why?

To allow for deprecating the Sterling TextField component, that implements their own as a Box around the TextField.

### Links

- [Jira]https://jira.pinadmin.com/browse/GESTALT-7558