### PR TITLE
Masonry: Fix initial flash for two-column mode

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -577,21 +577,19 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       gridBody = <div style={{ width: '100%' }} ref={this.setGridWrapperRef} />;
     } else {
       // Full layout is possible
-      const itemsWithMeasurements = items.filter((item) => item && measurementStore.has(item));
-      const itemsWithPositions = items.filter((item) => item && positionStore.has(item));
-      const itemsToRender = _twoColItems ? itemsWithPositions : itemsWithMeasurements;
-
+      const itemsToRender = items.filter((item) => item && measurementStore.has(item));
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
       const hasTwoColumnItems =
         // $FlowFixMe[prop-missing] We're assuming `columnSpan` exists
         _twoColItems && itemsWithoutPositions.some((item) => item.columnSpan === 2);
+
       // If there are 2-col items, we need to measure more items to ensure we have enough possible layouts to find a suitable one
       const itemsToMeasureCount = hasTwoColumnItems ? TWO_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
       const itemsToMeasure = items
         .filter((item) => item && !measurementStore.has(item))
         .slice(0, itemsToMeasureCount);
 
-      const positions = getPositions(itemsWithMeasurements);
+      const positions = getPositions(itemsToRender);
       const measuringPositions = getPositions(itemsToMeasure);
       // Math.max() === -Infinity when there are no positions
       const height = positions.length
@@ -606,6 +604,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
                 item,
                 i,
                 // If we have items in the positionStore (newer way of tracking positions used for 2-col support), use that. Otherwise fall back to the classic way of tracking positions
+                // this is only required atm because the two column layout doesn't not return positions in their original item order
                 positionStore.get(item) ?? positions[i],
               ),
             )}
@@ -615,7 +614,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
               // itemsToMeasure is always the length of minCols, so i will always be 0..minCols.length
               // we normalize the index here relative to the item list as a whole so that itemIdx is correct
               // and so that React doesnt reuse the measurement nodes
-              const measurementIndex = itemsWithMeasurements.length + i;
+              const measurementIndex = itemsToRender.length + i;
               const position = measuringPositions[i];
               return (
                 <div

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -378,25 +378,34 @@ const defaultTwoColumnModuleLayout = <T>({
           ? lowestScoreNode
           : startNodeData;
 
-      const { positions: winningPositions } = winningNode;
+      const { positions } = winningNode;
 
       // Insert 2-col item(s)
       const twoColItem = twoColumnItems[0]; // this should always only be one
       const {
         additionalWhitespace,
-        heights: finalHeights,
+        heights: updatedHeights,
         position: twoColItemPosition,
       } = getTwoColItemPosition<T>({
         item: twoColItem,
-        heights: lowestScoreNode.heights,
+        heights: winningNode.heights,
         ...commonGetPositionArgs,
       });
 
       // Combine winning positions and 2-col item position, add to cache
-      const finalPositions = [
-        ...winningPositions,
-        { item: twoColItem, position: twoColItemPosition },
-      ];
+      const winningPositions = positions.concat({ item: twoColItem, position: twoColItemPosition });
+
+      const positionedItems = new Set(winningPositions.map(({ item }) => item));
+      // depending on where the 2-col item is positioned, there may be items that are still not positioned
+      // calculate the remaining items and add them to the list of final positions
+      const remainingItems = items.filter((item) => !positionedItems.has(item));
+      const { heights: finalHeights, positions: remainingItemPositions } =
+        getOneColumnItemPositions<T>({
+          items: remainingItems,
+          heights: updatedHeights,
+          ...commonGetPositionArgs,
+        });
+      const finalPositions = winningPositions.concat(remainingItemPositions);
 
       // Log additional whitespace shown above the 2-col module
       // This may need to be tweaked or removed if pin leveling is implemented

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -219,7 +219,7 @@ const defaultTwoColumnModuleLayout = <T>({
   logWhitespace?: (number) => void,
   measurementCache: Cache<T, number>,
   minCols?: number,
-  positionCache?: Cache<T, Position>,
+  positionCache: Cache<T, Position>,
   rawItemCount: number,
   width?: ?number,
 }): ((items: $ReadOnlyArray<T>) => $ReadOnlyArray<Position>) => {
@@ -415,7 +415,7 @@ const defaultTwoColumnModuleLayout = <T>({
       logWhitespace?.(additionalWhitespaceAboveTwoColModule);
 
       finalPositions.forEach(({ item, position }) => {
-        positionCache?.set(item, position);
+        positionCache.set(item, position);
       });
       heightsCache?.setHeights(finalHeights);
 

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -1,0 +1,72 @@
+// @flow strict
+import defaultTwoColumnModuleLayout from './defaultTwoColumnModuleLayout';
+import HeightsStore from './HeightsStore';
+import MeasurementStore from './MeasurementStore';
+import { type Position } from './types';
+
+describe('two column layout test cases', () => {
+  test('returns positions for all items', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 206, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 207, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 208, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 209, 'color': '#F45098' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1200,
+    });
+    // perform single column layout first since we expect two column items on second page+ currently
+    layout(items);
+
+    const newItems = [
+      { name: 'Pin 10', height: 210, color: '#30BAF6' },
+      { name: 'Pin 11', height: 211, color: '#7076FA' },
+      { name: 'Pin 12', height: 212, color: '#B032ED' },
+      { name: 'Pin 13', height: 213, color: '#F21DCF', columnSpan: 2 },
+      { name: 'Pin 14', height: 214, color: '#45098F' },
+    ];
+    newItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    const updatedItems = items.concat(newItems);
+    const positions = layout(updatedItems);
+    expect(positions.length).toEqual(updatedItems.length);
+    expect(positions).toEqual([
+      { 'height': 210, 'left': 607, 'top': 436, 'width': 240 },
+      { 'height': 212, 'left': 861, 'top': 438, 'width': 240 },
+      { 'height': 214, 'left': 99, 'top': 654, 'width': 240 },
+      { 'height': 213, 'left': 353, 'top': 660, 'width': 494 },
+      { 'height': 200, 'left': 99, 'top': 0, 'width': 240 },
+      { 'height': 201, 'left': 353, 'top': 0, 'width': 240 },
+      { 'height': 202, 'left': 607, 'top': 0, 'width': 240 },
+      { 'height': 203, 'left': 861, 'top': 0, 'width': 240 },
+      { 'height': 204, 'left': 99, 'top': 214, 'width': 240 },
+      { 'height': 205, 'left': 353, 'top': 215, 'width': 240 },
+      { 'height': 206, 'left': 607, 'top': 216, 'width': 240 },
+      { 'height': 207, 'left': 861, 'top': 217, 'width': 240 },
+      { 'height': 208, 'left': 99, 'top': 432, 'width': 240 },
+      { 'height': 209, 'left': 353, 'top': 434, 'width': 240 },
+      { 'height': 211, 'left': 861, 'top': 664, 'width': 240 },
+    ]);
+  });
+});


### PR DESCRIPTION
### Summary

#### What changed?
This PR addresses two issues with Masonry when `_twoColItems` is enabled:
- `defaultTwoColumnModuleLayout` does not return the full set of item positions when there is a two column module (e.g. if we pass in 50 items, we currently do not get 50 positions back). This is because we currently early a subset of positions depending on where we end up placing the two column module. This PR addresses the issue by ensuring that we also return the positions for the remaining items as well.
- When hydrating from a server rendering, `itemsToRender` will initially be empty because we are rendering items which already have positions (in the two column case) vs items that have measurements. This was previously necessary because of the above mentioned issue. This PR addresses this by just being consistent and always rendering items that already have been measured. 

#### Why?

We received a report about the grid "flashing" during hydration from a server render when `_twoColItems` ie enabled. This PR addresses that issue. 

