### PR TITLE
SideNavigation: Display scrollbar only when content overflows

### DIFF
--- a/packages/gestalt/src/SideNavigation.css
+++ b/packages/gestalt/src/SideNavigation.css
@@ -15,7 +15,7 @@
 
 .fullHeight {
   height: 100%;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .contentWidthTransition {


### PR DESCRIPTION
### Summary

SideNavigation had `overflow: scroll` which makes the scrollbar always be displayed. It is now changed to `overflow: auto` so that scrollbar appears only when content overflows.

**BEFORE**
![Screenshot 2024-03-27 at 17 40 03](https://github.com/pinterest/gestalt/assets/29589560/ab289f61-0ef4-4460-acbc-06319b859395)

**AFTER**
![Screenshot 2024-03-27 at 17 40 25](https://github.com/pinterest/gestalt/assets/29589560/258e9cbb-f894-475b-95e7-7e4edf4aa23b)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
