### PR TITLE
SelectList: fix for hidden arrow-down Icon

### DIFF
--- a/docs/examples/selectlist/main.js
+++ b/docs/examples/selectlist/main.js
@@ -1,24 +1,22 @@
 // @flow strict
 import { type Node as ReactNode } from 'react';
-import { Box, Flex, SelectList } from 'gestalt';
+import { Flex, SelectList } from 'gestalt';
 
 export default function Example(): ReactNode {
   return (
-    <Box color="successWeak">
-      <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-        <SelectList id="selectlistexample1" label="Country" onChange={() => {}} size="lg">
-          {[
-            { label: 'Algeria', value: 'algeria' },
-            { label: 'Belgium', value: 'belgium' },
-            { label: 'Canada', value: 'canada' },
-            { label: 'Denmark', value: 'denmark' },
-            { label: 'Egypt', value: 'egypt' },
-            { label: 'France', value: 'france' },
-          ].map(({ label, value }) => (
-            <SelectList.Option key={label} label={label} value={value} />
-          ))}
-        </SelectList>
-      </Flex>
-    </Box>
+    <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
+      <SelectList id="selectlistexample1" label="Country" onChange={() => {}} size="lg">
+        {[
+          { label: 'Algeria', value: 'algeria' },
+          { label: 'Belgium', value: 'belgium' },
+          { label: 'Canada', value: 'canada' },
+          { label: 'Denmark', value: 'denmark' },
+          { label: 'Egypt', value: 'egypt' },
+          { label: 'France', value: 'france' },
+        ].map(({ label, value }) => (
+          <SelectList.Option key={label} label={label} value={value} />
+        ))}
+      </SelectList>
+    </Flex>
   );
 }

--- a/docs/examples/selectlist/main.js
+++ b/docs/examples/selectlist/main.js
@@ -1,22 +1,24 @@
 // @flow strict
 import { type Node as ReactNode } from 'react';
-import { Flex, SelectList } from 'gestalt';
+import { Box, Flex, SelectList } from 'gestalt';
 
 export default function Example(): ReactNode {
   return (
-    <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
-      <SelectList id="selectlistexample1" label="Country" onChange={() => {}} size="lg">
-        {[
-          { label: 'Algeria', value: 'algeria' },
-          { label: 'Belgium', value: 'belgium' },
-          { label: 'Canada', value: 'canada' },
-          { label: 'Denmark', value: 'denmark' },
-          { label: 'Egypt', value: 'egypt' },
-          { label: 'France', value: 'france' },
-        ].map(({ label, value }) => (
-          <SelectList.Option key={label} label={label} value={value} />
-        ))}
-      </SelectList>
-    </Flex>
+    <Box color="successWeak">
+      <Flex alignItems="center" gap={4} height="100%" justifyContent="center" width="100%">
+        <SelectList id="selectlistexample1" label="Country" onChange={() => {}} size="lg">
+          {[
+            { label: 'Algeria', value: 'algeria' },
+            { label: 'Belgium', value: 'belgium' },
+            { label: 'Canada', value: 'canada' },
+            { label: 'Denmark', value: 'denmark' },
+            { label: 'Egypt', value: 'egypt' },
+            { label: 'France', value: 'france' },
+          ].map(({ label, value }) => (
+            <SelectList.Option key={label} label={label} value={value} />
+          ))}
+        </SelectList>
+      </Flex>
+    </Box>
   );
 }

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -98,9 +98,13 @@ function SelectList({
   const classes = classnames(
     styles.select,
     formElement.base,
-    disabled ? formElement.disabled : formElement.enabled,
-    errorMessage ? formElement.errored : formElement.normal,
     size === 'md' ? layout.medium : layout.large,
+    {
+      [formElement.normal]: !errorMessage,
+      [formElement.enabledTransparent]: !disabled,
+      [formElement.disabled]: disabled,
+      [formElement.errored]: !disabled && !!errorMessage,
+    },
   );
 
   const showPlaceholder = placeholder && !value;

--- a/packages/gestalt/src/SelectList.js
+++ b/packages/gestalt/src/SelectList.js
@@ -123,11 +123,13 @@ function SelectList({
     <Box>
       {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
       <Box
-        color={disabled ? 'secondary' : 'default'}
         display="flex"
         position="relative"
         rounding={4}
         width="100%"
+        dangerouslySetInlineStyle={{
+          __style: { backgroundColor: 'var(--color-background-formfield-primary)' },
+        }}
       >
         <Box
           alignItems="center"

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -51,7 +51,7 @@ exports[`SelectList renders an option group 1`] = `
     </div>
     <select
       aria-invalid="false"
-      className="select base enabled normal medium"
+      className="select base medium normal enabledTransparent"
       disabled={false}
       id="optionGroup"
       onBlur={[Function]}
@@ -143,7 +143,7 @@ exports[`SelectList renders with a hidden label 1`] = `
     </div>
     <select
       aria-invalid="false"
-      className="select base enabled normal medium"
+      className="select base medium normal enabledTransparent"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -207,7 +207,7 @@ exports[`SelectList renders with typical props 1`] = `
     </div>
     <select
       aria-invalid="false"
-      className="select base enabled normal medium"
+      className="select base medium normal enabledTransparent"
       disabled={false}
       id="test"
       onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SelectList.test.js.snap
@@ -19,9 +19,10 @@ exports[`SelectList renders an option group 1`] = `
     </div>
   </label>
   <div
-    className="box default relative rounding4 xsDisplayFlex"
+    className="box relative rounding4 xsDisplayFlex"
     style={
       Object {
+        "backgroundColor": "var(--color-background-formfield-primary)",
         "width": "100%",
       }
     }
@@ -111,9 +112,10 @@ exports[`SelectList renders with a hidden label 1`] = `
     </div>
   </label>
   <div
-    className="box default relative rounding4 xsDisplayFlex"
+    className="box relative rounding4 xsDisplayFlex"
     style={
       Object {
+        "backgroundColor": "var(--color-background-formfield-primary)",
         "width": "100%",
       }
     }
@@ -175,9 +177,10 @@ exports[`SelectList renders with typical props 1`] = `
   className="box"
 >
   <div
-    className="box default relative rounding4 xsDisplayFlex"
+    className="box relative rounding4 xsDisplayFlex"
     style={
       Object {
+        "backgroundColor": "var(--color-background-formfield-primary)",
         "width": "100%",
       }
     }

--- a/packages/gestalt/src/shared/FormElement.css
+++ b/packages/gestalt/src/shared/FormElement.css
@@ -32,6 +32,11 @@
   color: var(--color-text-formfield-default);
 }
 
+.enabledTransparent {
+  background-color: var(--color-transparent);
+  color: var(--color-text-formfield-default);
+}
+
 .disabled {
   composes: borderColorLightGrayDisabled from "../Borders.css";
   background-color: var(--color-background-formfield-disabled);

--- a/packages/gestalt/src/shared/FormElement.css.flow
+++ b/packages/gestalt/src/shared/FormElement.css.flow
@@ -4,6 +4,7 @@ declare module.exports: {|
   +'base': string,
   +'disabled': string,
   +'enabled': string,
+  +'enabledTransparent': string,
   +'errored': string,
   +'normal': string,
   +'unstyled': string,


### PR DESCRIPTION
Fix.


BEFORE
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/eb2c6f48-e6e9-482c-8f1d-5326f5ae51ab)

AFTER with BUG
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/c8e21899-75a5-40cc-98c1-37e169d08021)

AFTER with FIX
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/71b5cc88-06c3-4631-8fa1-f8aef7ab2222)


We need move the background color below the Icon position so it's visible again.
