### PR TITLE
Tokens: set `outputReferences": true` for android/resources

### DIFF
--- a/packages/gestalt-design-tokens/build.js
+++ b/packages/gestalt-design-tokens/build.js
@@ -94,8 +94,8 @@ StyleDictionary.registerFormat({
 });
 
 StyleDictionary.registerFormat({
-  name: 'darkThemeFormat-android/colors',
-  formatter: formatDarkTheme('android/colors'),
+  name: 'darkThemeFormat-android/resources',
+  formatter: formatDarkTheme('android/resources'),
 });
 
 StyleDictionary.registerFormat({

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -137,17 +137,21 @@
       "files": [
         {
           "destination": "colors.xml",
-          "format": "android/colors",
+          "format": "android/resources",
           "_format_comment": "https://amzn.github.io/style-dictionary/#/formats?id=androidcolors",
+          "resourceType": "color",
           "filter": {
             "attributes": {
               "category": "color"
             }
+          },
+          "options": {
+            "outputReferences": true
           }
         },
         {
           "destination": "colors-dark.xml",
-          "format": "darkThemeFormat-android/colors",
+          "format": "darkThemeFormat-android/resources",
           "_filter_comment": "Custom. See packages/gestalt-design-tokens/build.js"
         },
         {

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -164,6 +164,9 @@
               "category": "font",
               "type": "size"
             }
+          },
+          "options": {
+            "outputReferences": true
           }
         },
         {
@@ -174,6 +177,9 @@
             "attributes": {
               "category": "opacity"
             }
+          },
+          "options": {
+            "outputReferences": true
           }
         },
         {
@@ -184,6 +190,9 @@
             "attributes": {
               "category": "rounding"
             }
+          },
+          "options": {
+            "outputReferences": true
           }
         },
         {
@@ -194,6 +203,9 @@
             "attributes": {
               "category": "space"
             }
+          },
+          "options": {
+            "outputReferences": true
           }
         }
       ]

--- a/packages/gestalt-design-tokens/config.json
+++ b/packages/gestalt-design-tokens/config.json
@@ -152,7 +152,13 @@
         {
           "destination": "colors-dark.xml",
           "format": "darkThemeFormat-android/resources",
-          "_filter_comment": "Custom. See packages/gestalt-design-tokens/build.js"
+          "_filter_comment": "Custom. See packages/gestalt-design-tokens/build.js",
+          "resourceType": "color",
+          "filter": {
+            "attributes": {
+              "category": "color"
+            }
+          }
         },
         {
           "destination": "font-size.xml",


### PR DESCRIPTION
Adding token original references to tokens

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/f5a6d2f1-fcde-423f-aedb-94d760c2366e)

https://amzn.github.io/style-dictionary/#/formats?id=androidresources

### BEFORE
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/8bf8e0b4-fe0d-445c-b619-f38b6a5ced1e)
 

### AFTER 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/d7350fd8-973b-44e5-ac3e-728a7009fc67)
