### PR TITLE
Masonry: Enable two column module on secod batch

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.js
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.js
@@ -86,31 +86,43 @@ export default class MasonryContainer extends Component<Props<{ ... }>, State> {
 
   randomNumberSeed: number = 0;
 
+  triggerReflow: () => void = () => {
+    if (this.gridRef.current) {
+      this.gridRef.current.reflow();
+      this.forceUpdate();
+    }
+  };
+
+  // $FlowFixMe[unclear-type]
+  setMasonryItems: (e: { detail: { items: $ReadOnlyArray<Object> } }) => void = (e) => {
+    this.setState({
+      items: e.detail.items,
+    });
+  };
+
+  // eslint-disable-next-line class-methods-use-this
+  countError: () => void = () => {
+    window.ERROR_COUNT += 1;
+  };
+
   componentDidMount() {
     window.TEST_FETCH_COUNTS = 0;
-
-    window.addEventListener('trigger-reflow', () => {
-      if (this.gridRef.current) {
-        this.gridRef.current.reflow();
-        this.forceUpdate();
-      }
-    });
-
-    window.addEventListener('set-masonry-items', (e) => {
-      this.setState({
-        items: e.detail.items,
-      });
-    });
-
     window.ERROR_COUNT = window.ERROR_COUNT || 0;
-    window.addEventListener('error', () => {
-      window.ERROR_COUNT += 1;
-    });
+
+    window.addEventListener('trigger-reflow', this.triggerReflow);
+    window.addEventListener('set-masonry-items', this.setMasonryItems);
+    window.addEventListener('error', this.countError);
 
     // Trigger a re-render in case we need to render /w scrollContainer.
     setTimeout(() => {
       this.setState({ mounted: true }); // eslint-disable-line react/no-unused-state
     });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('trigger-reflow', this.triggerReflow);
+    window.removeEventListener('set-masonry-items', this.setMasonryItems);
+    window.removeEventListener('error', this.countError);
   }
 
   handleToggleScrollContainer: () => void = () => {

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -594,8 +594,6 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
         ? Math.max(...positions.map((pos) => pos.top + pos.height))
         : 0;
 
-      console.log(positions);
-
       gridBody = (
         <div style={{ width: '100%' }} ref={this.setGridWrapperRef}>
           <div className={styles.Masonry} role="list" style={{ height, width }}>

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -577,7 +577,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       gridBody = <div style={{ width: '100%' }} ref={this.setGridWrapperRef} />;
     } else {
       // Full layout is possible
-      const itemsWithMeasures = items.filter((item) => item && measurementStore.has(item));
+      const itemsWithMeasurements = items.filter((item) => item && measurementStore.has(item));
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
       const hasTwoColumnItems =
         // $FlowFixMe[prop-missing] We're assuming `columnSpan` exists
@@ -593,12 +593,12 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       // for batch size number of items
       const itemsToRender = hasTwoColumnItems
         ? [
-            ...itemsWithMeasures.filter((item) => item && positionStore.has(item)),
-            ...itemsWithMeasures
+            ...itemsWithMeasurements.filter((item) => item && positionStore.has(item)),
+            ...itemsWithMeasurements
               .filter((item) => item && !positionStore.has(item))
               .slice(0, itemsToMeasureCount),
           ]
-        : itemsWithMeasures;
+        : itemsWithMeasurements;
 
       const positions = getPositions(itemsToRender);
       const measuringPositions = getPositions(itemsToMeasure);

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -577,7 +577,7 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       gridBody = <div style={{ width: '100%' }} ref={this.setGridWrapperRef} />;
     } else {
       // Full layout is possible
-      const itemsToRender = items.filter((item) => item && measurementStore.has(item));
+      const itemsWithMeasures = items.filter((item) => item && measurementStore.has(item));
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
       const hasTwoColumnItems =
         // $FlowFixMe[prop-missing] We're assuming `columnSpan` exists
@@ -588,6 +588,17 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
       const itemsToMeasure = items
         .filter((item) => item && !measurementStore.has(item))
         .slice(0, itemsToMeasureCount);
+
+      // If there is a two column module be sure that we only calculate new positions
+      // for batch size number of items
+      const itemsToRender = hasTwoColumnItems
+        ? [
+            ...itemsWithMeasures.filter((item) => item && positionStore.has(item)),
+            ...itemsWithMeasures
+              .filter((item) => item && !positionStore.has(item))
+              .slice(0, itemsToMeasureCount),
+          ]
+        : itemsWithMeasures;
 
       const positions = getPositions(itemsToRender);
       const measuringPositions = getPositions(itemsToMeasure);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -452,13 +452,6 @@ const defaultTwoColumnModuleLayout = <T>({
       });
       heightsCache?.setHeights(finalHeights);
 
-      /* console.log('module layout in two column module');
-       * console.log({
-       *   prevOneColumnItems,
-       *   batchWithTwoColumnItem,
-       *   finalPositions,
-       * }); */
-
       // FUTURE OPTIMIZATION - do we want a min threshold for an acceptably low score?
       // If so, we could save the 2-col item somehow and try again with the next batch of items
 

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -278,7 +278,7 @@ const defaultTwoColumnModuleLayout = <T>({
     };
 
     if (hasTwoColumnItems) {
-      const prevOneColumnItems = itemsWithPositions;
+      const prevOneColumnItems = [...itemsWithPositions];
       let batchWithTwoColumnItem: $ReadOnlyArray<T> = [];
 
       // If the number of items to position is greater that the batch size
@@ -318,6 +318,13 @@ const defaultTwoColumnModuleLayout = <T>({
           heights,
           ...commonGetPositionArgs,
         });
+
+      // Adding the extra prev one column items to the position cache
+      if (prevOneColumnItems.length > itemsWithPositions.length) {
+        paintedItemPositions.forEach(({ item, position }) => {
+          positionCache.set(item, position);
+        });
+      }
 
       // Initialize the graph
       const graph = new Graph<T>();

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -276,4 +276,63 @@ describe('two column layout test cases', () => {
       { 'height': 211, 'left': 861, 'top': 664, 'width': 240 },
     ]);
   });
+
+  test('returns positions for all items when two columns item is on a large batch', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 206, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 207, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 208, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 209, 'color': '#F45098' },
+      { 'name': 'Pin 10', 'height': 210, 'color': '#30BAF6' },
+      { 'name': 'Pin 11', 'height': 211, 'color': '#7076FA' },
+      { 'name': 'Pin 12', 'height': 212, 'color': '#B032ED' },
+      { 'name': 'Pin 13', 'height': 213, 'color': '#F21DCF', 'columnSpan': 2 },
+      { 'name': 'Pin 14', 'height': 214, 'color': '#45098F' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1200,
+    });
+
+    const positions = layout(items);
+    const orderedPositions = items.map((item) => positionCache.get(item));
+
+    expect(positions.length).toEqual(items.length);
+    expect(orderedPositions).toEqual([
+      { height: 200, left: 99, top: 0, width: 240 },
+      { height: 201, left: 353, top: 0, width: 240 },
+      { height: 202, left: 607, top: 0, width: 240 },
+      { height: 203, left: 861, top: 0, width: 240 },
+      { height: 204, left: 99, top: 214, width: 240 },
+      { height: 205, left: 353, top: 215, width: 240 },
+      { height: 206, left: 607, top: 216, width: 240 },
+      { height: 207, left: 861, top: 217, width: 240 },
+      { height: 208, left: 99, top: 432, width: 240 },
+      { height: 209, left: 353, top: 434, width: 240 },
+      { height: 210, left: 607, top: 436, width: 240 },
+      { height: 211, left: 861, top: 664, width: 240 },
+      { height: 212, left: 861, top: 438, width: 240 },
+      { height: 213, left: 353, top: 660, width: 494 },
+      { height: 214, left: 99, top: 654, width: 240 },
+    ]);
+  });
 });

--- a/playwright/masonry/two-module.spec.mjs
+++ b/playwright/masonry/two-module.spec.mjs
@@ -21,4 +21,53 @@ test.describe('Masonry: two columns module', () => {
 
     await expect(page.getByText('columnSpan: 2')).toBeVisible();
   });
+
+  test('render the two column module on second batch with hydration', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1200, height: 900 });
+    await page.goto(
+      getServerURL({
+        manualFetch: true,
+        twoColItems: true,
+      })
+    );
+
+    const testItems = [
+      { name: 'Pin 0', height: 200, color: '#E230BA' },
+      { name: 'Pin 1', height: 202, color: '#FAB032' },
+      { name: 'Pin 2', height: 206, color: '#EDF21D' },
+      { name: 'Pin 3', height: 204, color: '#CF4509' },
+      { name: 'Pin 4', height: 205, color: '#230BAF' },
+      { name: 'Pin 5', height: 209, color: '#67076F' },
+      { name: 'Pin 6', height: 207, color: '#AB032E' },
+      { name: 'Pin 7', height: 208, color: '#DF21DC' },
+      { name: 'Pin 8', height: 209, color: '#F45098' },
+      { name: 'Pin 9', height: 201, color: '#F67076', columnSpan: 2 },
+      { name: 'Pin 10', height: 209, color: '#67076F' },
+      { name: 'Pin 11', height: 207, color: '#AB032E' },
+      { name: 'Pin 12', height: 208, color: '#DF21DC' },
+      { name: 'Pin 13', height: 209, color: '#F45098' },
+      { name: 'Pin 14', height: 200, color: '#E230BA' },
+      { name: 'Pin 15', height: 202, color: '#FAB032' },
+    ];
+
+    // The two modules items appear after the 50th pin, we add at least 60 items
+    const toogleMountButton = await page.locator(selectors.toggleMount);
+    await toogleMountButton.click();
+
+    await page.evaluate((proxiedItemData) => {
+      window.dispatchEvent(
+        new CustomEvent('set-masonry-items', {
+          detail: {
+            items: proxiedItemData,
+          },
+        })
+      );
+    }, testItems);
+
+    await toogleMountButton.click();
+
+    await expect(page.getByText('columnSpan: 2')).toBeVisible();
+  });
 });

--- a/playwright/masonry/two-module.spec.mjs
+++ b/playwright/masonry/two-module.spec.mjs
@@ -52,7 +52,6 @@ test.describe('Masonry: two columns module', () => {
       { name: 'Pin 15', height: 202, color: '#FAB032' },
     ];
 
-    // The two modules items appear after the 50th pin, we add at least 60 items
     const toogleMountButton = await page.locator(selectors.toggleMount);
     await toogleMountButton.click();
 


### PR DESCRIPTION
### Summary

This PR fixes an issue where the page would freeze trying to calculate the position of a two column module when there are many items that have the height already measured but not the position. This is required to enable the use of a two column module on the first page (with the items comming from the server).

#### Detail

When Masonry is first rendered it measures the heights of all the items at the same time, after that it calculates the positions. This was not a problem for one column items because the process to calculate the positions is very fast, but for two column items this is really hard because it has to create the graph for all the items not limited to the batch size, depending on the amount of items this can freeze the page completely. 

To fix it we can force the batch size when there is a two column module taking into account the items that don't have positions and limiting those to the batch size.

This PR also fixes a bug on the integration test page were the event are added twice.
