### PR TITLE
TextField: Fixing data-testid typo

### DIFF
--- a/packages/gestalt/src/TextField/InternalTextField.js
+++ b/packages/gestalt/src/TextField/InternalTextField.js
@@ -196,7 +196,7 @@ const InternalTextFieldWithForwardRef: AbstractComponent<Props, HTMLInputElement
       aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
       autoComplete={autoComplete}
       className={tags ? unstyledClasses : styledClasses}
-      data-test-id={dataTestId}
+      data-testid={dataTestId}
       disabled={disabled}
       enterKeyHint={mobileEnterKeyHint}
       id={id}


### PR DESCRIPTION
### Summary

#### What changed?

Removed a dash in the InternalTextField dataTestId prop

#### Why?

The previous data-test-id prop was not the actual attribute used by HTML.