### PR TITLE
Popover: Remove autofocusing dismiss button

### DIFF
--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -290,7 +290,7 @@ export default function Dropdown({
       positionRelativeToAnchor={isWithinFixedContainer}
       disablePortal
       role="menu"
-      shouldFocus
+      shouldFocus={false}
       size="xl"
       __dangerouslySetMaxHeight={maxHeight}
       __onPositioned={() => setIsPopoverPositioned(true)}

--- a/packages/gestalt/src/Popover/InternalPopover.js
+++ b/packages/gestalt/src/Popover/InternalPopover.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Node as ReactNode, useEffect, useRef } from 'react';
+import { type Node as ReactNode, useRef } from 'react';
 import Controller from './Controller';
 import Box from '../Box';
 import { useDefaultLabelContext } from '../contexts/DefaultLabelProvider';
@@ -58,13 +58,10 @@ export default function InternalPopover({
 
   const dismissButtonRef = useRef<null | HTMLAnchorElement | HTMLButtonElement>(null);
 
-  useEffect(() => {
-    dismissButtonRef.current?.focus();
-  }, []);
-
   if (!anchor) {
     return null;
   }
+
   return (
     <Controller
       accessibilityLabel={accessibilityLabel}


### PR DESCRIPTION
### Summary

Auto focusing dismiss button when Popover is mounted causing the content jump. 
When Popover is mounted, it is not yet positioned correctly and it is at `top: 0; left: 0`. That's why focusing it scrolls the page up.

Focusing the dismiss button is actually redundant and `FloatingFocusManager` takes care of focusing the 1st focusable element inside floating element, i.e. Popover.

Also, for Dropdown `shouldFocus={false}` was set to Popover becasue Dropdown's item always gets the focus. That's why focusing on Popover itself is redundant.

### Links

- [Bug in Jira](https://jira.pinadmin.com/browse/BUG-180930)

### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
