### PR TITLE
Masonry: Positions tcm correctly for last item on first row

### DIFF
--- a/packages/gestalt/src/Masonry/MeasurementStore.js
+++ b/packages/gestalt/src/Masonry/MeasurementStore.js
@@ -18,10 +18,6 @@ export default class MeasurementStore<T: { ... } | $ReadOnlyArray<mixed>, V>
     this.map.set(key, value);
   }
 
-  delete(key: T): void {
-    this.map.delete(key);
-  }
-
   reset(): void {
     this.map = new WeakMap();
   }

--- a/packages/gestalt/src/Masonry/MeasurementStore.js
+++ b/packages/gestalt/src/Masonry/MeasurementStore.js
@@ -18,6 +18,10 @@ export default class MeasurementStore<T: { ... } | $ReadOnlyArray<mixed>, V>
     this.map.set(key, value);
   }
 
+  delete(key: T): void {
+    this.map.delete(key);
+  }
+
   reset(): void {
     this.map = new WeakMap();
   }

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -40,15 +40,24 @@ function calculateTwoColumnModuleWidth(columnWidth: number, gutter: number): num
   return columnWidth * 2 + gutter;
 }
 
-function calculateSplitIndex(
+function calculateSplitIndex({
+  oneColumnItemsLength,
+  twoColumnIndex,
+  isFirstRow,
+  fitsFirstRow,
+  availableSlotsOnFirstRow,
+  columnCount,
+}: {
   oneColumnItemsLength: number,
   twoColumnIndex: number,
-  isFirstRow: ?boolean,
-  fitsFirstRow: ?boolean,
-): number {
+  isFirstRow: boolean,
+  fitsFirstRow: boolean,
+  availableSlotsOnFirstRow: number,
+  columnCount: number,
+}): number {
   // We add one more item to pre so it is positioned instead of two column item
-  if (isFirstRow && !fitsFirstRow) {
-    return twoColumnIndex + 1;
+  if (isFirstRow && twoColumnIndex < columnCount && !fitsFirstRow) {
+    return availableSlotsOnFirstRow;
   }
 
   // If the items length is the same as the batch size we don't set a split index
@@ -328,7 +337,14 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       // Calculate how many items are on pre array and how many on graphBatch
       const splitIndex = skipGraph
         ? twoColumnIndex
-        : calculateSplitIndex(oneColumnItems.length, twoColumnIndex, isFirstRow, fitsFirstRow);
+        : calculateSplitIndex({
+            oneColumnItemsLength: oneColumnItems.length,
+            twoColumnIndex,
+            isFirstRow,
+            fitsFirstRow,
+            availableSlotsOnFirstRow,
+            columnCount,
+          });
 
       // Pre items are positioned before the two column item
       const pre = oneColumnItems.slice(0, splitIndex);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -325,7 +325,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       const skipGraph = isFirstRow && fitsFirstRow;
 
       // Calculate how many items are on pre array and how many on graphBatch
-      const splitIndex = calculateSplitIndex(
+      const splitIndex = skipGraph ? twoColumnIndex : calculateSplitIndex(
         oneColumnItems.length,
         twoColumnIndex,
         isFirstRow,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -316,21 +316,19 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 
       const isFirstRow = heights.some((height) => height === 0);
       const multiColumnItemWidth = parseInt(twoColumnItems[0].columnSpan, 10);
-      const availableSlotsOnFirstRow = heights.reduce((acc, height) => {
-        return height === 0 ? acc + 1 : acc;
-      }, 0);
+      const availableSlotsOnFirstRow = heights.reduce(
+        (acc, height) => (height === 0 ? acc + 1 : acc),
+        0,
+      );
       const fitsFirstRow = availableSlotsOnFirstRow >= multiColumnItemWidth + twoColumnIndex;
 
       // Skip the graph logic if the two column item batch is on the first line and fits
       const skipGraph = isFirstRow && fitsFirstRow;
 
       // Calculate how many items are on pre array and how many on graphBatch
-      const splitIndex = skipGraph ? twoColumnIndex : calculateSplitIndex(
-        oneColumnItems.length,
-        twoColumnIndex,
-        isFirstRow,
-        fitsFirstRow,
-      );
+      const splitIndex = skipGraph
+        ? twoColumnIndex
+        : calculateSplitIndex(oneColumnItems.length, twoColumnIndex, isFirstRow, fitsFirstRow);
 
       // Pre items are positioned before the two column item
       const pre = oneColumnItems.slice(0, splitIndex);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -455,4 +455,59 @@ describe('two column layout test cases', () => {
       width: 494,
     });
   });
+
+  test('fills in remaining columns in the first row when multi column item cannot fit', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { name: 'Pin 0', height: 250, color: '#E230BA' },
+      { name: 'Pin 1', height: 202, color: '#FAB032' },
+      { name: 'Pin 2', height: 210, color: '#EDF21D' },
+      { name: 'Pin 3', height: 300, color: '#CF4509' },
+      { name: 'Pin 4', height: 150, color: '#230BAF' },
+      { name: 'Pin 5', height: 500, color: '#67076F', columnSpan: 2 },
+      { name: 'Pin 6', height: 300, color: '#AB032E' },
+      { name: 'Pin 7', height: 310, color: '#DF21DC' },
+      { name: 'Pin 8', height: 280, color: '#F45098' },
+      { name: 'Pin 9', height: 170, color: '#F67076' },
+      { name: 'Pin 10', height: 220, color: '#67076F' },
+      { name: 'Pin 11', height: 280, color: '#AB032E' },
+      { name: 'Pin 12', height: 150, color: '#DF21DC' },
+      { name: 'Pin 13', height: 200, color: '#F45098' },
+      { name: 'Pin 14', height: 250, color: '#E230BA' },
+      { name: 'Pin 15', height: 300, color: '#FAB032' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const columnWidth = 240;
+    const screenWidth = 1500;
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth,
+      gutter: 0,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: screenWidth, // 6 rows
+    });
+    // perform single column layout first since we expect two column items on second page+ currently
+    layout(items);
+
+    // there should be 6 rows (1500 / 240)
+    // the first row items should be Pin 0, Pin 1, Pin 2, Pin 3, Pin 4, Pin 6
+    const columnCount = Math.floor(screenWidth / columnWidth);
+    const firstRowItems = items.filter((i) => !i.columnSpan).slice(0, columnCount);
+    const margin = (screenWidth - columnWidth * columnCount) / 2;
+    firstRowItems.forEach((item, i) => {
+      const position = positionCache.get(item);
+      expect(position?.top).toBe(0);
+      expect(position?.left).toBe(i * columnWidth + margin);
+    });
+  });
 });


### PR DESCRIPTION
### Summary

When we render the items of the first row if there is a two column item on the last spot of the row we have to replace it with another one column item, we can handle that on ssr but when hydration happens this item can swap places with other item since it is part of the graph of the two column item.

This PR handles this taking advantage of the concepts of pre items (items to be rendered before the two column module) and introducing a new array `graphBatch` this two represent what comes before the two column item and what is used to create the graph to position the two column item.

We can change the `splitIndex` so we can have more items on the `pre` depending on if the two column module fits or not and have a consistent experience with ssr. 

#### Important notes

So the original position of the two column item don't affect this calculations the pr removes it from the batch array, because of this the items on the batch array are in fact one less than before that's why I changed the `TWO_COL_ITEMS_MEASURE_BATCH_SIZE` constant to 5.
