### PR TITLE
Masonry: seeded random values for deterministic integration tests

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -233,7 +233,7 @@ export default class MasonryContainer extends Component<Props<{ ... }>, State> {
             name,
             numberOfItems: until - from,
             previousItemCount: from,
-            randomNumberSeed: Math.random(),
+            randomNumberSeed: this.randomNumberSeed,
             pinHeightsSample,
             twoColItems: twoColItems && from > TWO_COL_MINDEX,
           })
@@ -277,7 +277,7 @@ export default class MasonryContainer extends Component<Props<{ ... }>, State> {
             name: undefined,
             numberOfItems: until - defaultFrom,
             previousItemCount: defaultFrom,
-            randomNumberSeed: Math.random(),
+            randomNumberSeed: this.randomNumberSeed,
             pinHeightsSample,
             twoColItems: twoColItems && defaultFrom > TWO_COL_MINDEX,
           })

--- a/docs/integration-test-helpers/masonry/items-utils/generateExampleItems.js
+++ b/docs/integration-test-helpers/masonry/items-utils/generateExampleItems.js
@@ -27,7 +27,7 @@ export default function generateExampleItems({
   twoColItems,
 }: Args): $ReadOnlyArray<ExampleItem> {
   const getRandomNumber = getRandomNumberGenerator(randomNumberSeed);
-  const twoColItemIndex = twoColItems ? Math.floor(Math.random() * numberOfItems) : undefined;
+  const twoColItemIndex = twoColItems ? Math.floor(getRandomNumber() * numberOfItems) : undefined;
 
   return Array.from({ length: numberOfItems }).map((_, i) => {
     const pin = {

--- a/docs/integration-test-helpers/masonry/items-utils/generateRealisticExampleItems.js
+++ b/docs/integration-test-helpers/masonry/items-utils/generateRealisticExampleItems.js
@@ -32,7 +32,7 @@ export default function generateRealisticExampleItems({
 }: Args): $ReadOnlyArray<ExampleItem> {
   const getRandomNumber = getRandomNumberGenerator(randomNumberSeed);
   const baseIndex = Math.ceil(randomNumberSeed * 10);
-  const twoColItemIndex = twoColItems ? Math.floor(Math.random() * numberOfItems) : undefined;
+  const twoColItemIndex = twoColItems ? Math.floor(getRandomNumber() * numberOfItems) : undefined;
 
   return Array.from({ length: numberOfItems }).map((_, i) => {
     const pin = {

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { ColorSchemeProvider, Masonry } from 'gestalt';
 import generateExampleItems from '../../integration-test-helpers/masonry/items-utils/generateExampleItems';
 import generateRealisticExampleItems from '../../integration-test-helpers/masonry/items-utils/generateRealisticExampleItems';
+import getRandomNumberGenerator from "../../integration-test-helpers/masonry/items-utils/getRandomNumberGenerator";
 import pinHeights, {
   type PinHeight,
 } from '../../integration-test-helpers/masonry/items-utils/pinHeights';
@@ -137,26 +138,13 @@ export default function TestPage({
   );
 }
 
-// Math.random(), but deterministic if the same initialSeed is used
-// Important for consistent integration tests with placement determinism
-function createSeededRandom(initialSeed: number) {
-  let seed = initialSeed;
-  return () => {
-    const a = 1664525;
-    const c = 1013904223;
-    const m = 2 ** 32;
-    seed = (a * seed + c) % m;
-    return seed / m;
-  };
-}
-
 export async function getServerSideProps(): Promise<{
   props: { randomNumberSeeds: $ReadOnlyArray<number> },
 }> {
   // This is used to ensure we're using the same dataset of realistic pins on the server and client
   const randomNumberSeeds = Array.from({
     length: REALISTIC_PINS_DATASET_SIZE,
-  }).map(createSeededRandom(12345));
+  }).map(getRandomNumberGenerator(12345));
   return {
     props: {
       randomNumberSeeds,

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -137,13 +137,26 @@ export default function TestPage({
   );
 }
 
+// Math.random(), but deterministic if the same initialSeed is used
+// Important for consistent integration tests with placement determinism
+function createSeededRandom(initialSeed: number) {
+  let seed = initialSeed;
+  return () => {
+    const a = 1664525;
+    const c = 1013904223;
+    const m = 2 ** 32;
+    seed = (a * seed + c) % m;
+    return seed / m;
+  };
+}
+
 export async function getServerSideProps(): Promise<{
   props: { randomNumberSeeds: $ReadOnlyArray<number> },
 }> {
   // This is used to ensure we're using the same dataset of realistic pins on the server and client
   const randomNumberSeeds = Array.from({
     length: REALISTIC_PINS_DATASET_SIZE,
-  }).map(() => Math.random());
+  }).map(createSeededRandom(12345));
   return {
     props: {
       randomNumberSeeds,

--- a/docs/pages/integration-test/masonry.js
+++ b/docs/pages/integration-test/masonry.js
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { ColorSchemeProvider, Masonry } from 'gestalt';
 import generateExampleItems from '../../integration-test-helpers/masonry/items-utils/generateExampleItems';
 import generateRealisticExampleItems from '../../integration-test-helpers/masonry/items-utils/generateRealisticExampleItems';
-import getRandomNumberGenerator from "../../integration-test-helpers/masonry/items-utils/getRandomNumberGenerator";
+import getRandomNumberGenerator from '../../integration-test-helpers/masonry/items-utils/getRandomNumberGenerator';
 import pinHeights, {
   type PinHeight,
 } from '../../integration-test-helpers/masonry/items-utils/pinHeights';


### PR DESCRIPTION
### Summary

#### What changed?

Masonry integration tests now have randomized values that are deterministic from one test run to the next due to the addition of a custom pseudo random number generator that accepts a seed value.

#### Why?

This allows us to write integration tests to assert things like "this two column element should be rendered on the third row, which is the optimal position given these item sizes".

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-7638)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
