### PR TITLE
RadioGroup, Accordion, Datapoint, Dropdown: Fixing badge type

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -67,6 +67,7 @@ interface BadgeObject {
     | 'neutral'
     | 'darkWash'
     | 'lightWash'
+    | 'recommendation'
     | undefined;
 }
 
@@ -1686,6 +1687,7 @@ interface RadioGroupRadioButtonProps {
   id: string;
   onChange: AbstractEventHandler<React.SyntheticEvent<HTMLInputElement>, { checked: boolean }>;
   value: string;
+  badge?: BadgeObject | undefined;
   checked?: boolean | undefined;
   disabled?: boolean | undefined;
   helperText?: string | undefined;

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -10,7 +10,7 @@ import IconButton from './IconButton';
 import IconButtonLink from './IconButtonLink';
 import icons from './icons/index';
 
-export type BadgeType = {
+type BadgeType = {
   text: string,
   type?:
     | 'info'

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -3,6 +3,7 @@ import { type Element, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './Accordion/applyModuleDensity';
 import AccordionTitle from './Accordion/Title';
 import AccordionExpandable from './AccordionExpandable';
+import Badge from './Badge';
 import Box from './Box';
 import { useColorScheme } from './contexts/ColorSchemeProvider';
 import Flex from './Flex';
@@ -10,9 +11,9 @@ import IconButton from './IconButton';
 import IconButtonLink from './IconButtonLink';
 import icons from './icons/index';
 
-type BadgeType = {
+export type BadgeType = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?: $ElementType<React$ElementConfig<typeof Badge>, 'type'>,
 };
 
 type Props = {

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -3,7 +3,6 @@ import { type Element, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './Accordion/applyModuleDensity';
 import AccordionTitle from './Accordion/Title';
 import AccordionExpandable from './AccordionExpandable';
-import Badge from './Badge';
 import Box from './Box';
 import { useColorScheme } from './contexts/ColorSchemeProvider';
 import Flex from './Flex';
@@ -13,7 +12,15 @@ import icons from './icons/index';
 
 export type BadgeType = {
   text: string,
-  type?: $ElementType<React$ElementConfig<typeof Badge>, 'type'>,
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type Props = {

--- a/packages/gestalt/src/Accordion/ExpandableItem.js
+++ b/packages/gestalt/src/Accordion/ExpandableItem.js
@@ -2,6 +2,7 @@
 import { type Element as ReactElement, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './applyModuleDensity';
 import ModuleTitle from './Title';
+import { type BadgeType } from '../Accordion';
 import Box from '../Box';
 import Flex from '../Flex';
 import Icon from '../Icon';
@@ -9,11 +10,6 @@ import IconButton from '../IconButton';
 import icons from '../icons/index';
 import TapArea from '../TapArea';
 import Text from '../Text';
-
-type BadgeType = {
-  text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
-};
 
 export default function AccordionExpandableItem({
   accessibilityCollapseLabel,

--- a/packages/gestalt/src/Accordion/ExpandableItem.js
+++ b/packages/gestalt/src/Accordion/ExpandableItem.js
@@ -2,7 +2,6 @@
 import { type Element as ReactElement, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './applyModuleDensity';
 import ModuleTitle from './Title';
-import { type BadgeType } from '../Accordion';
 import Box from '../Box';
 import Flex from '../Flex';
 import Icon from '../Icon';
@@ -10,6 +9,19 @@ import IconButton from '../IconButton';
 import icons from '../icons/index';
 import TapArea from '../TapArea';
 import Text from '../Text';
+
+export type BadgeType = {
+  text: string,
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
+};
 
 export default function AccordionExpandableItem({
   accessibilityCollapseLabel,

--- a/packages/gestalt/src/Accordion/Title.js
+++ b/packages/gestalt/src/Accordion/Title.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Element, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './applyModuleDensity';
+import { type BadgeType } from '../Accordion';
 import Badge from '../Badge';
 import Box from '../Box';
 import Flex from '../Flex';
@@ -9,11 +10,6 @@ import IconButton from '../IconButton';
 import IconButtonLink from '../IconButtonLink';
 import icons from '../icons/index';
 import Text from '../Text';
-
-type BadgeType = {
-  text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
-};
 
 export default function AccordionTitle(props: {
   badge?: BadgeType,

--- a/packages/gestalt/src/Accordion/Title.js
+++ b/packages/gestalt/src/Accordion/Title.js
@@ -1,7 +1,6 @@
 // @flow strict
 import { type Element, type Node as ReactNode } from 'react';
 import applyModuleDensityStyle from './applyModuleDensity';
-import { type BadgeType } from '../Accordion';
 import Badge from '../Badge';
 import Box from '../Box';
 import Flex from '../Flex';
@@ -10,6 +9,19 @@ import IconButton from '../IconButton';
 import IconButtonLink from '../IconButtonLink';
 import icons from '../icons/index';
 import Text from '../Text';
+
+export type BadgeType = {
+  text: string,
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
+};
 
 export default function AccordionTitle(props: {
   badge?: BadgeType,

--- a/packages/gestalt/src/AccordionExpandable.js
+++ b/packages/gestalt/src/AccordionExpandable.js
@@ -7,7 +7,6 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { type BadgeType } from './Accordion';
 import applyModuleDensityStyle from './Accordion/applyModuleDensity';
 import AccordionExpandableItem from './Accordion/ExpandableItem';
 import Box from './Box';
@@ -16,6 +15,19 @@ import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
 import Divider from './Divider';
 import IconButton from './IconButton';
 import icons from './icons/index';
+
+export type BadgeType = {
+  text: string,
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
+};
 
 function getExpandedId(expandedIndex: ?number): ?number {
   return Number.isFinite(expandedIndex) ? expandedIndex : null;

--- a/packages/gestalt/src/AccordionExpandable.js
+++ b/packages/gestalt/src/AccordionExpandable.js
@@ -7,6 +7,7 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { type BadgeType } from './Accordion';
 import applyModuleDensityStyle from './Accordion/applyModuleDensity';
 import AccordionExpandableItem from './Accordion/ExpandableItem';
 import Box from './Box';
@@ -19,11 +20,6 @@ import icons from './icons/index';
 function getExpandedId(expandedIndex: ?number): ?number {
   return Number.isFinite(expandedIndex) ? expandedIndex : null;
 }
-
-type BadgeType = {
-  text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
-};
 
 type Props = {
   /**

--- a/packages/gestalt/src/Datapoint.js
+++ b/packages/gestalt/src/Datapoint.js
@@ -5,7 +5,15 @@ import { type Indexable } from './zIndex';
 
 type BadgeObject = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type TrendObject = {

--- a/packages/gestalt/src/Datapoint/InternalDatapoint.js
+++ b/packages/gestalt/src/Datapoint/InternalDatapoint.js
@@ -13,7 +13,15 @@ import { type Indexable } from '../zIndex';
 
 type BadgeObject = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type TrendObject = {

--- a/packages/gestalt/src/Dropdown/OptionItem.js
+++ b/packages/gestalt/src/Dropdown/OptionItem.js
@@ -23,7 +23,15 @@ export type OptionItemType = {
 
 type BadgeType = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type Props = {

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -5,7 +5,15 @@ import OptionItem from './Dropdown/OptionItem';
 
 type BadgeType = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type OptionItemType = {

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -5,7 +5,15 @@ import OptionItem from './Dropdown/OptionItem';
 
 type BadgeType = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type OptionItemType = {

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -28,6 +28,10 @@ type BadgeType = {
 
 type Props = {
   /**
+   * An optional [Badge](https://gestalt.pinterest.systems/web/badge) component can be supplied to add a badge to each radio button. See the [badges example](https://gestalt.pinterest.systems/web/radiogroup#With-Badge) for more details.
+   */
+  badge?: BadgeType,
+  /**
    * Indicates if the input is checked. See the [state example](https://gestalt.pinterest.systems/web/radiogroup#States) for more details.
    */
   checked?: boolean,
@@ -74,7 +78,6 @@ type Props = {
    * The value of the input.
    */
   value: string,
-  badge?: BadgeType,
 };
 
 /**

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -15,7 +15,15 @@ import useFocusVisible from './useFocusVisible';
 
 type BadgeType = {
   text: string,
-  type?: $ElementType<React$ElementConfig<typeof Badge>, 'type'>,
+  type?:
+    | 'info'
+    | 'error'
+    | 'warning'
+    | 'success'
+    | 'neutral'
+    | 'recommendation'
+    | 'darkWash'
+    | 'lightWash',
 };
 
 type Props = {

--- a/packages/gestalt/src/RadioGroupButton.js
+++ b/packages/gestalt/src/RadioGroupButton.js
@@ -15,7 +15,7 @@ import useFocusVisible from './useFocusVisible';
 
 type BadgeType = {
   text: string,
-  type?: 'info' | 'error' | 'warning' | 'success' | 'neutral' | 'darkWash' | 'lightWash',
+  type?: $ElementType<React$ElementConfig<typeof Badge>, 'type'>,
 };
 
 type Props = {


### PR DESCRIPTION
### Summary

#### What changed?

Adding dynamic types to hardcoded versions of BadgeType across Gestalt.

#### Why?

Adding more types to Badge would not be reflected on the BadgeType for these components.

### Links

- [Slack](https://pinterest.slack.com/archives/C13KLG5P0/p1708713858987789?thread_ts=1705437845.356239&cid=C13KLG5P0)