### PR TITLE
TagData: Move to BreakAll

### DIFF
--- a/packages/gestalt/src/TagData.js
+++ b/packages/gestalt/src/TagData.js
@@ -230,6 +230,7 @@ export default function TagData({
                 title={tooltip && tooltip.text ? '' : text} // removes html caption if a tooltip exists
                 lineClamp={1}
                 color={fgColor}
+                overflow="breakAll"
               >
                 {text}
               </Text>

--- a/packages/gestalt/src/__snapshots__/TagData.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.js.snap
@@ -57,7 +57,7 @@ exports[`TagData TagData has a tooltip 1`] = `
             }
           >
             <span
-              className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -138,7 +138,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -214,7 +214,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -290,7 +290,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -366,7 +366,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -442,7 +442,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -518,7 +518,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -594,7 +594,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -670,7 +670,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -746,7 +746,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -822,7 +822,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -898,7 +898,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -974,7 +974,7 @@ exports[`TagData renders all colors as expected 1`] = `
                 }
               >
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -1111,7 +1111,7 @@ exports[`TagData renders base color as expected 1`] = `
                   </div>
                 </div>
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -1241,7 +1241,7 @@ exports[`TagData renders base color as expected 1`] = `
                   </div>
                 </div>
                 <span
-                  className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+                  className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
                   style={
                     Object {
                       "WebkitLineClamp": 1,
@@ -1367,7 +1367,7 @@ exports[`TagData renders disabled selected state 1`] = `
               </div>
             </div>
             <span
-              className="Text fontSize200 subtle alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize200 subtle alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -1477,7 +1477,7 @@ exports[`TagData renders disabled unselected state 1`] = `
               </div>
             </div>
             <span
-              className="Text fontSize200 subtle alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize200 subtle alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -1606,7 +1606,7 @@ exports[`TagData renders dismisible button with color background 1`] = `
               </div>
             </div>
             <span
-              className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -1772,7 +1772,7 @@ exports[`TagData renders dismissable button 1`] = `
               </div>
             </div>
             <span
-              className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+              className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
               style={
                 Object {
                   "WebkitLineClamp": 1,
@@ -1912,7 +1912,7 @@ exports[`TagData renders tagdata in RTL mode as expected 1`] = `
             </div>
           </div>
           <span
-            className="Text fontSize200 default alignStart breakWord fontWeightNormal lineClamp"
+            className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
             style={
               Object {
                 "WebkitLineClamp": 1,


### PR DESCRIPTION
# Pull Request Instructions

Changing Breakword to BreakAll:

![image](https://github.com/pinterest/gestalt/assets/5509813/a1a7ad2a-d0d4-4d1f-8de7-f8d3218a4563)

To align with Tag Behavior as in https://github.com/pinterest/gestalt/pull/3435

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
