### PR TITLE
Dropdown: Add disabled variant

### DIFF
--- a/docs/examples/dropdown/disabled.js
+++ b/docs/examples/dropdown/disabled.js
@@ -1,0 +1,70 @@
+// @flow strict
+import { Fragment, type Node as ReactNode, useRef, useState } from 'react';
+import { Box, Button, CompositeZIndex, Dropdown, FixedZIndex } from 'gestalt';
+
+export default function CustomDisabledDropdown(): ReactNode {
+  const PAGE_HEADER_ZINDEX = new FixedZIndex(10);
+
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<null | {
+    label: string,
+    subtext?: string,
+    value: string,
+  }>(null);
+  const anchorRef = useRef<null | HTMLAnchorElement | HTMLButtonElement>(null);
+
+  const onSelect: $ElementType<React$ElementConfig<typeof Dropdown.Item>, 'onSelect'> = ({
+    item,
+  }) => setSelected(item);
+
+  return (
+    <Fragment>
+      <Box display="flex" justifyContent="center" width="100%" margin={2}>
+        <Button
+          accessibilityControls="demo-dropdown-example"
+          accessibilityExpanded={open}
+          accessibilityHaspopup
+          iconEnd="arrow-down"
+          onClick={() => setOpen((prevVal) => !prevVal)}
+          ref={anchorRef}
+          selected={open}
+          size="lg"
+          text="Menu"
+        />
+      </Box>
+      {open && (
+        <Dropdown
+          anchor={anchorRef.current}
+          id="demo-dropdown-example"
+          onDismiss={() => setOpen(false)}
+          zIndex={new CompositeZIndex([PAGE_HEADER_ZINDEX])}
+        >
+          <Dropdown.Item
+            onSelect={onSelect}
+            option={{ value: 'Download image', label: 'Download image' }}
+            selected={selected}
+          />
+          <Dropdown.Item
+            disabled
+            badge={{ text: 'New' }}
+            onSelect={onSelect}
+            option={{ value: 'Hide Pin', label: 'Hide Pin' }}
+            selected={selected}
+          />
+          <Dropdown.Link
+            disabled
+            href="https://pinterest.com"
+            isExternal
+            option={{ value: 'Report Pin', label: 'Report Pin' }}
+            onClick={({ event }) => event.preventDefault()}
+          />
+          <Dropdown.Item
+            onSelect={onSelect}
+            option={{ value: 'Delete Pin', label: 'Delete Pin' }}
+            selected={selected}
+          />
+        </Dropdown>
+      )}
+    </Fragment>
+  );
+}

--- a/docs/pages/web/dropdown.js
+++ b/docs/pages/web/dropdown.js
@@ -16,6 +16,7 @@ import badges from '../../examples/dropdown/badges';
 import composability from '../../examples/dropdown/composability';
 import customHeader from '../../examples/dropdown/customHeader';
 import customItem from '../../examples/dropdown/customItem';
+import disabled from '../../examples/dropdown/disabled';
 import doFeatures from '../../examples/dropdown/doFeatures';
 import doIcons from '../../examples/dropdown/doIcons';
 import dontCustom from '../../examples/dropdown/dontCustom';
@@ -241,6 +242,16 @@ When the text of the Dropdown.Item becomes longer than the width of the menu, ei
             description={`If an item navigates to a new page, use Dropdown.Link with the required \`href\` prop. If the item navigates to a page outside of the current context, (either a non-Pinterest site or a different Pinterest sub-site), the \`isExternal\` prop should also be specified to display the "up-right" icon. Optional additional actions to be taken on navigation are handled by \`onClick\`. Dropdown.Link can be paired with GlobalEventsHandlerProvider. See [GlobalEventsHandlerProvider](/web/utilities/globaleventshandlerprovider#Link-handlers) to learn more about link navigation.
             `}
             sandpackExample={<SandpackExample code={link} name="Link example" layout="column" />}
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="Disabled"
+          description="Dropdown items can be marked as `disabled`. They will not receive focus and will appear inactive."
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={<SandpackExample code={disabled} name="Sections example" />}
           />
         </MainSection.Subsection>
 

--- a/packages/gestalt/src/Dropdown.js
+++ b/packages/gestalt/src/Dropdown.js
@@ -196,8 +196,9 @@ export default function Dropdown({
   const handleKeyNavigation = (
     event: SyntheticKeyboardEvent<HTMLElement>,
     direction: DirectionOptionType,
+    index: number,
   ) => {
-    const newIndex = direction + (hoveredItemIndex ?? 0);
+    const newIndex = direction + (index ?? 0);
     const optionsCount = allowedChildrenOptions.length - 1;
 
     // If there's an existing item, navigate from that position
@@ -216,6 +217,13 @@ export default function Dropdown({
 
     if (cursorOption) {
       const item = cursorOption.option;
+
+      if (cursorOption.disabled) {
+        // re-run the function again and try with the next cursorIndex
+        handleKeyNavigation(event, direction, cursorIndex);
+        return;
+      }
+
       setHoveredItemIndex(cursorIndex);
 
       if (direction === KEYS.ENTER) {
@@ -230,14 +238,14 @@ export default function Dropdown({
   const onKeyDown = ({ event }: { event: SyntheticKeyboardEvent<HTMLElement> }) => {
     const { keyCode } = event;
     if (keyCode === UP_ARROW) {
-      handleKeyNavigation(event, KEYS.UP);
+      handleKeyNavigation(event, KEYS.UP, hoveredItemIndex);
       event.preventDefault();
     } else if (keyCode === DOWN_ARROW) {
-      handleKeyNavigation(event, KEYS.DOWN);
+      handleKeyNavigation(event, KEYS.DOWN, hoveredItemIndex);
       event.preventDefault();
     } else if (keyCode === ENTER) {
       event.stopPropagation();
-      handleKeyNavigation(event, KEYS.ENTER);
+      handleKeyNavigation(event, KEYS.ENTER, hoveredItemIndex);
     } else if ([ESCAPE, TAB].includes(keyCode)) {
       anchor?.focus();
       onDismiss?.();

--- a/packages/gestalt/src/Dropdown/OptionItem.js
+++ b/packages/gestalt/src/Dropdown/OptionItem.js
@@ -38,6 +38,7 @@ type Props = {
   badge?: BadgeType,
   children?: ReactNode,
   dataTestId?: string,
+  disabled?: boolean,
   hoveredItemIndex: ?number,
   href?: string,
   id: string,
@@ -66,6 +67,7 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
     badge,
     children,
     dataTestId,
+    disabled,
     onSelect,
     hoveredItemIndex,
     href,
@@ -95,6 +97,8 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
     if (!href && !children) {
       event.preventDefault();
     }
+
+    if (disabled) return;
     onSelect?.({ event, item: option });
   };
 
@@ -104,8 +108,10 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
     [focusStyles.accessibilityOutline]: isFocusVisible,
     [focusStyles.accessibilityOutlineFocusWithin]: isFocusVisible,
     [styles.fullWidth]: true,
-    [styles.pointer]: true,
+    [styles.pointer]: !disabled,
   });
+
+  const textColor = disabled ? 'subtle' : 'default';
 
   const optionItemContent = (
     <Flex>
@@ -113,10 +119,10 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
         <Flex alignItems="center">
           {children || (
             <Fragment>
-              <Text color="default" inline lineClamp={1} weight={textWeight}>
+              <Text color={textColor} inline lineClamp={1} weight={textWeight}>
                 {option?.label}
               </Text>
-              {badge && (
+              {badge && !disabled && (
                 <Box marginStart={2} marginTop={1}>
                   {/* Adds a pause for screen reader users between the text content */}
                   <Box display="visuallyHidden">{`, `}</Box>
@@ -155,7 +161,7 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
           // marginStart is for spacing relative to Badge, should not be moved to parent Flex's gap
           marginStart={2}
         >
-          <Icon accessibilityLabel="" color="default" icon="visit" size={12} />
+          <Icon accessibilityLabel="" color={textColor} icon="visit" size={12} />
         </Box>
       )}
     </Flex>
@@ -178,20 +184,25 @@ const OptionItemWithForwardRef: AbstractComponent<Props, ?HTMLElement> = forward
         event.stopPropagation();
         event.preventDefault();
       }}
-      onMouseEnter={() => setHoveredItemIndex(index)}
+      onMouseEnter={() => {
+        if (!disabled) {
+          setHoveredItemIndex(index);
+        }
+      }}
       ref={index === hoveredItemIndex ? ref : null}
       role="menuitem"
+      aria-disabled={disabled}
       rounding={2}
-      tabIndex={isMobile ? 0 : -1}
+      tabIndex={isMobile && !disabled ? 0 : -1}
     >
       <Box
-        color={index === hoveredItemIndex ? 'secondary' : 'transparent'}
+        color={index === hoveredItemIndex && !disabled ? 'secondary' : 'transparent'}
         direction="column"
         display="flex"
         padding={2}
         rounding={2}
       >
-        {href ? (
+        {href && !disabled ? (
           <Link
             underline="none"
             href={href}

--- a/packages/gestalt/src/DropdownItem.js
+++ b/packages/gestalt/src/DropdownItem.js
@@ -36,6 +36,10 @@ type Props = {
    */
   dataTestId?: string,
   /**
+   * Disabled items appear inactive and cannot be interacted with.
+   */
+  disabled?: boolean,
+  /**
    * Callback when the user selects an item using the mouse or keyboard.
    */ onSelect: ({
     event: SyntheticInputEvent<HTMLInputElement>,
@@ -77,6 +81,7 @@ export default function DropdownItem({
   badge,
   children,
   dataTestId,
+  disabled,
   _index = 0,
   onSelect,
   option,
@@ -88,6 +93,7 @@ export default function DropdownItem({
         <OptionItem
           badge={badge}
           dataTestId={dataTestId}
+          disabled={disabled}
           hoveredItemIndex={hoveredItemIndex}
           id={id}
           index={_index}

--- a/packages/gestalt/src/DropdownLink.js
+++ b/packages/gestalt/src/DropdownLink.js
@@ -36,6 +36,10 @@ type Props = {
    */
   dataTestId?: string,
   /**
+   * Disabled items appear inactive and cannot be interacted with.
+   */
+  disabled?: boolean,
+  /**
    * Directs users to the url when item is selected. See the [Types of items](https://gestalt.pinterest.systems/web/dropdown#Types-of-items) variant to learn more.
    */
   href: string,
@@ -68,6 +72,7 @@ export default function DropdownLink({
   badge,
   children,
   dataTestId,
+  disabled,
   href,
   _index = 0,
   isExternal,
@@ -80,6 +85,7 @@ export default function DropdownLink({
         <OptionItem
           badge={badge}
           dataTestId={dataTestId}
+          disabled={disabled}
           hoveredItemIndex={hoveredItemIndex}
           href={href}
           id={id}


### PR DESCRIPTION
# Pull Request Instructions

This adds a disabled variant to Dropdown Items.

Disabled items do not receive focus and are not announced by screen-readers.

### Summary

If Disabled:

When Disabled:
<img width="275" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/17c4df90-4827-417c-808b-e4987d893787">


Note: Badges are also hidden in a _disabled_ state:
<img width="261" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/af97749e-b3f9-4cd9-b2c9-2600dcdfb745">


#### What changed?

At a high level, what changes does this PR introduce?

#### Why?

What is the purpose of this PR? Please include the context around these changes for Future Us. In addition to _what_ is changing, we need to know _why_ these changes are needed. Imagine someone is looking at these changes a year from now and needs to know why they were made.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
