### PR TITLE
Masonry: Fill in first row when multi-column item can't fit

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -455,4 +455,59 @@ describe('two column layout test cases', () => {
       width: 494,
     });
   });
+
+  test('fills in remaining columns in the first row when multi column item cannot fit', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { name: 'Pin 0', height: 250, color: '#E230BA' },
+      { name: 'Pin 1', height: 202, color: '#FAB032' },
+      { name: 'Pin 2', height: 210, color: '#EDF21D' },
+      { name: 'Pin 3', height: 300, color: '#CF4509' },
+      { name: 'Pin 4', height: 150, color: '#230BAF' },
+      { name: 'Pin 5', height: 500, color: '#67076F', columnSpan: 2 },
+      { name: 'Pin 6', height: 300, color: '#AB032E' },
+      { name: 'Pin 7', height: 310, color: '#DF21DC' },
+      { name: 'Pin 8', height: 280, color: '#F45098' },
+      { name: 'Pin 9', height: 170, color: '#F67076' },
+      { name: 'Pin 10', height: 220, color: '#67076F' },
+      { name: 'Pin 11', height: 280, color: '#AB032E' },
+      { name: 'Pin 12', height: 150, color: '#DF21DC' },
+      { name: 'Pin 13', height: 200, color: '#F45098' },
+      { name: 'Pin 14', height: 250, color: '#E230BA' },
+      { name: 'Pin 15', height: 300, color: '#FAB032' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const columnWidth = 240;
+    const screenWidth = 1500;
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth,
+      gutter: 0,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: screenWidth, // 6 rows
+    });
+    // perform single column layout first since we expect two column items on second page+ currently
+    layout(items);
+
+    // there should be 6 rows (1500 / 240)
+    // the first row items should be Pin 0, Pin 1, Pin 2, Pin 3, Pin 4, Pin 6
+    const columnCount = Math.floor(screenWidth / columnWidth);
+    const firstRowItems = items.filter((i) => !i.columnSpan).slice(0, columnCount);
+    const margin = (screenWidth - columnWidth * columnCount) / 2;
+    firstRowItems.forEach((item, i) => {
+      const position = positionCache.get(item);
+      expect(position?.top).toBe(0);
+      expect(position?.left).toBe(i * columnWidth + margin);
+    });
+  });
 });


### PR DESCRIPTION
### Summary
The approach we're taking to server render a multi-column item in the first row is:
- If the multi-column item can fit in the first row, render it in place
- If the multi-column item cannot fit in the first row, hide it and rendering single column modules in its place

For the second scenario, we currently cannot guarantee that the single column item which end up filling in the first row are the same as the server rendered layout. This PR addresses this by having the `defaultTwoColumnLayout` take this case into consideration and apply the following logic:
- Split items into two batches: `pre`( items before the multi column module), `batchWithTwoColumnItems` (multi-column item + other items)
- For first row only (e.g. 0 heights), if the multi column module cannot fit in the first row, iterate through `batchWithTwoColumnItems` and move enough single column items into `pre` to fill out the first row.

