### PR TITLE
Masonry: Update scroll performance test

### DIFF
--- a/playwright/masonry/scroll-performance.spec.mjs
+++ b/playwright/masonry/scroll-performance.spec.mjs
@@ -160,7 +160,8 @@ test.describe('Masonry: scrolls', () => {
       JSON.stringify(results, null, 2)
     );
 
-    // this is realistically too low but setting this as an initial assertion until we have more data
-    expect(results.fps).toBeGreaterThan(30);
+    // just setting some initial assertion until we gather more data
+    expect(results.fps).toBeGreaterThan(0);
+    expect(results.completeFrames).toBeGreaterThan(0);
   });
 });

--- a/playwright/masonry/scroll-performance.spec.mjs
+++ b/playwright/masonry/scroll-performance.spec.mjs
@@ -2,25 +2,72 @@
 import fs from 'fs';
 import { expect, test } from '@playwright/test';
 import getServerURL from './utils/getServerURL.mjs';
-import {
-  eventsToCsv,
-  getFpsFromEvents,
-  getFpsMetricsPerScroll,
-  metricsToCsv,
-} from './utils/tracingEvents.mjs';
 import waitForRenderedItems from './utils/waitForRenderedItems.mjs';
+
+const DEFAULT_SCROLL_COUNT = 5;
+const PINS_COUNT = 20;
+const PAGE_HEIGHT = 1000;
 
 /*::
 type Event = {
   name: string,
   ts: number,
-  fps?: number,
+  args?: { frameSeqId?: number },
 };
 */
 
-const DEFAULT_SCROLL_COUNT = 5;
-const PINS_COUNT = 20;
-const PAGE_HEIGHT = 1000;
+function isValidEvent(event /*: Event */) {
+  return event.name === 'clock_sync' || event.args?.frameSeqId;
+}
+
+function microsecondsToMilliseconds(microseconds /*: number */) {
+  return microseconds / 1e3;
+}
+
+/*
+  Parse out the following frame data from the collected trace events:
+  - droppedFrames: These are events with the name DroppedFrame and represent frames that were either dropped or not fully rendered
+  - completeFrames: These are events with the name DrawFrame and represent frames that were fully rendered
+  - frameDuration: This is the duration of each frame, either complete or dropped. A frame duration is calculated as the time between the DrawFrame or DroppedFrame event and the next BeginFrame event
+*/
+function parseFrameData(events /*: $ReadOnlyArray<Event> */) {
+  let currentFrameStartTime;
+  const droppedFrames = events.filter((e) => e.name === 'DroppedFrame').length;
+  const completeFrames = events.filter((e) => e.name === 'DrawFrame').length;
+  const frameDuration = events.reduce(
+    (acc, event) => {
+      if (event.name === 'BeginFrame') {
+        if (currentFrameStartTime != null) {
+          // ts is stored in microseconds. See: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit
+          const delta = microsecondsToMilliseconds(
+            event.ts - currentFrameStartTime
+          );
+          acc.push(delta);
+        }
+      }
+      if (event.name === 'DrawFrame' || event.name === 'DroppedFrame') {
+        currentFrameStartTime = event.ts;
+      }
+      return acc;
+    },
+    ([] /*: Array<number> */)
+  );
+
+  return {
+    droppedFrames,
+    completeFrames,
+    frameDurations: frameDuration,
+  };
+}
+
+function filterAndSortEvents(events /*: Array<Event> */) {
+  const sortedEvents = events.sort((a, b) => a.ts - b.ts);
+  const firstScrollEvent = sortedEvents.find(
+    (e) => e.name === 'scrollTimingStart'
+  );
+  // return all events that occur after the initial scroll
+  return sortedEvents.filter((e) => e.ts > (firstScrollEvent?.ts ?? 0));
+}
 
 test.describe('Masonry: scrolls', () => {
   test('scroll test', async ({ page }) => {
@@ -28,41 +75,49 @@ test.describe('Masonry: scrolls', () => {
 
     // Starting the CDP session only including the desired categories
     const client = await page.context().newCDPSession(page);
-    await client.send('Tracing.start', {
-      traceConfig: {
-        includedCategories: ['benchmark', 'clock_sync'],
-      },
-    });
-
-    // This will be called when tracing is complete
-    client.on('Tracing.dataCollected', (data) => {
-      events.push(
-        ...data.value
-          .filter((e) =>
-            ['DirectRenderer::DrawFrame', 'clock_sync'].includes(e.name)
-          )
-          .map((e) => ({ name: e.name, ts: e.ts }))
-      );
-    });
-
-    const tracingCompleteEvent = new Promise((resolve) => {
-      client.on('Tracing.tracingComplete', () => {
-        resolve();
-      });
-    });
 
     await page.setViewportSize({ width: 1600, height: PAGE_HEIGHT });
     await page.goto(getServerURL());
 
+    // wait for initial paint before we start scrolling to flush out paints
+    await waitForRenderedItems(page, {
+      targetItemsGTE: PINS_COUNT,
+    });
+
+    const traceCompleteEvent = new Promise((resolve) => {
+      client.on('Tracing.tracingComplete', () => {
+        resolve();
+      });
+    });
+    // This will be called when tracing is complete
+    client.on('Tracing.dataCollected', (data) => {
+      events.push(...data.value.filter(isValidEvent));
+    });
+
+    await client.send('Tracing.start', {
+      traceConfig: {
+        includedCategories: [
+          'benchmark',
+          'clock_sync',
+          // add these categories to ensure we get frame data
+          'disabled-by-default-devtools.timeline',
+          'disabled-by-default-devtools.timeline.frame',
+        ],
+      },
+    });
+
     // Scroll x amount of times, we add the sync marker at the start of each scroll
     for (let i = 1; i < DEFAULT_SCROLL_COUNT; i += 1) {
       await client.send('Tracing.recordClockSyncMarker', {
-        syncId: 'scrollTimingMark',
+        syncId: 'scrollTimingStart',
       });
 
       await page.evaluate(
         ({ pageHeight, index }) => {
-          window.scrollTo({ top: pageHeight * index, behavior: 'smooth' });
+          window.scrollTo({
+            top: pageHeight * (index + 1),
+            behavior: 'smooth',
+          });
         },
         { pageHeight: PAGE_HEIGHT, index: i }
       );
@@ -74,23 +129,38 @@ test.describe('Masonry: scrolls', () => {
     await client.send('Tracing.end');
 
     // We need this to wait for the tracing data to be completed
-    await tracingCompleteEvent;
+    await traceCompleteEvent;
 
-    // Calculate fps per scroll and metrics
-    const fpsEvents = getFpsFromEvents(events);
-    const fpsMetricsPerScroll = getFpsMetricsPerScroll(fpsEvents);
+    const sortedEvents = filterAndSortEvents(events);
+    const totalTime = microsecondsToMilliseconds(
+      sortedEvents[sortedEvents.length - 1].ts - sortedEvents[0].ts
+    );
+
+    const { droppedFrames, completeFrames, frameDurations } =
+      parseFrameData(sortedEvents);
+
+    const results = {
+      totalTime,
+      droppedFrames,
+      completeFrames,
+      frameDurations,
+      meanFrameDuration:
+        frameDurations.reduce((a, b) => a + b, 0) / frameDurations.length,
+      maxFrameDuration: Math.max(...frameDurations),
+      // define FPS as the number of complete frames / total time (in seconds)
+      fps: completeFrames / (totalTime / 1000),
+    };
+
+    // eslint-disable-next-line no-console
+    console.log('Test results', results);
 
     // This is temp until we understand the numbers on ci environment
     fs.writeFileSync(
-      'playwright/test-results/scroll-performance-timings.csv',
-      eventsToCsv(fpsEvents)
-    );
-    fs.writeFileSync(
-      'playwright/test-results/scroll-performance-fps-metrics.csv',
-      metricsToCsv(fpsMetricsPerScroll)
+      'playwright/test-results/scroll-performance-results.json',
+      JSON.stringify(results, null, 2)
     );
 
-    // This is only for testing purpouses
-    expect(fpsMetricsPerScroll.every((metric) => metric.avg > 1)).toBeTruthy();
+    // this is realistically too low but setting this as an initial assertion until we have more data
+    expect(results.fps).toBeGreaterThan(30);
   });
 });


### PR DESCRIPTION
### Summary

This PR updates the implementation of the Masonry scroll performance test (first introduced in https://github.com/pinterest/gestalt/pull/3388) to improve the accuracy of the calculations

#### Why
I was looking into comparing data from the scroll performance test against previous runs. Before doing so, I wanted to validate the accuracy of our existing scroll performance test. 

After running the existing test locally, I noticed two things:
- the average FPS numbers seemed consistently high (e.g. 80, 90)
- if i artificially slow down the render (e.g. by rendering a very deep component), the average FPS drops but is still much higher than it should be (50+)  

#### How
The current implementation captures `Tracing` events via the chrome devtools protocol and specifically uses the delta between `DirectRenderer::DrawFrame` events to determine FPS - the assumption being that this is how we determine how long a frame took to render.  

Since there is little/no documentation on how to "best" calculate FPS from Chrome's tracing data, I decided to work backwards from an actual trace to validate our assumption.  

This is an example profile of scrolling the Masonry test page:
![image](https://github.com/pinterest/gestalt/assets/6487551/28b593cd-af6b-476e-99d1-e0e1762bf00f)

The tracing json (for the timeframe of the highlighted frame) looks something like this
```
{"args":{"frameSeqId":6549,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"BeginFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259055358,"tts":94433,"selfTime":0},
{"args":{},"cat":"disabled-by-default-devtools.timeline","dur":3,"name":"RunTask","ph":"X","pid":1566,"tdur":2,"tid":259,"ts":92259055372,"tts":407613506},
{"args":{},"cat":"disabled-by-default-devtools.timeline","dur":24,"name":"RunTask","ph":"X","pid":1566,"tdur":23,"tid":23043,"ts":92259055385,"tts":67460671},
...
{"args":{"frameSeqId":6549,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"DrawFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259055933,"tts":94561,"selfTime":0},
{"args":{},"cat":"disabled-by-default-devtools.timeline","dur":27,"name":"RunTask","ph":"X","pid":1566,"tdur":27,"tid":23043,"ts":92259055950,"tts":67460725},
{"args":{},"cat":"disabled-by-default-devtools.timeline","dur":140,"name":"RunTask","ph":"X","pid":1566,"tdur":138,"tid":23043,"ts":92259055978,"tts":67460752},
...
{"args":{"frameSeqId":6550,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"BeginFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259064537,"tts":94671,"selfTime":0},
{"args":{},"cat":"disabled-by-default-devtools.timeline","dur":28,"name":"RunTask","ph":"X","pid":1566,"tdur":27,"tid":23043,"ts":92259064552,"tts":67461059},
...
{"args":{"frameSeqId":6550,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"DrawFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259065081,"tts":94788,"selfTime":0},
```

- Each frame begins with a `BeginFrame` event and ends with a `DrawFrame` event (note: sometimes a frame can also end with a `DroppedFrame` event). 
- To calculate the time spent rendering a frame, we need to calculate the time between each `BeginFrame` event. In the above example, we would be calculating the delta the timestamps of these two frames `{"args":{"frameSeqId":6550,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"BeginFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259064537,"tts":94671,"selfTime":0},` vs `{"args":{"frameSeqId":6549,"layerTreeId":1},"cat":"disabled-by-default-devtools.timeline.frame","name":"BeginFrame","ph":"I","pid":29114,"s":"t","tid":30467,"ts":92259055358,"tts":94433,"selfTime":0}` which comes out to 9179 microseconds or 9.17ms.

#### Changes
Based on the above explanation, I made the following changes to the test:
- Wait to start the tracing until after the initial render. Also make sure we filter out any events that occur before the initial scroll - this ensures that we only calculate FPS based on the relevant events after scroll starts
- Update `traceConfig.includedCategories` to include `'disabled-by-default-devtools.timeline` and `disabled-by-default-devtools.timeline.frame`. This ensures that we get the relevant frame data mentioned above
- Update the test to determine the following data points:
  -  dropped frames. This is the number of `DroppedFrame` events we see
  - completed frames. This is the number of `DrawFrame` events we see
  - frame duration: This is the duration of each frame (calculated as the delta between `BeginFrame` events
  - FPS: This is now calculated as the overall number of `completeFrames` completed in the time frame. We previously calculated this as the average FPS of each frame - in my testing this didn't seem as accurate as determining how many frames were actually rendered in the time frame

#### Testing
Tested locally, verified data looks _more_ accurate now
```
Test results {
  totalTime: 675.525,
  droppedFrames: 0,
  completeFrames: 41,
  frameDurations: [
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666,
    16.666, 16.666, 16.666, 16.666
  ],
  meanFrameDuration: 16.66600000000001,
  maxFrameDuration: 16.666,
  fps: 60.69353465822879
}
```
















