### PR TITLE
PopoverEducational: fix zIndex bug + add example

### DIFF
--- a/docs/examples/popovereducational/zIndex.js
+++ b/docs/examples/popovereducational/zIndex.js
@@ -25,12 +25,12 @@ export default function Example(): ReactNode {
 
   return (
     <Flex
-      width="100%"
-      height="100%"
-      justifyContent="center"
       alignItems="center"
       direction="column"
       gap={12}
+      height="100%"
+      justifyContent="center"
+      width="100%"
     >
       <Flex alignItems="center" gap={2}>
         <Label htmlFor="introExample">
@@ -44,8 +44,8 @@ export default function Example(): ReactNode {
         />
       </Flex>
       <Flex gap={2}>
-        <TapArea ref={anchorRef} rounding={3} fullWidth={false}>
-          <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+        <TapArea ref={anchorRef} fullWidth={false} rounding={3}>
+          <Box color="secondary" height={75} padding={3} rounding={3} width={200}>
             <Flex gap={2}>
               <Box aria-hidden width={50}>
                 <Mask rounding={3} wash>
@@ -68,24 +68,24 @@ export default function Example(): ReactNode {
         </TapArea>
         {open && (
           <PopoverEducational
-            zIndex={hasZindex ? new FixedZIndex(50) : undefined}
             accessibilityLabel={`Description of new "More ideas" feature`}
+            anchor={anchorRef.current}
             id="popover-primary-action"
             idealDirection="right"
-            anchor={anchorRef.current}
-            onDismiss={() => {}}
             message="Tap to tag a product or press and hold to see product details"
+            onDismiss={() => {}}
             primaryAction={{ text: 'Next', role: 'button' }}
+            zIndex={hasZindex ? new FixedZIndex(50) : undefined}
           />
         )}
         <Box
-          padding={3}
           color="secondary"
           height={75}
-          width={200}
-          rounding={3}
-          zIndex={new FixedZIndex(1)}
+          padding={3}
           position="relative"
+          rounding={3}
+          width={200}
+          zIndex={new FixedZIndex(1)}
         >
           <Flex gap={2}>
             <Box aria-hidden width={50}>

--- a/docs/examples/popovereducational/zIndex.js
+++ b/docs/examples/popovereducational/zIndex.js
@@ -1,0 +1,112 @@
+// @flow strict
+import { type Node as ReactNode, useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  FixedZIndex,
+  Flex,
+  Image,
+  Label,
+  Mask,
+  PopoverEducational,
+  Switch,
+  TapArea,
+  Text,
+} from 'gestalt';
+
+export default function Example(): ReactNode {
+  const [open, setOpen] = useState(false);
+  const [hasZindex, setHasZindex] = useState(false);
+
+  const anchorRef = useRef<HTMLDivElement | HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    setOpen(true);
+  }, []);
+
+  return (
+    <Flex
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      direction="column"
+      gap={12}
+    >
+      <Flex alignItems="center" gap={2}>
+        <Label htmlFor="introExample">
+          <Text>Apply new FixedZIndex(2)</Text>
+        </Label>
+
+        <Switch
+          id="introExample"
+          onChange={() => setHasZindex((currVal) => !currVal)}
+          switched={hasZindex}
+        />
+      </Flex>
+      <Flex gap={2}>
+        <TapArea ref={anchorRef} rounding={3} fullWidth={false}>
+          <Box padding={3} color="secondary" height={75} width={200} rounding={3}>
+            <Flex gap={2}>
+              <Box aria-hidden width={50}>
+                <Mask rounding={3} wash>
+                  <Image
+                    alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                    color="rgb(231, 186, 176)"
+                    loading="lazy"
+                    naturalHeight={1}
+                    naturalWidth={1}
+                    src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                  />
+                </Mask>
+              </Box>
+              <Flex direction="column">
+                <Text size="100">More ideas for</Text>
+                <Text weight="bold">Food, Drinks, Snacks</Text>
+              </Flex>
+            </Flex>
+          </Box>
+        </TapArea>
+        {open && (
+          <PopoverEducational
+            zIndex={hasZindex ? new FixedZIndex(50) : undefined}
+            accessibilityLabel={`Description of new "More ideas" feature`}
+            id="popover-primary-action"
+            idealDirection="right"
+            anchor={anchorRef.current}
+            onDismiss={() => {}}
+            message="Tap to tag a product or press and hold to see product details"
+            primaryAction={{ text: 'Next', role: 'button' }}
+          />
+        )}
+        <Box
+          padding={3}
+          color="secondary"
+          height={75}
+          width={200}
+          rounding={3}
+          zIndex={new FixedZIndex(1)}
+          position="relative"
+        >
+          <Flex gap={2}>
+            <Box aria-hidden width={50}>
+              <Mask rounding={3} wash>
+                <Image
+                  alt="Image of a Spanish paella from above. Yellow rice with red peppers and shrimp on top."
+                  color="rgb(231, 186, 176)"
+                  loading="lazy"
+                  naturalHeight={1}
+                  naturalWidth={1}
+                  src="https://i.ibb.co/d2tpDss/IMG-0494.jpg"
+                />
+              </Mask>
+            </Box>
+            <Flex direction="column">
+              <Text size="100">More ideas for</Text>
+              <Text weight="bold">Halloween customs</Text>
+            </Flex>
+          </Flex>
+        </Box>
+      </Flex>
+    </Flex>
+  );
+}

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -212,8 +212,8 @@ PopoverEducational's positioning algorithm requires that the anchor element rend
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          title="With z-index"
           description="PopoverEducational supports [zIndex](/web/zindex_classes)"
+          title="With z-index"
         >
           <MainSection.Card
             cardSize="lg"

--- a/docs/pages/web/popovereducational.js
+++ b/docs/pages/web/popovereducational.js
@@ -19,6 +19,7 @@ import message from '../../examples/popovereducational/message';
 import primaryAction from '../../examples/popovereducational/primaryAction';
 import size from '../../examples/popovereducational/size';
 import visibility from '../../examples/popovereducational/visibility';
+import zIndex from '../../examples/popovereducational/zIndex';
 
 export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
@@ -207,6 +208,16 @@ PopoverEducational's positioning algorithm requires that the anchor element rend
             sandpackExample={
               <SandpackExample code={visibility} hideEditor name="Visibility variant" />
             }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection
+          title="With z-index"
+          description="PopoverEducational supports [zIndex](/web/zindex_classes)"
+        >
+          <MainSection.Card
+            cardSize="lg"
+            sandpackExample={<SandpackExample code={zIndex} hideEditor name="zIndex variant" />}
           />
         </MainSection.Subsection>
       </MainSection>

--- a/packages/gestalt/src/LegacyContents.js
+++ b/packages/gestalt/src/LegacyContents.js
@@ -23,6 +23,7 @@ import {
   getContainerNode,
   getPopoverDir,
 } from './utils/positioningUtils';
+import { type Indexable } from './zIndex';
 
 export type Role = 'dialog' | 'listbox' | 'menu' | 'tooltip';
 
@@ -45,6 +46,7 @@ type OwnProps = {
   triggerRect: ?ClientRect,
   width: ?number,
   __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
+  zIndex?: Indexable,
 };
 
 type HookProps = {
@@ -237,8 +239,18 @@ class LegacyContents extends Component<Props, State> {
   }
 
   render(): ReactNode {
-    const { accessibilityLabel, bgColor, border, caret, children, id, role, rounding, width } =
-      this.props;
+    const {
+      accessibilityLabel,
+      bgColor,
+      border,
+      caret,
+      children,
+      id,
+      role,
+      rounding,
+      width,
+      zIndex,
+    } = this.props;
     const { caretOffset, popoverOffset, popoverDir } = this.state;
 
     // Needed to prevent UI thrashing
@@ -261,7 +273,13 @@ class LegacyContents extends Component<Props, State> {
           styles.maxDimensions,
           width !== null && styles.minDimensions,
         )}
-        style={{ visibility, ...popoverOffset, ...topValue }}
+        // popoverOffset positions the Popover component
+        style={{
+          zIndex: zIndex ? zIndex?.index() : undefined,
+          visibility,
+          ...popoverOffset,
+          ...topValue,
+        }}
         // popoverOffset positions the Popover component
         tabIndex={-1}
       >

--- a/packages/gestalt/src/LegacyController.js
+++ b/packages/gestalt/src/LegacyController.js
@@ -6,6 +6,7 @@ import { ESCAPE } from './keyCodes';
 import LegacyContents, { type Role } from './LegacyContents';
 import { type ClientRect, type Coordinates } from './utils/positioningTypes';
 import { getTriggerRect } from './utils/positioningUtils';
+import { type Indexable } from './zIndex';
 
 const SIZE_WIDTH_MAP = {
   xs: 180,
@@ -31,6 +32,7 @@ type OwnProps = {
   shouldFocus?: boolean,
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | null,
   __dangerouslyIgnoreScrollBoundaryContainerSize?: boolean,
+  zIndex?: Indexable,
 };
 
 type HookProps = {
@@ -135,6 +137,7 @@ class LegacyController extends Component<Props, State> {
       shouldFocus,
       size,
       __dangerouslyIgnoreScrollBoundaryContainerSize,
+      zIndex,
     } = this.props;
     const { relativeOffset, triggerBoundingRect } = this.state;
 
@@ -162,6 +165,7 @@ class LegacyController extends Component<Props, State> {
           shouldFocus={shouldFocus}
           triggerRect={triggerBoundingRect}
           width={width}
+          zIndex={zIndex}
         >
           {children}
         </LegacyContents>

--- a/packages/gestalt/src/Popover/LegacyInternalPopover.js
+++ b/packages/gestalt/src/Popover/LegacyInternalPopover.js
@@ -5,6 +5,7 @@ import { useDefaultLabelContext } from '../contexts/DefaultLabelProvider';
 import Flex from '../Flex';
 import LegacyController from '../LegacyController';
 import InternalDismissButton from '../shared/InternalDismissButton';
+import { type Indexable } from '../zIndex';
 
 type Color = 'blue' | 'white' | 'darkGray';
 type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'flexible' | number;
@@ -27,6 +28,7 @@ type Props = {|
   showDismissButton?: boolean,
   size?: Size,
   __dangerouslySetMaxHeight?: '30vh',
+  zIndex?: Indexable,
 |};
 
 export default function InternalPopover({
@@ -46,6 +48,7 @@ export default function InternalPopover({
   showCaret,
   size = 'sm',
   __dangerouslySetMaxHeight,
+  zIndex,
 }: Props): null | ReactNode {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
@@ -77,6 +80,7 @@ export default function InternalPopover({
       rounding={4}
       shouldFocus={shouldFocus}
       size={size === 'flexible' ? null : size}
+      zIndex={zIndex}
     >
       {showDismissButton ? (
         <Flex direction="column">

--- a/packages/gestalt/src/PopoverEducational.js
+++ b/packages/gestalt/src/PopoverEducational.js
@@ -170,35 +170,34 @@ export default function PopoverEducational({
 
   if (!isInExperiment)
     return (
-      <Box position={zIndex ? 'relative' : undefined} zIndex={zIndex}>
-        <LegacyInternalPopover
-          accessibilityLabel={accessibilityLabel}
-          anchor={anchor}
-          color="blue"
-          id={id}
-          idealDirection={idealDirection}
-          onDismiss={onDismiss}
-          positionRelativeToAnchor
-          role={primaryAction && !children ? 'dialog' : role}
-          shouldFocus={shouldFocus}
-          showCaret
-          size={size}
-        >
-          {children ??
-            (message ? (
-              <Box padding={4} tabIndex={0}>
-                <Flex direction="column" gap={3}>
-                  {textElement}
-                  {primaryAction ? (
-                    <Flex.Item alignSelf="end" flex="grow">
-                      <PrimaryAction {...primaryAction} />
-                    </Flex.Item>
-                  ) : null}
-                </Flex>
-              </Box>
-            ) : null)}
-        </LegacyInternalPopover>
-      </Box>
+      <LegacyInternalPopover
+        accessibilityLabel={accessibilityLabel}
+        anchor={anchor}
+        color="blue"
+        id={id}
+        idealDirection={idealDirection}
+        onDismiss={onDismiss}
+        positionRelativeToAnchor
+        role={primaryAction && !children ? 'dialog' : role}
+        shouldFocus={shouldFocus}
+        showCaret
+        size={size}
+        zIndex={zIndex}
+      >
+        {children ??
+          (message ? (
+            <Box padding={4} tabIndex={0}>
+              <Flex direction="column" gap={3}>
+                {textElement}
+                {primaryAction ? (
+                  <Flex.Item alignSelf="end" flex="grow">
+                    <PrimaryAction {...primaryAction} />
+                  </Flex.Item>
+                ) : null}
+              </Flex>
+            </Box>
+          ) : null)}
+      </LegacyInternalPopover>
     );
 
   return (

--- a/packages/gestalt/src/__snapshots__/LegacyController.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/LegacyController.jsdom.test.js.snap
@@ -9,6 +9,7 @@ exports[`Controller renders 1`] = `
         "left": -10,
         "top": 4,
         "visibility": "visible",
+        "zIndex": undefined,
       }
     }
     tabIndex={-1}


### PR DESCRIPTION
PopoverEducational: fix zIndex bug + add example

Zindex was not properly working. Zindex was not being applied to absolute positioned Contents component. Removed unnecessary Box.


BEFORE
![Brave Browser - PopoverEducational - Gestalt 2024-03-19 at 11 13 18 PM](https://github.com/pinterest/gestalt/assets/10593890/73aded49-158f-4e48-902c-59f888b32116)


AFTER
![Brave Browser - PopoverEducational - Gestalt 2024-03-19 at 11 14 24 PM](https://github.com/pinterest/gestalt/assets/10593890/26c14040-3c33-4829-a893-865cf4015853)
