### PR TITLE
ESLint plugin: `only-valid-tokens`

### DIFF
--- a/docs/pages/get_started/developers/eslint_plugin.js
+++ b/docs/pages/get_started/developers/eslint_plugin.js
@@ -17,6 +17,12 @@ export default function EslintPluginPage(): ReactNode {
         description="The following ESLint rules provide guidance on how to replace native HTML elements and attributes with available Gestalt equivalents"
       >
         <MainSection.Subsection
+          title="gestalt/only-valid-tokens"
+          description={`
+        Prevent the consumption of Gestalt tokens via hard-coded strings p.e. "var(--color-border-error)". Instead import constant from 'gestalt-design-tokens' p.e. import { TOKEN_COLOR_BORDER_ERROR } from "gestalt-design-tokens".
+      `}
+        />
+        <MainSection.Subsection
           title="gestalt/prefer-box-inline-style"
           description={`
         Prevent using \`<div>\` inline styling for attributes that are already implemented in Box.

--- a/packages/eslint-plugin-gestalt/README.md
+++ b/packages/eslint-plugin-gestalt/README.md
@@ -40,33 +40,7 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
-### gestalt/button-icon-restrictions
-
-Require a specific value when using an icon with Button. Gestalt is more permissive than we recommend internally for adding icons to Buttons, so Buttons using iconEnd must use icon "arrow-down".
-
-### gestalt/no-box-marginleft-marginright
-
-Disallow marginLeft/marginRight on Box. In order to have consistent usage of marginLeft/marginRight on Box in production, we update all of them to marginStart/marginEnd.
-
-### gestalt/no-box-dangerous-style-duplicates
-
-Prevent using dangerouslySetInlineStyle on Box for props that are already directly implemented. Box supports some props already that are not widely known and instead are being implemented with dangerouslySetInlineStyle. This linter checks for usage of already available props as dangerous styles and suggests the alternative.
-
-### gestalt/no-medium-formfields
-
-Disallow medium form fields. In order to have consistent form fields in production, we update all of their sizes to large and disallow medium.
-
-### gestalt/no-role-link-components
-
-Do not allow `role='link'` on `Button`, `TapArea`, and `IconButton` in cases where an alternative with additional functionality must be used instead such as for use with a routing library
-
-### gestalt/prefer-box
-
-Prevent using inline styles on divs that could be gestalt Box props. We prefer using gestalt Box over divs with inline styling to get styling consistency across the app and shared css classes. This linter checks for usage of inline styling that is available as Box props.
-
-### gestalt/prefer-list
-
-Disallow use of `<ol>` or `<ul>` elements in favor of our [List](https://gestalt.pinterest.systems/web/list) component.
+Visit [our ESLint rules documentation page](https://gestalt.pinterest.systems/get_started/developers/eslint_plugin)
 
 ## Development
 

--- a/packages/eslint-plugin-gestalt/rollup.config.js
+++ b/packages/eslint-plugin-gestalt/rollup.config.js
@@ -1,5 +1,6 @@
 // eslint-disable-next-line flowtype/require-valid-file-annotation
 import babel from '@rollup/plugin-babel';
+import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
@@ -36,6 +37,7 @@ const rollupConfig = {
       plugins: ['@babel/proposal-class-properties'],
       exclude: 'node_modules/**',
     }),
+    commonjs(),
   ],
 };
 

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/dangerouslySetInlineStyle-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/dangerouslySetInlineStyle-input.js
@@ -1,0 +1,13 @@
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundColor: 'var(--color-border-container)',
+        },
+      }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/dangerouslySetInlineStyle-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/dangerouslySetInlineStyle-output.js
@@ -1,0 +1,14 @@
+import { TOKEN_COLOR_BORDER_CONTAINER } from 'gestalt-design-tokens';
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundColor: `${TOKEN_COLOR_BORDER_CONTAINER}` + 'var(--color-border-container)',
+        },
+      }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/inline-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/inline-input.js
@@ -1,0 +1,15 @@
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Box>
+      <div
+        className="appContent"
+        role="main"
+        style={{
+          backgroundColor: 'var(--color-border-error)',
+        }}
+      />
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/inline-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/inline-output.js
@@ -1,0 +1,16 @@
+import { TOKEN_COLOR_BORDER_ERROR } from 'gestalt-design-tokens';
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  return (
+    <Box>
+      <div
+        className="appContent"
+        role="main"
+        style={{
+          backgroundColor: `${TOKEN_COLOR_BORDER_ERROR}` + 'var(--color-border-error)',
+        }}
+      />
+    </Box>
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/unsafeCss-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/unsafeCss-input.js
@@ -1,0 +1,11 @@
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  const getTableInlineStyle = () => `
+.CustomColor tbody tr td > button[aria-label="collapse"] {
+  background-color: var(--color-background-default);
+}
+`;
+
+  return <div />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/unsafeCss-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/unsafeCss-output.js
@@ -1,0 +1,12 @@
+import { TOKEN_COLOR_BACKGROUND_DEFAULT } from 'gestalt-design-tokens';
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  const getTableInlineStyle = () => `${TOKEN_COLOR_BACKGROUND_DEFAULT}` + `
+.CustomColor tbody tr td > button[aria-label="collapse"] {
+  background-color: var(--color-background-default);
+}
+`;
+
+  return <div />;
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/variable-input.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/variable-input.js
@@ -1,0 +1,15 @@
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  const colorToken = 'var(--color-white-mochimalist-0)';
+
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundColor: colorToken,
+        },
+      }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/variable-output.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/invalid/variable-output.js
@@ -1,0 +1,16 @@
+import { TOKEN_COLOR_WHITE_MOCHIMALIST_0 } from 'gestalt-design-tokens';
+import { Box } from 'gestalt';
+
+export default function TestElement() {
+  const colorToken = `${TOKEN_COLOR_WHITE_MOCHIMALIST_0}` + 'var(--color-white-mochimalist-0)';
+
+  return (
+    <Box
+      dangerouslySetInlineStyle={{
+        __style: {
+          backgroundColor: colorToken,
+        },
+      }}
+    />
+  );
+}

--- a/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/valid/valid.js
+++ b/packages/eslint-plugin-gestalt/src/__fixtures__/only-valid-tokens/valid/valid.js
@@ -1,0 +1,11 @@
+import { Box } from 'gestalt'
+
+export default function TestElement() {
+  const a = 'var(--color-123)'
+  return <ul>
+    <li>Gestalt</li>
+    <Box dangerouslySetInlineStyle={{ __style: {
+      backgroundColor: 'var(--color-123)'
+    }}}/>
+  </ul>;
+}

--- a/packages/eslint-plugin-gestalt/src/index.js
+++ b/packages/eslint-plugin-gestalt/src/index.js
@@ -9,6 +9,7 @@ import noMediumFormfields from './no-medium-formfields';
 import noRoleLinkComponents from './no-role-link-components';
 import noSpreadProps from './no-spread-props';
 import noWorkflowStatusIcon from './no-workflow-status-icon';
+import onlyValidTokens from './only-valid-tokens';
 import preferBoxAsTag from './prefer-box-as-tag';
 import preferBoxInlineStyle from './prefer-box-inline-style';
 import preferBoxNoClassname from './prefer-box-no-disallowed';
@@ -28,6 +29,7 @@ module.exports = {
     'no-role-link-components': noRoleLinkComponents,
     'no-spread-props': noSpreadProps,
     'no-workflow-status-icon': noWorkflowStatusIcon,
+    'only-valid-tokens': onlyValidTokens,
     'prefer-box-inline-style': preferBoxInlineStyle,
     'prefer-box-no-disallowed': preferBoxNoClassname,
     'prefer-box-as-tag': preferBoxAsTag,

--- a/packages/eslint-plugin-gestalt/src/only-valid-tokens.js
+++ b/packages/eslint-plugin-gestalt/src/only-valid-tokens.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Only valid tokens: prevent the consumption of Gestalt tokens via hard-coded strings p.e. var(--color-border-error). Instead import constant from 'gestalt-design-tokens' p.e. import { TOKEN_COLOR_BORDER_ERROR } from 'gestalt-design-tokens'.
+ */
+// @flow strict
+import tokens from 'gestalt-design-tokens/dist/js/constants';
+import { getTextNodeFromSourceCode } from './helpers/eslintASTHelpers';
+import { type ESLintRule } from './helpers/eslintFlowTypes';
+
+const tokensValues: $ReadOnlyArray<$ReadOnlyArray<mixed>> = Object.entries(tokens);
+
+const rule: ESLintRule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Only valid tokens: Import Gestalt tokens from gestalt-design-tokens rather than hard-coded strings',
+      category: 'Gestalt alternatives',
+      recommended: true,
+      url: 'https://gestalt.pinterest.systems/eslint%20plugin#gestaltprefer-list',
+    },
+    schema: ([]: $ReadOnlyArray<empty>),
+    fixable: 'code',
+    messages: {
+      invalidTokenString: `This string contains Gestalt hard-coded strings tokens: '{{ token }}'. Replace with equivalent constant: import { {{ replacement }} } from 'gestalt-design-tokens'.`,
+    },
+  },
+
+  create(context) {
+    let data;
+    return {
+      Program(programNode) {
+        programNode.tokens.forEach((nodeToken) => {
+          if (
+            (nodeToken.type === 'String' || nodeToken.type === 'Template') &&
+            tokensValues.some(([key, value]) => {
+              const match = typeof value === 'string' ? value.match(/var\(([^)]+)\)/) : null;
+
+              const hasToken =
+                typeof value === 'string' && match && match[1]
+                  ? nodeToken.value.match(match[1])
+                  : false;
+
+              if (hasToken) {
+                data = [key, value];
+              }
+
+              return hasToken;
+            })
+          ) {
+            context.report({
+              node: nodeToken,
+              messageId: 'invalidTokenString',
+              data: {
+                token: data?.[1],
+                replacement: data?.[0],
+              },
+              fix: (fixer) => {
+                const importFixers = fixer.insertTextBefore(
+                  programNode,
+                  `import { ${
+                    typeof data?.[0] === 'string' ? data?.[0] : ''
+                  } } from 'gestalt-design-tokens';\n`,
+                );
+
+                const textFixer = fixer.replaceText(
+                  nodeToken,
+                  getTextNodeFromSourceCode({ context, elementNode: nodeToken }).replace(
+                    /^/,
+                    `\`\${${typeof data?.[0] === 'string' ? data?.[0] : ''}}\` + `,
+                  ),
+                );
+
+                const fixers = [importFixers, textFixer];
+                return fixers;
+              },
+            });
+          }
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/eslint-plugin-gestalt/src/only-valid-tokens.test.js
+++ b/packages/eslint-plugin-gestalt/src/only-valid-tokens.test.js
@@ -1,0 +1,52 @@
+// @flow strict
+import {
+  getPathFormatterByRuleName,
+  getRuleTester,
+  getTestTypePrepender,
+  readTestByPath,
+} from './helpers/testHelpers';
+import rule from './only-valid-tokens';
+
+const ruleName = 'only-valid-tokens';
+const ruleTester = getRuleTester();
+const pathFormatter = getPathFormatterByRuleName(ruleName);
+const validPrepender = getTestTypePrepender('valid');
+const invalidPrepender = getTestTypePrepender('invalid');
+
+const buildInvalidTest = (name: string) => readTestByPath(pathFormatter(invalidPrepender(name)));
+
+const validCode = readTestByPath(pathFormatter(validPrepender('valid')));
+
+const dangerouslySetInlineStyleInput = buildInvalidTest('dangerouslySetInlineStyle-input');
+const dangerouslySetInlineStyleOutput = buildInvalidTest('dangerouslySetInlineStyle-output');
+
+const inlineInput = buildInvalidTest('inline-input');
+const inlineOutput = buildInvalidTest('inline-output');
+
+const unsafeCssInput = buildInvalidTest('unsafeCss-input');
+const unsafeCssOutput = buildInvalidTest('unsafeCss-output');
+
+const variableInput = buildInvalidTest('variable-input');
+const variableOutput = buildInvalidTest('variable-output');
+
+const messageColorBorderError = `This string contains Gestalt hard-coded strings tokens: 'var(--color-border-error)'. Replace with equivalent constant: import { TOKEN_COLOR_BORDER_ERROR } from 'gestalt-design-tokens'.`;
+
+const messageColorBorderContainer = `This string contains Gestalt hard-coded strings tokens: 'var(--color-border-container)'. Replace with equivalent constant: import { TOKEN_COLOR_BORDER_CONTAINER } from 'gestalt-design-tokens'.`;
+
+const messageColorWhiteMochimalist = `This string contains Gestalt hard-coded strings tokens: 'var(--color-white-mochimalist-0)'. Replace with equivalent constant: import { TOKEN_COLOR_WHITE_MOCHIMALIST_0 } from 'gestalt-design-tokens'.`;
+
+const messageColorBackgroundDefault = `This string contains Gestalt hard-coded strings tokens: 'var(--color-background-default)'. Replace with equivalent constant: import { TOKEN_COLOR_BACKGROUND_DEFAULT } from 'gestalt-design-tokens'.`;
+
+ruleTester.run('only-valid-tokens', rule, {
+  valid: [{ code: validCode }],
+  invalid: [
+    [dangerouslySetInlineStyleInput, dangerouslySetInlineStyleOutput, messageColorBorderContainer],
+    [inlineInput, inlineOutput, messageColorBorderError],
+    [unsafeCssInput, unsafeCssOutput, messageColorBackgroundDefault],
+    [variableInput, variableOutput, messageColorWhiteMochimalist],
+  ].map(([input, output, message]) => ({
+    code: input,
+    output,
+    errors: [{ message }],
+  })),
+});


### PR DESCRIPTION
ESLint plugin: only-valid-tokens


It includes FIX

ERROR
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/710eb29d-2d76-4ade-af7b-ec7a665f51ce)

FIX
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/5fdf72f0-5970-40f6-be4f-76c9e02069fe)

MESSAGING:
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/6283952a-4f37-475c-a835-dda1259c04c0)

Examples: 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/da70ee38-185c-4e35-96dc-54e008657c93)


