### PR TITLE
Masonry: Move TCM to start of batch on SSR

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -530,6 +530,14 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
     if (width == null && hasPendingMeasurements) {
       // When hyrdating from a server render, we don't have the width of the grid
       // and the measurement store is empty
+      const twoColumnIndex = items.slice(0, 6).findIndex((item) => item.columnSpan === 2);
+      const newItems = twoColumnIndex
+        ? [
+            items[twoColumnIndex],
+            ...items.slice(0, twoColumnIndex),
+            ...items.slice(twoColumnIndex + 1),
+          ]
+        : items;
       gridBody = (
         <div
           className={styles.Masonry}
@@ -537,7 +545,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
           role="list"
           style={{ height: 0, width: '100%' }}
         >
-          {items.filter(Boolean).map((item, i) => (
+          {newItems.filter(Boolean).map((item, i) => (
             <div // keep this in sync with renderMasonryComponent
               className="static"
               data-grid-item

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -536,14 +536,9 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       const twoColumnIndex = items
         .slice(0, TWO_COL_ITEMS_MEASURE_BATCH_SIZE)
         .findIndex((item) => item.columnSpan === 2);
-      const ssrItems =
-        twoColumnIndex > 0
-          ? [
-              items[twoColumnIndex],
-              ...items.slice(0, twoColumnIndex),
-              ...items.slice(twoColumnIndex + 1),
-            ]
-          : items;
+      const ssrItems = twoColumnIndex
+        ? [items[twoColumnIndex], ...items.filter((item, index) => index !== twoColumnIndex)]
+        : items;
 
       gridBody = (
         <div

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -536,13 +536,14 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       const twoColumnIndex = items
         .slice(0, TWO_COL_ITEMS_MEASURE_BATCH_SIZE)
         .findIndex((item) => item.columnSpan === 2);
-      const ssrItems = twoColumnIndex
-        ? [
-            items[twoColumnIndex],
-            ...items.slice(0, twoColumnIndex),
-            ...items.slice(twoColumnIndex + 1),
-          ]
-        : items;
+      const ssrItems =
+        twoColumnIndex > 0
+          ? [
+              items[twoColumnIndex],
+              ...items.slice(0, twoColumnIndex),
+              ...items.slice(twoColumnIndex + 1),
+            ]
+          : items;
 
       gridBody = (
         <div

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -533,27 +533,16 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
 
       // We have to match the positions of ssr items with the ones calculated on the layout logic,
       // this means if the heigths are the same the two col item is positioned as the first item
-      const hasTwoColumnItems = items.some((item) => item.columnSpan === 2);
-
-      const normalizeSSRItems = (items: $ReadOnlyArray<T>) => {
-        const normalizedItems: Array<T> = [];
-
-        for (let i = 0; i < items.length; i += TWO_COL_ITEMS_MEASURE_BATCH_SIZE) {
-          const batch: $ReadOnlyArray<T> = items.slice(i, i + TWO_COL_ITEMS_MEASURE_BATCH_SIZE);
-          const twoColumnIndex = batch.findIndex((item) => item.columnSpan === 2);
-          normalizedItems.push(
-            twoColumnIndex
-              ? [
-                  batch[twoColumnIndex],
-                  ...batch.slice(0, twoColumnIndex),
-                  ...batch.slice(twoColumnIndex + 1),
-                ]
-              : batch,
-          );
-        }
-
-        return normalizedItems;
-      };
+      const twoColumnIndex = items
+        .slice(0, TWO_COL_ITEMS_MEASURE_BATCH_SIZE)
+        .findIndex((item) => item.columnSpan === 2);
+      const ssrItems = twoColumnIndex
+        ? [
+            items[twoColumnIndex],
+            ...items.slice(0, twoColumnIndex),
+            ...items.slice(twoColumnIndex + 1),
+          ]
+        : items;
 
       gridBody = (
         <div
@@ -562,7 +551,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
           role="list"
           style={{ height: 0, width: '100%' }}
         >
-          {(hasTwoColumnItems ? normalizeSSRItems(items) : items).filter(Boolean).map((item, i) => (
+          {ssrItems.filter(Boolean).map((item, i) => (
             <div // keep this in sync with renderMasonryComponent
               className="static"
               data-grid-item

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -530,14 +530,31 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
     if (width == null && hasPendingMeasurements) {
       // When hyrdating from a server render, we don't have the width of the grid
       // and the measurement store is empty
-      const twoColumnIndex = items.slice(0, 6).findIndex((item) => item.columnSpan === 2);
-      const newItems = twoColumnIndex
-        ? [
-            items[twoColumnIndex],
-            ...items.slice(0, twoColumnIndex),
-            ...items.slice(twoColumnIndex + 1),
-          ]
-        : items;
+
+      // We have to match the positions of ssr items with the ones calculated on the layout logic,
+      // this means if the heigths are the same the two col item is positioned as the first item
+      const hasTwoColumnItems = items.some((item) => item.columnSpan === 2);
+
+      const normalizeSSRItems = (items: $ReadOnlyArray<T>) => {
+        const normalizedItems: Array<T> = [];
+
+        for (let i = 0; i < items.length; i += TWO_COL_ITEMS_MEASURE_BATCH_SIZE) {
+          const batch: $ReadOnlyArray<T> = items.slice(i, i + TWO_COL_ITEMS_MEASURE_BATCH_SIZE);
+          const twoColumnIndex = batch.findIndex((item) => item.columnSpan === 2);
+          normalizedItems.push(
+            twoColumnIndex
+              ? [
+                  batch[twoColumnIndex],
+                  ...batch.slice(0, twoColumnIndex),
+                  ...batch.slice(twoColumnIndex + 1),
+                ]
+              : batch,
+          );
+        }
+
+        return normalizedItems;
+      };
+
       gridBody = (
         <div
           className={styles.Masonry}
@@ -545,7 +562,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
           role="list"
           style={{ height: 0, width: '100%' }}
         >
-          {newItems.filter(Boolean).map((item, i) => (
+          {(hasTwoColumnItems ? normalizeSSRItems(items) : items).filter(Boolean).map((item, i) => (
             <div // keep this in sync with renderMasonryComponent
               className="static"
               data-grid-item


### PR DESCRIPTION
### Summary

#### What changed?

The positioning of the two column module on ssr and on the layout logic don't match since the layout logic sends the two column module to the first position of the batch.

With this pr we add logic to change the position of the two column module on the first batch to the first position.

#### Before

https://github.com/pinterest/gestalt/assets/700818/c0ee9b4f-2a5b-456f-becd-760f33b86d88

#### After

https://github.com/pinterest/gestalt/assets/700818/fac4cc80-5e4b-4253-bd7d-a43ab3a35fc4