### PR TITLE
Internal: Add initial unit test for masonry two column module

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -97,9 +97,13 @@ export default class MasonryContainer extends Component<Props<{ ... }>, State> {
     });
 
     window.addEventListener('set-masonry-items', (e) => {
-      this.setState({
-        items: e.detail.items,
-      });
+      const index = e?.detail.index;
+
+      this.setState(({ items: prevItems }) => ({
+        items: index
+          ? [...prevItems.slice(0, index), ...e.detail.items, ...prevItems.slice(index)]
+          : e.detail.items,
+      }));
     });
 
     window.ERROR_COUNT = window.ERROR_COUNT || 0;

--- a/docs/integration-test-helpers/masonry/items-utils/generateExampleItems.js
+++ b/docs/integration-test-helpers/masonry/items-utils/generateExampleItems.js
@@ -35,7 +35,7 @@ export default function generateExampleItems({
       height: baseHeight + previousItemCount + i,
       color: getRandomColor(getRandomNumber),
     };
-    return Boolean(twoColItemIndex) && i === twoColItemIndex
+    return twoColItemIndex !== undefined && i === twoColItemIndex
       ? {
           ...pin,
           columnSpan: 2,

--- a/playwright/masonry/two-module.spec.mjs
+++ b/playwright/masonry/two-module.spec.mjs
@@ -1,0 +1,58 @@
+// @flow strict
+import { expect, test } from '@playwright/test';
+import getServerURL from './utils/getServerURL.mjs';
+import selectors from './utils/selectors.mjs';
+import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
+
+test.describe('Masonry: two colums module', () => {
+  test('render the two column module', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(
+      getServerURL({
+        manualFetch: true,
+        twoColItems: true,
+      })
+    );
+
+    // The two modules items appear after the 50th pin, we add at least 60 items
+    const addItemsButton = await page.locator(selectors.addItems);
+    await addItemsButton.click();
+    await addItemsButton.click();
+    await addItemsButton.click();
+
+    await expect(page.getByText('columnSpan: 2')).toBeVisible();
+  });
+
+  test('position two module on specific place', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(
+      getServerURL({
+        manualFetch: true,
+        twoColItems: true,
+      })
+    );
+
+    const addItemsButton = await page.locator(selectors.addItems);
+    await addItemsButton.click();
+    await addItemsButton.click();
+
+    const masonryItemData = [
+      { name: 'fake1', height: 100, color: '#f00' },
+      { name: 'fake2', height: 200, color: '#f00' },
+      { name: 'fake3', height: 300, color: '#f00', columnSpan: 2 },
+    ];
+
+    await page.evaluate((proxiedItemData) => {
+      window.dispatchEvent(
+        new CustomEvent('set-masonry-items', {
+          detail: {
+            items: proxiedItemData,
+            index: 5,
+          },
+        })
+      );
+    }, masonryItemData);
+
+    await expect(page.getByText('columnSpan: 2')).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Summary

This PR creates an inital unit test with playwright for the two modules feature on masonry. I'm adding two tests, one that only verifies that the module is rendered and other to insert a two column element on a specific place to test the correct positioning.

#### What changed?

- The inclusion of the tests.
- Fixed a bug on the `generateExampleItems` where the two column item was not added when the random number is 0. 
- Added new logic for the `set-masonry-items` event to specify in what index to add the new items

#### Why?

To add coverage for the two column module tests.
