### PR TITLE
Masonry: Adds a data attribute for two column module on ssr

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -541,6 +541,8 @@ export default class Masonry<T: { ... }> extends ReactComponent<Props<T>, State<
             <div // keep this in sync with renderMasonryComponent
               className="static"
               data-grid-item
+              // $FlowFixMe[prop-missing] We're assuming `columnSpan` exists
+              data-column-span={item.columnSpan}
               // eslint-disable-next-line react/no-array-index-key
               key={i}
               ref={(el) => {

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -482,10 +482,6 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
     const { positionStore } = this;
-    const twoColumnWidth =
-      typeof columnWidth === 'number' && typeof gutter === 'number'
-        ? columnWidth * 2 + gutter
-        : columnWidth;
 
     let getPositions;
 
@@ -567,7 +563,9 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
                   layout === 'flexible' || layout === 'serverRenderedFlexible'
                     ? undefined // we can't set a width for server rendered flexible items
                     : layoutNumberToCssDimension(
-                        item.columnSpan === 2 ? twoColumnWidth : columnWidth,
+                        typeof item.columnSpan === 'number' && columnWidth != null && gutter != null
+                          ? columnWidth * item.columnSpan + gutter * (item.columnSpan - 1)
+                          : columnWidth,
                       ),
               }}
             >

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -1,5 +1,4 @@
 // @flow strict
-import { type } from 'os';
 import { Component as ReactComponent, type Node as ReactNode } from 'react';
 import debounce, { type DebounceReturn } from './debounce';
 import FetchItems from './FetchItems';
@@ -16,7 +15,6 @@ import ScrollContainer from './Masonry/ScrollContainer';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
 import { type Position } from './Masonry/types';
 import uniformRowLayout from './Masonry/uniformRowLayout';
-import { columnSticky } from './Table.css';
 import throttle, { type ThrottleReturn } from './throttle';
 
 const RESIZE_DEBOUNCE = 300;

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -130,10 +130,7 @@ type State<T> = {
  * ![Masonry light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Masonry.spec.mjs-snapshots/Masonry-chromium-darwin.png)
  *
  */
-export default class Masonry<T: { columnSpan?: number, ... }> extends ReactComponent<
-  Props<T>,
-  State<T>,
-> {
+export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Props<T>, State<T>> {
   static createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {
     return new MeasurementStore();
   }

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -204,7 +204,7 @@ function getTwoColItemPosition<T>({
   };
 }
 
-const defaultTwoColumnModuleLayout = <T: { columnSpan?: number, ... }>({
+const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
   columnWidth = 236,
   gutter = 14,
   heightsCache,
@@ -266,9 +266,7 @@ const defaultTwoColumnModuleLayout = <T: { columnSpan?: number, ... }>({
     const itemsWithPositions = items.filter((item) => positionCache?.has(item));
     const itemsWithoutPositions = items.filter((item) => !positionCache?.has(item));
 
-    const twoColumnItems = itemsWithoutPositions.filter(
-      (item) => item.columnSpan != null && item.columnSpan > 2,
-    );
+    const twoColumnItems = itemsWithoutPositions.filter((item) => item.columnSpan === 2);
     const hasTwoColumnItems = twoColumnItems.length > 0;
 
     const commonGetPositionArgs = {

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -252,7 +252,11 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
   return (items): $ReadOnlyArray<Position> => {
     if (isNil(width) || !items.every((item) => measurementCache.has(item))) {
       return items.map((item) =>
-        offscreen(item.columnSpan === 2 ? columnWidth * 2 + gutter : columnWidth),
+        offscreen(
+          typeof item.columnSpan === 'number'
+            ? columnWidth * item.columnSpan + gutter * (item.columnSpan - 1)
+            : columnWidth,
+        ),
       );
     }
 

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -204,7 +204,7 @@ function getTwoColItemPosition<T>({
   };
 }
 
-const defaultTwoColumnModuleLayout = <T>({
+const defaultTwoColumnModuleLayout = <T: { columnSpan?: number, ... }>({
   columnWidth = 236,
   gutter = 14,
   heightsCache,
@@ -234,7 +234,9 @@ const defaultTwoColumnModuleLayout = <T>({
 
   return (items): $ReadOnlyArray<Position> => {
     if (isNil(width) || !items.every((item) => measurementCache.has(item))) {
-      return items.map(() => offscreen(columnWidth));
+      return items.map((item) =>
+        offscreen(item.columnSpan === 2 ? columnWidth * 2 + gutter : columnWidth),
+      );
     }
 
     const centerOffset =
@@ -264,8 +266,9 @@ const defaultTwoColumnModuleLayout = <T>({
     const itemsWithPositions = items.filter((item) => positionCache?.has(item));
     const itemsWithoutPositions = items.filter((item) => !positionCache?.has(item));
 
-    // $FlowFixMe[incompatible-use] We're assuming `columnSpan` exists
-    const twoColumnItems = itemsWithoutPositions.filter((item) => item.columnSpan > 1);
+    const twoColumnItems = itemsWithoutPositions.filter(
+      (item) => item.columnSpan != null && item.columnSpan > 2,
+    );
     const hasTwoColumnItems = twoColumnItems.length > 0;
 
     const commonGetPositionArgs = {
@@ -309,7 +312,6 @@ const defaultTwoColumnModuleLayout = <T>({
       }
 
       const oneColumnItems = batchWithTwoColumnItems.filter(
-        // $FlowFixMe[incompatible-type] We're assuming `columnSpan` exists
         (item) => !item.columnSpan || item.columnSpan === 1,
       );
 

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -40,6 +40,23 @@ function calculateTwoColumnModuleWidth(columnWidth: number, gutter: number): num
   return columnWidth * 2 + gutter;
 }
 
+function calculateSplitIndex<T: { +[string]: mixed }>(
+  itemsWithoutPositions: $ReadOnlyArray<T>,
+): number {
+  // Currently we only support one two column item at the same time, more items will be supporped soon
+  const twoColumnIndex = itemsWithoutPositions.findIndex((item) => item.columnSpan === 2);
+
+  if (twoColumnIndex < TWO_COL_ITEMS_MEASURE_BATCH_SIZE) {
+    return 0;
+  }
+
+  if (twoColumnIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE > itemsWithoutPositions.length) {
+    return itemsWithoutPositions.length - TWO_COL_ITEMS_MEASURE_BATCH_SIZE;
+  }
+
+  return twoColumnIndex;
+}
+
 function initializeHeightsArray<T>({
   centerOffset,
   columnCount,
@@ -279,16 +296,10 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
     };
 
     if (hasTwoColumnItems) {
-      // Currently we only support one two column item at the same time, more items will be supporped soon
-      const twoColumnIndex = itemsWithoutPositions.indexOf(twoColumnItems[0]);
-
       // If the number of items to position is greater that the batch size
       // we identify the batch with the two column item and apply the graph only to those items
+      const splitIndex = calculateSplitIndex(itemsWithoutPositions);
       const shouldBatchItems = itemsWithoutPositions.length > TWO_COL_ITEMS_MEASURE_BATCH_SIZE;
-      const splitIndex =
-        twoColumnIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE > itemsWithoutPositions.length
-          ? itemsWithoutPositions.length - TWO_COL_ITEMS_MEASURE_BATCH_SIZE
-          : twoColumnIndex;
       const pre = shouldBatchItems ? itemsWithoutPositions.slice(0, splitIndex) : [];
       const batchWithTwoColumnItems = shouldBatchItems
         ? itemsWithoutPositions.slice(splitIndex, splitIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE)

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -281,22 +281,24 @@ describe('two column layout test cases', () => {
     const measurementStore = new MeasurementStore<{ ... }, number>();
     const positionCache = new MeasurementStore<{ ... }, Position>();
     const heightsCache = new HeightsStore();
+
+    // We use same height so the two column item is always at the start of the two column batch
     const items = [
       { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
-      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
-      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
-      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
-      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
-      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
-      { 'name': 'Pin 6', 'height': 206, 'color': '#67076F' },
-      { 'name': 'Pin 7', 'height': 207, 'color': '#AB032E' },
-      { 'name': 'Pin 8', 'height': 208, 'color': '#DF21DC' },
-      { 'name': 'Pin 9', 'height': 209, 'color': '#F45098' },
-      { 'name': 'Pin 10', 'height': 210, 'color': '#30BAF6' },
-      { 'name': 'Pin 11', 'height': 211, 'color': '#7076FA' },
-      { 'name': 'Pin 12', 'height': 212, 'color': '#B032ED' },
-      { 'name': 'Pin 13', 'height': 213, 'color': '#F21DCF', 'columnSpan': 2 },
-      { 'name': 'Pin 14', 'height': 214, 'color': '#45098F' },
+      { 'name': 'Pin 1', 'height': 200, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 200, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 200, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 200, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 200, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 200, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 200, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 200, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 200, 'color': '#F45098' },
+      { 'name': 'Pin 10', 'height': 200, 'color': '#30BAF6' },
+      { 'name': 'Pin 11', 'height': 200, 'color': '#7076FA' },
+      { 'name': 'Pin 12', 'height': 200, 'color': '#B032ED' },
+      { 'name': 'Pin 13', 'height': 200, 'color': '#F21DCF' },
+      { 'name': 'Pin 14', 'height': 200, 'color': '#45098F' },
     ];
     items.forEach((item) => {
       measurementStore.set(item, item.height);
@@ -313,27 +315,70 @@ describe('two column layout test cases', () => {
       width: 1200,
     });
 
-    const positions = layout(items);
-    const orderedPositions = items.map((item) => positionCache.get(item));
+    let mockItems;
+    let twoColumnModuleIndex;
 
-    expect(positions.length).toEqual(items.length);
-    expect(orderedPositions).toEqual([
-      { height: 200, left: 99, top: 0, width: 240 },
-      { height: 201, left: 353, top: 0, width: 240 },
-      { height: 202, left: 607, top: 0, width: 240 },
-      { height: 203, left: 861, top: 0, width: 240 },
-      { height: 204, left: 99, top: 214, width: 240 },
-      { height: 205, left: 353, top: 215, width: 240 },
-      { height: 206, left: 607, top: 216, width: 240 },
-      { height: 207, left: 861, top: 217, width: 240 },
-      { height: 208, left: 99, top: 432, width: 240 },
-      { height: 209, left: 353, top: 434, width: 240 },
-      { height: 210, left: 607, top: 436, width: 240 },
-      { height: 211, left: 861, top: 664, width: 240 },
-      { height: 212, left: 861, top: 438, width: 240 },
-      { height: 213, left: 353, top: 660, width: 494 },
-      { height: 214, left: 99, top: 654, width: 240 },
-    ]);
+    // Correct position when two column module is on the end of the batch
+    twoColumnModuleIndex = 13;
+    mockItems = [
+      ...items.slice(0, twoColumnModuleIndex),
+      { ...items[twoColumnModuleIndex], columnSpan: 2 },
+      ...items.slice(twoColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    expect(positionCache.get(mockItems[twoColumnModuleIndex])).toEqual({
+      height: 200,
+      left: 353,
+      top: 428,
+      width: 494,
+    });
+
+    // Correct position when two column module is on the middle of the batch
+    measurementStore.reset();
+    positionCache.reset();
+    heightsCache.reset();
+
+    twoColumnModuleIndex = 7;
+    mockItems = [
+      ...items.slice(0, twoColumnModuleIndex),
+      { ...items[twoColumnModuleIndex], columnSpan: 2 },
+      ...items.slice(twoColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    expect(positionCache.get(mockItems[twoColumnModuleIndex])).toEqual({
+      height: 200,
+      left: 99,
+      top: 428,
+      width: 494,
+    });
+
+    // Correct position when two column module is at the start of the batch
+    measurementStore.reset();
+    positionCache.reset();
+    heightsCache.reset();
+
+    twoColumnModuleIndex = 5;
+    mockItems = [
+      ...items.slice(0, twoColumnModuleIndex),
+      { ...items[twoColumnModuleIndex], columnSpan: 2 },
+      ...items.slice(twoColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    expect(positionCache.get(mockItems[twoColumnModuleIndex])).toEqual({
+      height: 200,
+      left: 99,
+      top: 0,
+      width: 494,
+    });
   });
 
   test('correctly position two column item when initial heights are 0', () => {


### PR DESCRIPTION
### Summary

To enable the use of a two column module on Masonry using SSR we need to:

- Identify on CSS and early scripts if an item is two column. This PR adds a new attribute to the ssr structure called `data-column-span` that can hold the column span value of the item.
- Add logic to set the correct witdh for n column modules when rendered for mearurements
- Change the logic of the split index on large batches so tcm can be moved to the first position when applicable