### PR TITLE
Internal: enable `gestalt/only-valid-tokens` ESLint rule + `gestalt-design-tokens` as peer dependency

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
   'plugins': [
     'eslint-comments',
     'flowtype',
+    'gestalt',
     'import',
     'jest',
     'jsx-a11y',
@@ -57,6 +58,7 @@ module.exports = {
     'flowtype/space-after-type-colon': [ERROR, ALWAYS, { 'allowLineBreak': true }],
     'flowtype/space-before-type-colon': [ERROR, NEVER],
     'flowtype/type-import-style': ERROR,
+    'gestalt/only-valid-tokens': ERROR,
     'import/extensions': [ERROR, 'ignorePackages', { 'js': 'never' }],
     'import/first': ERROR,
     'import/newline-after-import': ERROR,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,6 +122,12 @@ module.exports = {
   },
   'overrides': [
     {
+      'files': ['packages/gestalt-design-tokens/**/*.js'],
+      'rules': {
+        'gestalt/only-valid-tokens': OFF,
+      },
+    },
+    {
       'files': ['scripts/templates/*.js'],
       'rules': {
         'import/no-unresolved': OFF,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-flowtype": "^8.0.3",
+    "eslint-plugin-gestalt": ">0.0.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-jest": "^26.1.5",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/gestalt-charts/package.json
+++ b/packages/gestalt-charts/package.json
@@ -13,7 +13,8 @@
     "src"
   ],
   "dependencies": {
-    "recharts": "2.8.0"
+    "recharts": "2.8.0",
+    "gestalt-design-tokens": ">0.0.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-charts/package.json
+++ b/packages/gestalt-charts/package.json
@@ -13,11 +13,11 @@
     "src"
   ],
   "dependencies": {
-    "recharts": "2.8.0",
-    "gestalt-design-tokens": ">0.0.0"
+    "recharts": "2.8.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
+    "gestalt-design-tokens": ">0.0.0",
     "react": "^18.0",
     "react-dom": "^18.0"
   },

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -19,6 +19,7 @@
     "@mui/material": "^5.12.0",
     "@mui/x-date-pickers": "6.11.0",
     "classnames": "^2.2.6",
+    "gestalt-design-tokens": ">0.0.0",
     "react-datepicker": "4.0.0"
   },
   "peerDependencies": {

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -19,11 +19,11 @@
     "@mui/material": "^5.12.0",
     "@mui/x-date-pickers": "6.11.0",
     "classnames": "^2.2.6",
-    "gestalt-design-tokens": ">0.0.0",
     "react-datepicker": "4.0.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
+    "gestalt-design-tokens": ">0.0.0",
     "react": "^18.0",
     "react-dom": "^18.0"
   },

--- a/packages/gestalt/package.json
+++ b/packages/gestalt/package.json
@@ -15,10 +15,10 @@
   ],
   "dependencies": {
     "@floating-ui/react": "^0.25.4",
-    "classnames": "^2.2.6",
-    "gestalt-design-tokens": ">0.0.0"
+    "classnames": "^2.2.6"
   },
   "peerDependencies": {
+    "gestalt-design-tokens": ">0.0.0",
     "react": "^18.0",
     "react-dom": "^18.0"
   },


### PR DESCRIPTION
Internal: enable `gestalt/only-valid-tokens` ESLint rule