### PR TITLE
Docs: Fix md page width

### DIFF
--- a/docs/docs-components/MarkdownPage.js
+++ b/docs/docs-components/MarkdownPage.js
@@ -53,28 +53,32 @@ const components = {
   ul: (props) => {
     const filtered = Object.values(props.children).filter((a) => a !== '\n');
     return (
-      <List>
-        {filtered.map((a, index) => (
-          <List.Item
-            key={JSON.stringify(a?.props.child ?? index)}
-            text={<Text>{a?.props.children}</Text>}
-          />
-        ))}
-      </List>
+      <Box maxWidth={DOCS_COPY_MAX_WIDTH_PX}>
+        <List>
+          {filtered.map((a, index) => (
+            <List.Item
+              key={JSON.stringify(a?.props.child ?? index)}
+              text={<Text>{a?.props.children}</Text>}
+            />
+          ))}
+        </List>
+      </Box>
     );
   },
   // $FlowFixMe[missing-local-annot]
   ol: (props) => {
     const filtered = Object.values(props.children).filter((a) => a !== '\n');
     return (
-      <List type="ordered">
-        {filtered.map((a, index) => (
-          <List.Item
-            key={JSON.stringify(a?.props.child ?? index)}
-            text={<Text>{a?.props.children}</Text>}
-          />
-        ))}
-      </List>
+      <Box maxWidth={DOCS_COPY_MAX_WIDTH_PX}>
+        <List type="ordered">
+          {filtered.map((a, index) => (
+            <List.Item
+              key={JSON.stringify(a?.props.child ?? index)}
+              text={<Text>{a?.props.children}</Text>}
+            />
+          ))}
+        </List>
+      </Box>
     );
   },
   // $FlowFixMe[missing-local-annot]
@@ -118,6 +122,8 @@ const components = {
       <hr />
     </Box>
   ),
+  // $FlowFixMe[missing-local-annot]
+  p: (props) => <p style={{ maxWidth: DOCS_COPY_MAX_WIDTH_PX }}> {props.children} </p>,
   ActionButton: ({ children, href }: { href: string, children: string | null }) => (
     <ButtonLink
       href={href}

--- a/docs/markdown/team_support/contributions.md
+++ b/docs/markdown/team_support/contributions.md
@@ -14,6 +14,7 @@ Design system is about collaboration and building blocks! Gestalt offers the ele
 
 1. **Present your idea or suggestion during our Office Hour meetings**
     [Sign up](https://pinch.pinadmin.com/gestaltSignUp) for an office hours slot with your discussion topic!
+    
     Bring your work early-on— What we build into Gestalt comes from the teams across Pinterest, so we’d love to provide guidance and support early and often! The earlier we see the work, the better we're able to plan and the higher the likelihood we'll be able to help. It does not need to be a polished presentation but should have enough detail to help us understand the help you need and provide support.
 2. **Iterate on solutions**
     We love to see more iteration in your design. We ask you to consider all edge cases before presenting your work to us and coming up with explorations and possible solutions.


### PR DESCRIPTION
# Pull Request Instructions

The previous max width for text was defined globally. This adds it per element and wraps text to always to be 664px or less.

Before:
<img width="1183" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/cf118c62-cb2f-4d75-889c-4e611edcb90e">

After:
<img width="928" alt="image" src="https://github.com/pinterest/gestalt/assets/5509813/fd375bf0-6429-4066-aae9-324e7c4d7801">




## Pull Request Template

### Summary

#### What changed?

Wrapping 

#### Why?

This was creating inconsistencies in the docs site between markdown pages and js pages

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
