### PR TITLE
Enable use of heights with 0 on two column masonry logic

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -25,7 +25,7 @@ function getPositionsOnly<T>(
 function getAdjacentColumnHeightDeltas(heights: $ReadOnlyArray<number>): $ReadOnlyArray<number> {
   return heights.reduce((acc, height, index) => {
     const adjacentColumnHeight = heights[index + 1];
-    if (adjacentColumnHeight) {
+    if (adjacentColumnHeight >= 0) {
       return [...acc, Math.abs(height - adjacentColumnHeight)];
     }
     return acc;


### PR DESCRIPTION
### Summary

Enable use of heights with 0 on two column masonry logic

#### What changed?

...

#### Why?

...