### PR TITLE
Masonry: Multi column feature, fix first row items position when batch is small

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -586,7 +586,10 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
         _twoColItems && itemsWithoutPositions.some((item) => item.columnSpan === 2);
 
       // If there are 2-col items, we need to measure more items to ensure we have enough possible layouts to find a suitable one
-      const itemsToMeasureCount = hasTwoColumnItems ? TWO_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
+      // we need the batch size (number of one column items for the graph) + 1 (two column item)
+      const itemsToMeasureCount = hasTwoColumnItems
+        ? TWO_COL_ITEMS_MEASURE_BATCH_SIZE + 1
+        : minCols;
       const itemsToMeasure = items
         .filter((item) => item && !measurementStore.has(item))
         .slice(0, itemsToMeasureCount);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -334,14 +334,16 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 
       // Calculate how many items are on pre array and how many on graphBatch
       // pre items are positioned before the two column item
-      const splitIndex = calculateSplitIndex({
-        oneColumnItemsLength: oneColumnItems.length,
-        twoColumnIndex,
-        emptyColumns,
-        replaceWithOneColItems,
-      });
+      const splitIndex = skipGraph
+        ? twoColumnIndex
+        : calculateSplitIndex({
+            oneColumnItemsLength: oneColumnItems.length,
+            twoColumnIndex,
+            emptyColumns,
+            replaceWithOneColItems,
+          });
 
-      const pre = oneColumnItems.slice(0, skipGraph ? twoColumnIndex : splitIndex);
+      const pre = oneColumnItems.slice(0, splitIndex);
       const graphBatch = skipGraph
         ? []
         : oneColumnItems.slice(splitIndex, splitIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -44,11 +44,17 @@ function calculateSplitIndex({
   oneColumnItemsLength,
   twoColumnIndex,
   emptyColumns,
+  replaceWithOneColItems,
 }: {
   oneColumnItemsLength: number,
   twoColumnIndex: number,
   emptyColumns: number,
+  replaceWithOneColItems: boolean,
 }): number {
+  if (replaceWithOneColItems) {
+    return emptyColumns;
+  }
+
   // If two column module is near the end of the batch
   // we move the index so it has enough items for the graph
   if (twoColumnIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE > oneColumnItemsLength) {
@@ -226,55 +232,6 @@ function getTwoColItemPosition<T>({
   };
 }
 
-function getSkipGraphPositions<T>({
-  heights: heightsArg,
-  oneColumnItems,
-  twoColumnItem,
-  twoColumnIndex,
-  ...commonGetPositionArgs
-}: {
-  centerOffset: number,
-  columnWidth: number,
-  columnWidthAndGutter: number,
-  gutter: number,
-  heights: $ReadOnlyArray<number>,
-  measurementCache: Cache<T, number>,
-  positionCache?: Cache<T, Position>,
-  oneColumnItems: $ReadOnlyArray<T>,
-  twoColumnItem: T,
-  twoColumnIndex: number,
-}): {
-  positions: $ReadOnlyArray<{ item: T, position: Position }>,
-  heights: $ReadOnlyArray<number>,
-} {
-  const { positions: preItemsPositions, heights: preItemHeights } = getOneColumnItemPositions({
-    items: oneColumnItems.slice(0, twoColumnIndex),
-    heights: heightsArg,
-    ...commonGetPositionArgs,
-  });
-
-  const { heights: updatedHeights, position: twoColItemPosition } = getTwoColItemPosition<T>({
-    item: twoColumnItem,
-    heights: preItemHeights,
-    ...commonGetPositionArgs,
-  });
-
-  const { positions: remainingItemPositions, heights: finalHeights } = getOneColumnItemPositions({
-    items: oneColumnItems.slice(twoColumnIndex),
-    heights: updatedHeights,
-    ...commonGetPositionArgs,
-  });
-
-  return {
-    positions: [
-      ...preItemsPositions,
-      { item: twoColumnItem, position: twoColItemPosition },
-      ...remainingItemPositions,
-    ],
-    heights: finalHeights,
-  };
-}
-
 const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
   columnWidth = 236,
   gutter = 14,
@@ -365,45 +322,29 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
       const multiColumnItemColumnSpan = parseInt(twoColumnItems[0].columnSpan, 10);
-      const fitsFirstRow = emptyColumns >= multiColumnItemColumnSpan + twoColumnIndex;
 
-      // Skip the graph logic if the two column item can be displayed on the first row
-      if (fitsFirstRow) {
-        const { positions: finalPositions, heights: finalHeights } = getSkipGraphPositions({
-          oneColumnItems,
-          twoColumnItem: twoColumnItems[0],
-          twoColumnIndex,
-          heights,
-          ...commonGetPositionArgs,
-        });
+      // Skip the graph logic if the two column item can be displayed on the first row,
+      // this means graphBatch is empty and multi column item is positioned on its
+      // original position (twoColumnIndex)
+      const skipGraph = emptyColumns >= multiColumnItemColumnSpan + twoColumnIndex;
 
-        finalPositions.forEach(({ item, position }) => {
-          positionCache.set(item, position);
-        });
-        heightsCache?.setHeights(finalHeights);
-
-        return getPositionsOnly(finalPositions);
-      }
-
-      // When multi column item is the last item of the first row but can't fit we need to
-      // fill those spaces with one col items
-      const replaceWithOneColItems = twoColumnIndex < emptyColumns;
+      // When multi column item is the last item of the first row but can't fit
+      // we need to fill those spaces with one col items
+      const replaceWithOneColItems = !skipGraph && twoColumnIndex < emptyColumns;
 
       // Calculate how many items are on pre array and how many on graphBatch
-      const splitIndex = replaceWithOneColItems
-        ? emptyColumns
-        : calculateSplitIndex({
-            oneColumnItemsLength: oneColumnItems.length,
-            twoColumnIndex,
-            emptyColumns,
-          });
+      // pre items are positioned before the two column item
+      const splitIndex = calculateSplitIndex({
+        oneColumnItemsLength: oneColumnItems.length,
+        twoColumnIndex,
+        emptyColumns,
+        replaceWithOneColItems,
+      });
 
-      // Pre items are positioned before the two column item
-      const pre = oneColumnItems.slice(0, splitIndex);
-      const graphBatch = oneColumnItems.slice(
-        splitIndex,
-        splitIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE,
-      );
+      const pre = oneColumnItems.slice(0, skipGraph ? twoColumnIndex : splitIndex);
+      const graphBatch = skipGraph
+        ? []
+        : oneColumnItems.slice(splitIndex, splitIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE);
 
       // Get positions and heights for painted items
       const { positions: paintedItemPositions, heights: paintedItemHeights } =

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -46,29 +46,26 @@ function calculateSplitIndex({
   isFirstRow,
   fitsFirstRow,
   availableSlotsOnFirstRow,
-  columnCount,
 }: {
   oneColumnItemsLength: number,
   twoColumnIndex: number,
   isFirstRow: boolean,
   fitsFirstRow: boolean,
   availableSlotsOnFirstRow: number,
-  columnCount: number,
 }): number {
   // We add one more item to pre so it is positioned instead of two column item
-  if (isFirstRow && twoColumnIndex < columnCount && !fitsFirstRow) {
+  if (isFirstRow && twoColumnIndex < availableSlotsOnFirstRow && !fitsFirstRow) {
     return availableSlotsOnFirstRow;
-  }
-
-  // If the items length is the same as the batch size we don't set a split index
-  if (oneColumnItemsLength <= TWO_COL_ITEMS_MEASURE_BATCH_SIZE) {
-    return 0;
   }
 
   // If two column module is near the end of the batch
   // we move the index so it has enough items for the graph
   if (twoColumnIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE > oneColumnItemsLength) {
-    return oneColumnItemsLength - TWO_COL_ITEMS_MEASURE_BATCH_SIZE;
+    return Math.max(
+      oneColumnItemsLength - TWO_COL_ITEMS_MEASURE_BATCH_SIZE,
+      // We have to keep at least the items for the available slots to fill
+      availableSlotsOnFirstRow,
+    );
   }
 
   return twoColumnIndex;
@@ -343,7 +340,6 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
             isFirstRow,
             fitsFirstRow,
             availableSlotsOnFirstRow,
-            columnCount,
           });
 
       // Pre items are positioned before the two column item

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -44,13 +44,21 @@ function calculateSplitIndex({
   oneColumnItemsLength,
   twoColumnIndex,
   emptyColumns,
+  fitsFirstRow,
   replaceWithOneColItems,
 }: {
   oneColumnItemsLength: number,
   twoColumnIndex: number,
   emptyColumns: number,
+  fitsFirstRow: boolean,
   replaceWithOneColItems: boolean,
 }): number {
+  // multi column item is on its original position
+  if (fitsFirstRow) {
+    return twoColumnIndex;
+  }
+
+  // We use as many one col items as empty columns to fill first row
   if (replaceWithOneColItems) {
     return emptyColumns;
   }
@@ -60,7 +68,7 @@ function calculateSplitIndex({
   if (twoColumnIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE > oneColumnItemsLength) {
     return Math.max(
       oneColumnItemsLength - TWO_COL_ITEMS_MEASURE_BATCH_SIZE,
-      // We have to keep at least the items for the available slots to fill
+      // We have to keep at least the items for the empty columns to fill
       emptyColumns,
     );
   }
@@ -326,25 +334,24 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       // Skip the graph logic if the two column item can be displayed on the first row,
       // this means graphBatch is empty and multi column item is positioned on its
       // original position (twoColumnIndex)
-      const skipGraph = emptyColumns >= multiColumnItemColumnSpan + twoColumnIndex;
+      const fitsFirstRow = emptyColumns >= multiColumnItemColumnSpan + twoColumnIndex;
 
       // When multi column item is the last item of the first row but can't fit
       // we need to fill those spaces with one col items
-      const replaceWithOneColItems = !skipGraph && twoColumnIndex < emptyColumns;
+      const replaceWithOneColItems = !fitsFirstRow && twoColumnIndex < emptyColumns;
 
       // Calculate how many items are on pre array and how many on graphBatch
       // pre items are positioned before the two column item
-      const splitIndex = skipGraph
-        ? twoColumnIndex
-        : calculateSplitIndex({
-            oneColumnItemsLength: oneColumnItems.length,
-            twoColumnIndex,
-            emptyColumns,
-            replaceWithOneColItems,
-          });
+      const splitIndex = calculateSplitIndex({
+        oneColumnItemsLength: oneColumnItems.length,
+        twoColumnIndex,
+        emptyColumns,
+        fitsFirstRow,
+        replaceWithOneColItems,
+      });
 
       const pre = oneColumnItems.slice(0, splitIndex);
-      const graphBatch = skipGraph
+      const graphBatch = fitsFirstRow
         ? []
         : oneColumnItems.slice(splitIndex, splitIndex + TWO_COL_ITEMS_MEASURE_BATCH_SIZE);
 

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -510,4 +510,49 @@ describe('two column layout test cases', () => {
       expect(position?.left).toBe(i * columnWidth + margin);
     });
   });
+
+  test('fills in remaining columns in the first row when multi column item cannot fit on small batch', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { name: 'Pin 0', height: 250, color: '#E230BA' },
+      { name: 'Pin 1', height: 202, color: '#FAB032' },
+      { name: 'Pin 2', height: 210, color: '#EDF21D' },
+      { name: 'Pin 3', height: 300, color: '#CF4509', columnSpan: 2 },
+      { name: 'Pin 4', height: 150, color: '#230BAF' },
+      { name: 'Pin 5', height: 500, color: '#67076F' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const columnWidth = 240;
+    const screenWidth = 720;
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth,
+      gutter: 0,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: screenWidth, // 3 rows
+    });
+
+    layout(items);
+
+    // there should be 3 rows (720 / 240)
+    // the first row items should be Pin 0, Pin 1, Pin 2
+    const columnCount = Math.floor(screenWidth / columnWidth);
+    const firstRowItems = items.filter((i) => !i.columnSpan).slice(0, columnCount);
+    const margin = (screenWidth - columnWidth * columnCount) / 2;
+    firstRowItems.forEach((item, i) => {
+      const position = positionCache.get(item);
+      expect(position?.top).toBe(0);
+      expect(position?.left).toBe(i * columnWidth + margin);
+    });
+  });
 });


### PR DESCRIPTION
### Summary

When the position for items on the first row are calculated with a multi column item and the batch is small the correct postition was not set correctly because we returned `0` as split index although we have to maintain al least the position of the elements on the first row.

To fix this intead of returning 0 we return the number of available slots on first row to fill them correctly. This means that the multi column item will have less items to calculate the optimal position but in my testing is not that bad and we need to keep the items on the first row.

#### Testing

Unit test added

#### Other changes

- We were incorrectly passing batches of only 5 elements to the layout
- We can change `columnCount` with `availableSlotsOnFirstRow` to calculate split index since that is more accuarate