### PR TITLE
SideNavigation: Fix scrollbar clipping in collapsed state

### DIFF
--- a/docs/docs-components/ExampleCode.js
+++ b/docs/docs-components/ExampleCode.js
@@ -54,7 +54,7 @@ export default function ExampleCode({
   } else {
     containerBoxMaxHeight = CODE_EXAMPLE_HEIGHT;
   }
-  containerBoxMaxHeight = '0';
+
   useEffect(() => {
     const height = codeExampleRef?.current?.clientHeight ?? 0;
 

--- a/docs/docs-components/ExampleCode.js
+++ b/docs/docs-components/ExampleCode.js
@@ -54,7 +54,7 @@ export default function ExampleCode({
   } else {
     containerBoxMaxHeight = CODE_EXAMPLE_HEIGHT;
   }
-
+  containerBoxMaxHeight = '0';
   useEffect(() => {
     const height = codeExampleRef?.current?.clientHeight ?? 0;
 
@@ -116,9 +116,6 @@ export default function ExampleCode({
         </Flex>
         <Flex direction="column" width="100%">
           <Box
-            dangerouslySetInlineStyle={{
-              __style: { transition: 'max-height 0.4s' },
-            }}
             display="flex"
             maxHeight={containerBoxMaxHeight}
             overflow="hidden"

--- a/docs/examples/sidenavigation/collapsibleExample.js
+++ b/docs/examples/sidenavigation/collapsibleExample.js
@@ -7,8 +7,8 @@ export default function Example(): ReactNode {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Box display="flex" height="100%" overflow="scroll" width={1000}>
-      <Box maxWidth={280}>
+    <Box display="flex" height="100%" overflow="auto">
+      <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"
           collapsed={collapsed}
@@ -121,9 +121,9 @@ export default function Example(): ReactNode {
             />
           </SideNavigation.Section>
         </SideNavigation>
-      </Box>
+      </div>
 
-      <Box padding={4}>
+      <Box height={800} padding={4}>
         <Heading size="500">Page main content</Heading>
       </Box>
     </Box>

--- a/docs/examples/sidenavigation/collapsibleExample.js
+++ b/docs/examples/sidenavigation/collapsibleExample.js
@@ -8,6 +8,7 @@ export default function Example(): ReactNode {
 
   return (
     <Box display="flex" height="100%" overflow="auto">
+      {/* It is recommended the wrapper to be sticky. */}
       <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"

--- a/docs/examples/sidenavigation/collapsibleHeaderExample.js
+++ b/docs/examples/sidenavigation/collapsibleHeaderExample.js
@@ -8,8 +8,8 @@ export default function Example(): ReactNode {
   const [preview, setPreview] = useState(false);
 
   return (
-    <Box display="flex" height="100%" overflow="scroll" width={1000}>
-      <Box maxWidth={280}>
+    <Box display="flex" height="100%" overflow="auto">
+      <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"
           collapsed={collapsed}
@@ -84,9 +84,9 @@ export default function Example(): ReactNode {
             />
           </SideNavigation.Section>
         </SideNavigation>
-      </Box>
+      </div>
 
-      <Box padding={4}>
+      <Box height={800} padding={4}>
         <Heading size="500">Page main content</Heading>
       </Box>
     </Box>

--- a/docs/examples/sidenavigation/collapsibleHeaderExample.js
+++ b/docs/examples/sidenavigation/collapsibleHeaderExample.js
@@ -9,6 +9,7 @@ export default function Example(): ReactNode {
 
   return (
     <Box display="flex" height="100%" overflow="auto">
+      {/* It is recommended the wrapper to be sticky. */}
       <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"

--- a/docs/examples/sidenavigation/collapsibleWithMixedIconsExample.js
+++ b/docs/examples/sidenavigation/collapsibleWithMixedIconsExample.js
@@ -7,8 +7,8 @@ export default function Example(): ReactNode {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Box display="flex" height="100%" overflow="scroll" width={1000}>
-      <Box maxWidth={280}>
+    <Box display="flex" height="100%" overflow="auto">
+      <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"
           collapsed={collapsed}
@@ -120,9 +120,9 @@ export default function Example(): ReactNode {
             />
           </SideNavigation.Section>
         </SideNavigation>
-      </Box>
+      </div>
 
-      <Box padding={4}>
+      <Box height={800} padding={4}>
         <Heading size="500">Page main content</Heading>
       </Box>
     </Box>

--- a/docs/examples/sidenavigation/collapsibleWithMixedIconsExample.js
+++ b/docs/examples/sidenavigation/collapsibleWithMixedIconsExample.js
@@ -8,6 +8,7 @@ export default function Example(): ReactNode {
 
   return (
     <Box display="flex" height="100%" overflow="auto">
+      {/* It is recommended the wrapper to be sticky. */}
       <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"

--- a/docs/examples/sidenavigation/collapsibleWithoutIconsExample.js
+++ b/docs/examples/sidenavigation/collapsibleWithoutIconsExample.js
@@ -8,6 +8,7 @@ export default function Example(): ReactNode {
 
   return (
     <Box display="flex" height="100%" overflow="auto">
+      {/* It is recommended the wrapper to be sticky. */}
       <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"

--- a/docs/examples/sidenavigation/collapsibleWithoutIconsExample.js
+++ b/docs/examples/sidenavigation/collapsibleWithoutIconsExample.js
@@ -7,8 +7,8 @@ export default function Example(): ReactNode {
   const [collapsed, setCollapsed] = useState(false);
 
   return (
-    <Box display="flex" height="100%" overflow="scroll" width={1000}>
-      <Box maxWidth={280}>
+    <Box display="flex" height="100%" overflow="auto">
+      <div style={{ position: 'sticky', top: 0 }}>
         <SideNavigation
           accessibilityLabel="Collapsible example"
           collapsed={collapsed}
@@ -115,9 +115,9 @@ export default function Example(): ReactNode {
             />
           </SideNavigation.Section>
         </SideNavigation>
-      </Box>
+      </div>
 
-      <Box padding={4}>
+      <Box height={800} padding={4}>
         <Heading size="500">Page main content</Heading>
       </Box>
     </Box>

--- a/docs/pages/web/sidenavigation.js
+++ b/docs/pages/web/sidenavigation.js
@@ -460,7 +460,10 @@ When building SideNavigation, we might want to render different combinations of 
         </MainSection.Subsection>
 
         <MainSection.Subsection
-          description="Providing `collapsed` prop to SideNavigation makes the component collapsible. Collapsible variant of SideNavigation is a controlled component and it has expand/collapse icon button at the top. Clicking the icon button reveals a complete list of navigation options when expanded and minimizes these options, often to a series of compact icons or completely hidden when collapsed. This variant is not available for mobile."
+          description={`Providing \`collapsed\` prop to SideNavigation makes the component collapsible. Collapsible variant of SideNavigation is a controlled component and it has expand/collapse icon button at the top. Clicking the icon button reveals a complete list of navigation options when expanded and minimizes these options, often to a series of compact icons or completely hidden when collapsed. This variant is not available for mobile.
+
+It is recommended the wrapper to be \`sticky\` (not \`fixed\`) so that it stays visible and keeps its position "relative" to other elements. Being sticky means SideNavigation's can naturally shift the adjacent elements/components.
+          `}
           title="Collapsible"
         >
           <MainSection.Card

--- a/packages/gestalt/src/Layout.css
+++ b/packages/gestalt/src/Layout.css
@@ -44,6 +44,11 @@
   overflow: auto;
 }
 
+.overflowAutoY {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
 .fit {
   max-width: 100%;
 }

--- a/packages/gestalt/src/Layout.css.flow
+++ b/packages/gestalt/src/Layout.css.flow
@@ -50,6 +50,7 @@ declare module.exports: {|
   +'orderFirst': string,
   +'orderLast': string,
   +'overflowAuto': string,
+  +'overflowAutoY': string,
   +'overflowHidden': string,
   +'overflowScroll': string,
   +'overflowScrollX': string,

--- a/packages/gestalt/src/SideNavigation.css
+++ b/packages/gestalt/src/SideNavigation.css
@@ -15,7 +15,6 @@
 
 .fullHeight {
   height: 100%;
-  overflow-y: auto;
 }
 
 .contentWidthTransition {

--- a/packages/gestalt/src/SideNavigation/NavigationContent.js
+++ b/packages/gestalt/src/SideNavigation/NavigationContent.js
@@ -41,8 +41,10 @@ export default function NavigationContent({
     transitioning,
   } = useSideNavigation();
 
+  const mainContainer = useRef<HTMLElement | null>(null);
   const scrollContainer = useRef<HTMLDivElement | null>(null);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [collapsedContainerWidth, setCollapsedContainerWidth] = useState<number | void>();
   const previewTimeoutRef = useRef<?Timeout>();
 
   useEffect(() => {
@@ -52,6 +54,7 @@ export default function NavigationContent({
     const mouseEnterHandler = () => {
       if (sideNavigationCollapsed && !transitioning) {
         clearTimeout(previewTimeoutRef.current);
+        setCollapsedContainerWidth(mainContainer.current?.offsetWidth);
         setOverlayPreview(true);
       }
     };
@@ -88,62 +91,65 @@ export default function NavigationContent({
   const normalWidth = 280;
   const headerWidth = isCollapsed ? 44 : undefined;
   const collapsedWidth = shouldCollapseEmpty ? 40 : 60;
-
-  const wrapperWidth = sideNavigationCollapsed ? collapsedWidth : normalWidth;
   const contentWidth = isCollapsed ? collapsedWidth : normalWidth;
 
   return (
     <Box
+      ref={mainContainer}
       aria-label={accessibilityLabel}
       as="nav"
       color="default"
       height="100%"
       minWidth={collapsible ? undefined : normalWidth}
       position="relative"
-      width={collapsible ? wrapperWidth : undefined}
+      width={sideNavigationCollapsed ? collapsedContainerWidth : undefined}
       zIndex={overlayPreview ? new FixedZIndex(1) : undefined}
     >
       <div
         ref={scrollContainer}
-        className={classnames(styles.fullHeight, layoutStyles.borderBox, {
+        className={classnames(styles.fullHeight, layoutStyles.overflowAutoY, {
           [borderStyles.borderRight]: showBorder && !overlayPreview,
           [borderStyles.raisedBottom]: overlayPreview,
           [styles.contentWidthTransition]: collapsible,
-          [layoutStyles.overflowScrollY]: collapsible,
           [boxStyles.default]: collapsible,
         })}
-        style={{ width: collapsible ? contentWidth : undefined }}
+        style={{ width: collapsible ? 'max-content' : undefined }}
       >
-        {collapsible && <Collapser raised={isScrolled} />}
-
-        <Box
-          dangerouslySetInlineStyle={{
-            __style: {
-              paddingBottom: 24,
-            },
-          }}
-          display={shouldHideItems ? 'none' : undefined}
-          padding={2}
-          width={collapsible ? contentWidth : undefined}
+        <div
+          className={classnames({ [styles.contentWidthTransition]: collapsible })}
+          style={{ width: collapsible ? contentWidth : undefined }}
         >
-          <Flex direction="column" gap={{ column: 4, row: 0 }}>
-            {header ? (
-              <Flex direction="column" gap={{ column: 4, row: 0 }}>
-                <Box width={headerWidth}>{header}</Box>
-                <Divider />
-              </Flex>
-            ) : null}
+          {collapsible && <Collapser raised={isScrolled} />}
 
-            <ul className={classnames(styles.ulItem)}>{items}</ul>
+          <Box
+            dangerouslySetInlineStyle={{
+              __style: {
+                paddingBottom: 24,
+              },
+            }}
+            display={shouldHideItems ? 'none' : undefined}
+            padding={2}
+            width={collapsible ? contentWidth : undefined}
+          >
+            <Flex direction="column" gap={{ column: 4, row: 0 }}>
+              {header ? (
+                <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                  <Box width={headerWidth}>{header}</Box>
+                  <Divider />
+                </Flex>
+              ) : null}
 
-            {footer ? (
-              <Flex direction="column" gap={{ column: 4, row: 0 }}>
-                <Divider />
-                <Box width={headerWidth}>{footer}</Box>
-              </Flex>
-            ) : null}
-          </Flex>
-        </Box>
+              <ul className={classnames(styles.ulItem)}>{items}</ul>
+
+              {footer ? (
+                <Flex direction="column" gap={{ column: 4, row: 0 }}>
+                  <Divider />
+                  <Box width={headerWidth}>{footer}</Box>
+                </Flex>
+              ) : null}
+            </Flex>
+          </Box>
+        </div>
       </div>
     </Box>
   );

--- a/packages/gestalt/src/SideNavigation/NavigationContent.js
+++ b/packages/gestalt/src/SideNavigation/NavigationContent.js
@@ -94,6 +94,7 @@ export default function NavigationContent({
   const contentWidth = isCollapsed ? collapsedWidth : normalWidth;
 
   return (
+    // 1st wrapper - always has dynamic width, but in overlay-preview state its width is static
     <Box
       ref={mainContainer}
       aria-label={accessibilityLabel}
@@ -105,6 +106,7 @@ export default function NavigationContent({
       width={sideNavigationCollapsed ? collapsedContainerWidth : undefined}
       zIndex={overlayPreview ? new FixedZIndex(1) : undefined}
     >
+      {/* 2nd wrapper - mainly acts as scroll-container and has dynamic width */}
       <div
         ref={scrollContainer}
         className={classnames(styles.fullHeight, layoutStyles.overflowAutoY, {
@@ -115,6 +117,7 @@ export default function NavigationContent({
         })}
         style={{ width: collapsible ? 'max-content' : undefined }}
       >
+        {/* 3rd wrapper - when collapsible=true, it has static width and responsible for expand/collpase transition */}
         <div
           className={classnames({ [styles.contentWidthTransition]: collapsible })}
           style={{ width: collapsible ? contentWidth : undefined }}

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.js.snap
@@ -22,7 +22,7 @@ exports[`SideNavigation renders Header + Footer 1`] = `
     }
   >
     <div
-      className="fullHeight borderBox"
+      className="fullHeight overflowAutoY"
       style={
         Object {
           "width": undefined,
@@ -30,151 +30,160 @@ exports[`SideNavigation renders Header + Footer 1`] = `
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
             <div
-              className="Flex rowGap0 columnGap4 xsDirectionColumn"
+              className="FlexItem"
             >
               <div
-                className="FlexItem"
+                className="Flex rowGap0 columnGap4 xsDirectionColumn"
               >
                 <div
-                  className="box"
-                  style={
-                    Object {
-                      "width": undefined,
-                    }
-                  }
+                  className="FlexItem"
                 >
                   <div
-                    className="box default"
+                    className="box"
                     style={
                       Object {
-                        "height": 100,
-                        "width": "100%",
-                      }
-                    }
-                  />
-                </div>
-              </div>
-              <div
-                className="FlexItem"
-              >
-                <hr
-                  className="divider"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            className="FlexItem"
-          >
-            <ul
-              className="ulItem"
-            >
-              <li
-                className="liItem"
-              >
-                <a
-                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                  href="#"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  rel=""
-                  tabIndex={0}
-                  target={null}
-                >
-                  <div
-                    className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                    style={
-                      Object {
-                        "minHeight": 44,
-                        "paddingInlineEnd": "16px",
-                        "paddingInlineStart": "var(--space-400)",
                         "width": undefined,
                       }
                     }
                   >
                     <div
-                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      className="box default"
                       style={
                         Object {
-                          "height": "100%",
+                          "height": 100,
                           "width": "100%",
+                        }
+                      }
+                    />
+                  </div>
+                </div>
+                <div
+                  className="FlexItem"
+                >
+                  <hr
+                    className="divider"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="FlexItem"
+            >
+              <ul
+                className="ulItem"
+              >
+                <li
+                  className="liItem"
+                >
+                  <a
+                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                    href="#"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    rel=""
+                    tabIndex={0}
+                    target={null}
+                  >
+                    <div
+                      className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
+                      style={
+                        Object {
+                          "minHeight": 44,
+                          "paddingInlineEnd": "16px",
+                          "paddingInlineStart": "var(--space-400)",
+                          "width": undefined,
                         }
                       }
                     >
                       <div
-                        className="FlexItem flexGrow selfCenter"
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
                       >
-                        <span
-                          className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                        <div
+                          className="FlexItem flexGrow selfCenter"
                         >
-                          test
-                        </span>
+                          <span
+                            className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                          >
+                            test
+                          </span>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </a>
-              </li>
-            </ul>
-          </div>
-          <div
-            className="FlexItem"
-          >
+                  </a>
+                </li>
+              </ul>
+            </div>
             <div
-              className="Flex rowGap0 columnGap4 xsDirectionColumn"
+              className="FlexItem"
             >
               <div
-                className="FlexItem"
-              >
-                <hr
-                  className="divider"
-                />
-              </div>
-              <div
-                className="FlexItem"
+                className="Flex rowGap0 columnGap4 xsDirectionColumn"
               >
                 <div
-                  className="box"
-                  style={
-                    Object {
-                      "width": undefined,
-                    }
-                  }
+                  className="FlexItem"
+                >
+                  <hr
+                    className="divider"
+                  />
+                </div>
+                <div
+                  className="FlexItem"
                 >
                   <div
-                    className="box default"
+                    className="box"
                     style={
                       Object {
-                        "height": 100,
-                        "width": "100%",
+                        "width": undefined,
                       }
                     }
-                  />
+                  >
+                    <div
+                      className="box default"
+                      style={
+                        Object {
+                          "height": 100,
+                          "width": "100%",
+                        }
+                      }
+                    />
+                  </div>
                 </div>
               </div>
             </div>
@@ -208,7 +217,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
     }
   >
     <div
-      className="fullHeight borderBox borderRight"
+      className="fullHeight overflowAutoY borderRight"
       style={
         Object {
           "width": undefined,
@@ -216,303 +225,312 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
-            <ul
-              className="ulItem"
+            <div
+              className="FlexItem"
             >
-              <li
-                className="liItem section"
+              <ul
+                className="ulItem"
               >
-                <div
-                  className="box marginBottom2 paddingX4"
-                  role="presentation"
+                <li
+                  className="liItem section"
                 >
                   <div
-                    className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
-                    style={
-                      Object {
-                        "WebkitLineClamp": 2,
-                      }
-                    }
-                    title="section"
+                    className="box marginBottom2 paddingX4"
+                    role="presentation"
                   >
-                    section
-                  </div>
-                </div>
-                <ul
-                  className="ulItem"
-                >
-                  <li
-                    className="liItem"
-                  >
-                    <a
-                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                      href="#"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      rel=""
-                      tabIndex={0}
-                      target={null}
-                    >
-                      <div
-                        className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "minHeight": 44,
-                            "paddingInlineEnd": "16px",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
+                    <div
+                      className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 2,
                         }
+                      }
+                      title="section"
+                    >
+                      section
+                    </div>
+                  </div>
+                  <ul
+                    className="ulItem"
+                  >
+                    <li
+                      className="liItem"
+                    >
+                      <a
+                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                        href="#"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        rel=""
+                        tabIndex={0}
+                        target={null}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "minHeight": 44,
+                              "paddingInlineEnd": "16px",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
                             <div
-                              aria-hidden={true}
-                              className="box"
+                              className="FlexItem selfCenter"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-label=""
-                                className="default icon"
-                                height={20}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={20}
-                              >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
-                            </div>
-                          </div>
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              test
                               <div
-                                className="box marginStart1 xsDisplayInlineBlock"
-                                style={
-                                  Object {
-                                    "height": "100%",
-                                  }
-                                }
+                                aria-hidden={true}
+                                className="box"
                               >
-                                <div
-                                  className="box xsDisplayVisuallyHidden"
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon"
+                                  height={20}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={20}
                                 >
-                                  , 
-                                </div>
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                            <div
+                              className="FlexItem flexGrow selfCenter"
+                            >
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                test
                                 <div
-                                  className="Badge middle info"
+                                  className="box marginStart1 xsDisplayInlineBlock"
+                                  style={
+                                    Object {
+                                      "height": "100%",
+                                    }
+                                  }
                                 >
                                   <div
-                                    className="Flex rowGap1 columnGap1 xsDirectionRow xsItemsCenter"
+                                    className="box xsDisplayVisuallyHidden"
+                                  >
+                                    , 
+                                  </div>
+                                  <div
+                                    className="Badge middle info"
                                   >
                                     <div
-                                      className="FlexItem"
+                                      className="Flex rowGap1 columnGap1 xsDirectionRow xsItemsCenter"
                                     >
                                       <div
-                                        className="box xsDisplayInlineBlock"
-                                        style={
-                                          Object {
-                                            "marginTop": "2px",
-                                          }
-                                        }
+                                        className="FlexItem"
                                       >
-                                        New
+                                        <div
+                                          className="box xsDisplayInlineBlock"
+                                          style={
+                                            Object {
+                                              "marginTop": "2px",
+                                            }
+                                          }
+                                        >
+                                          New
+                                        </div>
                                       </div>
                                     </div>
                                   </div>
                                 </div>
-                              </div>
-                            </span>
-                          </div>
-                          <div
-                            className="FlexItem flexNone selfCenter"
-                          >
-                            <div
-                              className="box xsDisplayVisuallyHidden"
-                            >
-                              , 
+                              </span>
                             </div>
                             <div
-                              aria-label="You have 20 notifications"
-                              className="box marginEndN2"
+                              className="FlexItem flexNone selfCenter"
                             >
                               <div
-                                className="Text fontSize300 subtle alignEnd breakWord fontWeightNormal"
+                                className="box xsDisplayVisuallyHidden"
                               >
-                                20
+                                , 
+                              </div>
+                              <div
+                                aria-label="You have 20 notifications"
+                                className="box marginEndN2"
+                              >
+                                <div
+                                  className="Text fontSize300 subtle alignEnd breakWord fontWeightNormal"
+                                >
+                                  20
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </a>
-                  </li>
-                  <li
-                    className="liItem"
-                  >
-                    <a
-                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                      href="#"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      rel=""
-                      tabIndex={0}
-                      target={null}
+                      </a>
+                    </li>
+                    <li
+                      className="liItem"
                     >
-                      <div
-                        className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "minHeight": 44,
-                            "paddingInlineEnd": "16px",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
-                        }
+                      <a
+                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                        href="#"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        rel=""
+                        tabIndex={0}
+                        target={null}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "minHeight": 44,
+                              "paddingInlineEnd": "16px",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
                             <div
-                              aria-hidden={true}
-                              className="box"
+                              className="FlexItem selfCenter"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-label=""
-                                className="default icon"
-                                height={20}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={20}
-                              >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
-                            </div>
-                          </div>
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              test
                               <div
-                                className="box marginStart1 xsDisplayInlineBlock"
-                                style={
-                                  Object {
-                                    "height": "100%",
-                                  }
-                                }
+                                aria-hidden={true}
+                                className="box"
                               >
-                                <div
-                                  className="box xsDisplayVisuallyHidden"
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon"
+                                  height={20}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={20}
                                 >
-                                  , 
-                                </div>
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                            <div
+                              className="FlexItem flexGrow selfCenter"
+                            >
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                test
                                 <div
-                                  aria-label="You have new messages"
-                                  className="box circle primary"
-                                  role="status"
+                                  className="box marginStart1 xsDisplayInlineBlock"
                                   style={
                                     Object {
-                                      "height": 8,
-                                      "width": 8,
+                                      "height": "100%",
                                     }
                                   }
-                                />
-                              </div>
-                            </span>
-                          </div>
-                          <div
-                            className="FlexItem flexNone selfCenter"
-                          >
-                            <div
-                              className="box xsDisplayVisuallyHidden"
-                            >
-                              , 
+                                >
+                                  <div
+                                    className="box xsDisplayVisuallyHidden"
+                                  >
+                                    , 
+                                  </div>
+                                  <div
+                                    aria-label="You have new messages"
+                                    className="box circle primary"
+                                    role="status"
+                                    style={
+                                      Object {
+                                        "height": 8,
+                                        "width": 8,
+                                      }
+                                    }
+                                  />
+                                </div>
+                              </span>
                             </div>
                             <div
-                              aria-label="You have 20 notifications"
-                              className="box marginEndN2"
+                              className="FlexItem flexNone selfCenter"
                             >
                               <div
-                                className="Text fontSize300 subtle alignEnd breakWord fontWeightNormal"
+                                className="box xsDisplayVisuallyHidden"
                               >
-                                20
+                                , 
+                              </div>
+                              <div
+                                aria-label="You have 20 notifications"
+                                className="box marginEndN2"
+                              >
+                                <div
+                                  className="Text fontSize300 subtle alignEnd breakWord fontWeightNormal"
+                                >
+                                  20
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -543,7 +561,7 @@ exports[`SideNavigation renders Sections 1`] = `
     }
   >
     <div
-      className="fullHeight borderBox"
+      className="fullHeight overflowAutoY"
       style={
         Object {
           "width": undefined,
@@ -551,104 +569,113 @@ exports[`SideNavigation renders Sections 1`] = `
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
-            <ul
-              className="ulItem"
+            <div
+              className="FlexItem"
             >
-              <li
-                className="liItem section"
+              <ul
+                className="ulItem"
               >
-                <div
-                  className="box marginBottom2 paddingX4"
-                  role="presentation"
+                <li
+                  className="liItem section"
                 >
                   <div
-                    className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
-                    style={
-                      Object {
-                        "WebkitLineClamp": 2,
-                      }
-                    }
-                    title="section"
+                    className="box marginBottom2 paddingX4"
+                    role="presentation"
                   >
-                    section
-                  </div>
-                </div>
-                <ul
-                  className="ulItem"
-                >
-                  <li
-                    className="liItem"
-                  >
-                    <a
-                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                      href="#"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      rel=""
-                      tabIndex={0}
-                      target={null}
-                    >
-                      <div
-                        className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "minHeight": 44,
-                            "paddingInlineEnd": "16px",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
+                    <div
+                      className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 2,
                         }
+                      }
+                      title="section"
+                    >
+                      section
+                    </div>
+                  </div>
+                  <ul
+                    className="ulItem"
+                  >
+                    <li
+                      className="liItem"
+                    >
+                      <a
+                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                        href="#"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        rel=""
+                        tabIndex={0}
+                        target={null}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "minHeight": 44,
+                              "paddingInlineEnd": "16px",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem flexGrow selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                            <div
+                              className="FlexItem flexGrow selfCenter"
                             >
-                              test
-                            </span>
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                test
+                              </span>
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    </a>
-                  </li>
-                </ul>
-              </li>
-            </ul>
+                      </a>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -679,7 +706,7 @@ exports[`SideNavigation renders basic Item 1`] = `
     }
   >
     <div
-      className="fullHeight borderBox"
+      className="fullHeight overflowAutoY"
       style={
         Object {
           "width": undefined,
@@ -687,80 +714,89 @@ exports[`SideNavigation renders basic Item 1`] = `
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
-            <ul
-              className="ulItem"
+            <div
+              className="FlexItem"
             >
-              <li
-                className="liItem"
+              <ul
+                className="ulItem"
               >
-                <a
-                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                  href="#"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  rel=""
-                  tabIndex={0}
-                  target={null}
+                <li
+                  className="liItem"
                 >
-                  <div
-                    className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                    style={
-                      Object {
-                        "minHeight": 44,
-                        "paddingInlineEnd": "16px",
-                        "paddingInlineStart": "var(--space-400)",
-                        "width": undefined,
-                      }
-                    }
+                  <a
+                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                    href="#"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    rel=""
+                    tabIndex={0}
+                    target={null}
                   >
                     <div
-                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "height": "100%",
-                          "width": "100%",
+                          "minHeight": 44,
+                          "paddingInlineEnd": "16px",
+                          "paddingInlineStart": "var(--space-400)",
+                          "width": undefined,
                         }
                       }
                     >
                       <div
-                        className="FlexItem flexGrow selfCenter"
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
                       >
-                        <span
-                          className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                        <div
+                          className="FlexItem flexGrow selfCenter"
                         >
-                          test
-                        </span>
+                          <span
+                            className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                          >
+                            test
+                          </span>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </a>
-              </li>
-            </ul>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -791,7 +827,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
     }
   >
     <div
-      className="fullHeight borderBox"
+      className="fullHeight overflowAutoY"
       style={
         Object {
           "width": undefined,
@@ -799,488 +835,497 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
-            <ul
-              className="ulItem"
+            <div
+              className="FlexItem"
             >
-              <li
-                className="liItem"
+              <ul
+                className="ulItem"
               >
-                <a
-                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                  href="#"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  rel=""
-                  tabIndex={0}
-                  target={null}
+                <li
+                  className="liItem"
                 >
-                  <div
-                    className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                    style={
-                      Object {
-                        "minHeight": 44,
-                        "paddingInlineEnd": "16px",
-                        "paddingInlineStart": "var(--space-400)",
-                        "width": undefined,
-                      }
-                    }
+                  <a
+                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                    href="#"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    rel=""
+                    tabIndex={0}
+                    target={null}
                   >
                     <div
-                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "height": "100%",
-                          "width": "100%",
+                          "minHeight": 44,
+                          "paddingInlineEnd": "16px",
+                          "paddingInlineStart": "var(--space-400)",
+                          "width": undefined,
                         }
                       }
                     >
                       <div
-                        className="FlexItem selfCenter"
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
                       >
                         <div
-                          aria-hidden={true}
-                          className="box"
+                          className="FlexItem selfCenter"
                         >
-                          <svg
+                          <div
                             aria-hidden={true}
-                            aria-label=""
-                            className="rtlSupport default icon"
-                            height={20}
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width={20}
+                            className="box"
                           >
-                            <path
-                              d="test-file-stub"
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden={true}
+                              aria-label=""
+                              className="rtlSupport default icon"
+                              height={20}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={20}
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          className="FlexItem flexGrow selfCenter"
+                        >
+                          <span
+                            className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                          >
+                            Reporting
+                          </span>
                         </div>
                       </div>
-                      <div
-                        className="FlexItem flexGrow selfCenter"
-                      >
-                        <span
-                          className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                        >
-                          Reporting
-                        </span>
-                      </div>
                     </div>
-                  </div>
-                </a>
-              </li>
-              <li
-                className="liItem"
-              >
-                <a
-                  className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                  href="#"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  rel=""
-                  tabIndex={0}
-                  target={null}
+                  </a>
+                </li>
+                <li
+                  className="liItem"
                 >
-                  <div
-                    className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                    style={
-                      Object {
-                        "minHeight": 44,
-                        "paddingInlineEnd": "16px",
-                        "paddingInlineStart": "var(--space-400)",
-                        "width": undefined,
-                      }
-                    }
+                  <a
+                    className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                    href="#"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    rel=""
+                    tabIndex={0}
+                    target={null}
                   >
                     <div
-                      className="Flex rowGap2 columnGap0 xsDirectionRow"
+                      className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "height": "100%",
-                          "width": "100%",
+                          "minHeight": 44,
+                          "paddingInlineEnd": "16px",
+                          "paddingInlineStart": "var(--space-400)",
+                          "width": undefined,
                         }
                       }
                     >
                       <div
-                        className="FlexItem selfCenter"
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
                       >
                         <div
-                          aria-hidden={true}
-                          className="box"
+                          className="FlexItem selfCenter"
                         >
-                          <svg
+                          <div
                             aria-hidden={true}
-                            aria-label=""
-                            className="default icon"
-                            height={20}
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width={20}
+                            className="box"
                           >
-                            <path
-                              d="test-file-stub"
-                            />
-                          </svg>
+                            <svg
+                              aria-hidden={true}
+                              aria-label=""
+                              className="default icon"
+                              height={20}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={20}
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          className="FlexItem flexGrow selfCenter"
+                        >
+                          <span
+                            className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                          >
+                            Conversions
+                          </span>
                         </div>
                       </div>
-                      <div
-                        className="FlexItem flexGrow selfCenter"
-                      >
-                        <span
-                          className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                        >
-                          Conversions
-                        </span>
-                      </div>
                     </div>
-                  </div>
-                </a>
-              </li>
-              <li
-                className="liItem section"
-              >
-                <div
-                  className="box marginBottom2 paddingX4"
-                  role="presentation"
+                  </a>
+                </li>
+                <li
+                  className="liItem section"
                 >
                   <div
-                    className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
-                    style={
-                      Object {
-                        "WebkitLineClamp": 2,
+                    className="box marginBottom2 paddingX4"
+                    role="presentation"
+                  >
+                    <div
+                      className="Text fontSize300 default alignStart breakWord fontWeightSemiBold lineClamp"
+                      style={
+                        Object {
+                          "WebkitLineClamp": 2,
+                        }
                       }
-                    }
-                    title="Audiences"
-                  >
-                    Audiences
+                      title="Audiences"
+                    >
+                      Audiences
+                    </div>
                   </div>
-                </div>
-                <ul
-                  className="ulItem"
-                >
-                  <li
-                    className="liItem"
+                  <ul
+                    className="ulItem"
                   >
-                    <a
-                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                      href="#"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      rel=""
-                      tabIndex={0}
-                      target={null}
+                    <li
+                      className="liItem"
                     >
-                      <div
-                        className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "minHeight": 44,
-                            "paddingInlineEnd": "16px",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
-                        }
+                      <a
+                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                        href="#"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        rel=""
+                        tabIndex={0}
+                        target={null}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "minHeight": 44,
+                              "paddingInlineEnd": "16px",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
                             <div
-                              aria-hidden={true}
-                              className="box"
+                              className="FlexItem selfCenter"
                             >
-                              <svg
+                              <div
                                 aria-hidden={true}
-                                aria-label=""
-                                className="default icon"
-                                height={20}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={20}
+                                className="box"
                               >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon"
+                                  height={20}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={20}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                            <div
+                              className="FlexItem flexGrow selfCenter"
+                            >
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                Thanksgiving
+                              </span>
                             </div>
                           </div>
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              Thanksgiving
-                            </span>
-                          </div>
                         </div>
-                      </div>
-                    </a>
-                  </li>
-                  <li
-                    className="liItem"
-                  >
-                    <div
-                      aria-controls=":rd:"
-                      aria-disabled={false}
-                      aria-expanded={false}
-                      className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      role="button"
-                      tabIndex={0}
+                      </a>
+                    </li>
+                    <li
+                      className="liItem"
                     >
                       <div
-                        className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "height": undefined,
-                            "minHeight": 44,
-                            "paddingInlineEnd": "var(--space-400)",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
-                        }
+                        aria-controls=":rd:"
+                        aria-disabled={false}
+                        aria-expanded={false}
+                        className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "height": undefined,
+                              "minHeight": 44,
+                              "paddingInlineEnd": "var(--space-400)",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
                             <div
-                              aria-hidden={true}
-                              className="box"
+                              className="FlexItem selfCenter"
                             >
-                              <svg
+                              <div
                                 aria-hidden={true}
-                                aria-label=""
-                                className="default icon"
-                                height={20}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={20}
+                                className="box"
                               >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon"
+                                  height={20}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={20}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
                             </div>
-                          </div>
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              Christmas
-                            </span>
-                          </div>
-                          <div
-                            className="FlexItem flexNone selfCenter"
-                          >
                             <div
-                              aria-hidden={true}
-                              className="box circle marginEndN2 marginStart2"
-                              tabIndex={-1}
+                              className="FlexItem flexGrow selfCenter"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-label=""
-                                className="default icon iconBlock"
-                                height={12}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={12}
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
                               >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
+                                Christmas
+                              </span>
+                            </div>
+                            <div
+                              className="FlexItem flexNone selfCenter"
+                            >
+                              <div
+                                aria-hidden={true}
+                                className="box circle marginEndN2 marginStart2"
+                                tabIndex={-1}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon iconBlock"
+                                  height={12}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={12}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </li>
-                  <li
-                    className="liItem"
-                  >
-                    <div
-                      aria-controls=":re:"
-                      aria-disabled={false}
-                      aria-expanded={false}
-                      className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      role="button"
-                      tabIndex={0}
+                    </li>
+                    <li
+                      className="liItem"
                     >
                       <div
-                        className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "height": undefined,
-                            "minHeight": 44,
-                            "paddingInlineEnd": "var(--space-400)",
-                            "paddingInlineStart": "var(--space-400)",
-                            "width": undefined,
-                          }
-                        }
+                        aria-controls=":re:"
+                        aria-disabled={false}
+                        aria-expanded={false}
+                        className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        role="button"
+                        tabIndex={0}
                       >
                         <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
+                          className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "height": "100%",
-                              "width": "100%",
+                              "height": undefined,
+                              "minHeight": 44,
+                              "paddingInlineEnd": "var(--space-400)",
+                              "paddingInlineStart": "var(--space-400)",
+                              "width": undefined,
                             }
                           }
                         >
                           <div
-                            className="FlexItem selfCenter"
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
                           >
                             <div
-                              aria-hidden={true}
-                              className="box"
+                              className="FlexItem selfCenter"
                             >
-                              <svg
+                              <div
                                 aria-hidden={true}
-                                aria-label=""
-                                className="default icon"
-                                height={20}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={20}
+                                className="box"
                               >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon"
+                                  height={20}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={20}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
                             </div>
-                          </div>
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              Halloween
-                            </span>
-                          </div>
-                          <div
-                            className="FlexItem flexNone selfCenter"
-                          >
                             <div
-                              aria-hidden={true}
-                              className="box circle marginEndN2 marginStart2"
-                              tabIndex={-1}
+                              className="FlexItem flexGrow selfCenter"
                             >
-                              <svg
-                                aria-hidden={true}
-                                aria-label=""
-                                className="default icon iconBlock"
-                                height={12}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={12}
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
                               >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
+                                Halloween
+                              </span>
+                            </div>
+                            <div
+                              className="FlexItem flexNone selfCenter"
+                            >
+                              <div
+                                aria-hidden={true}
+                                className="box circle marginEndN2 marginStart2"
+                                tabIndex={-1}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon iconBlock"
+                                  height={12}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={12}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
                             </div>
                           </div>
                         </div>
                       </div>
-                    </div>
-                  </li>
-                </ul>
-              </li>
-            </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>
@@ -1311,7 +1356,7 @@ exports[`SideNavigation renders expanded group 1`] = `
     }
   >
     <div
-      className="fullHeight borderBox"
+      className="fullHeight overflowAutoY"
       style={
         Object {
           "width": undefined,
@@ -1319,46 +1364,460 @@ exports[`SideNavigation renders expanded group 1`] = `
       }
     >
       <div
-        className="box paddingX2 paddingY2"
+        className=""
         style={
           Object {
-            "paddingBottom": 24,
             "width": undefined,
           }
         }
       >
         <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
         >
           <div
-            className="FlexItem"
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
           >
-            <ul
-              className="ulItem"
+            <div
+              className="FlexItem"
             >
-              <li
-                className="liItem"
+              <ul
+                className="ulItem"
               >
-                <div
-                  aria-controls=":ri:"
-                  aria-disabled={false}
-                  aria-expanded={true}
-                  className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchCancel={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  role="button"
-                  tabIndex={0}
+                <li
+                  className="liItem"
+                >
+                  <div
+                    aria-controls=":ri:"
+                    aria-disabled={false}
+                    aria-expanded={true}
+                    className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div
+                      className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "minHeight": 44,
+                          "paddingInlineEnd": "var(--space-400)",
+                          "paddingInlineStart": "var(--space-400)",
+                          "width": undefined,
+                        }
+                      }
+                    >
+                      <div
+                        className="Flex rowGap2 columnGap0 xsDirectionRow"
+                        style={
+                          Object {
+                            "height": "100%",
+                            "width": "100%",
+                          }
+                        }
+                      >
+                        <div
+                          className="FlexItem selfCenter"
+                        >
+                          <div
+                            aria-hidden={true}
+                            className="box"
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-label=""
+                              className="default icon"
+                              height={20}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={20}
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <div
+                          className="FlexItem flexGrow selfCenter"
+                        >
+                          <span
+                            className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                          >
+                            Christmas
+                          </span>
+                        </div>
+                        <div
+                          className="FlexItem flexNone selfCenter"
+                        >
+                          <div
+                            aria-hidden={true}
+                            className="box circle marginEndN2 marginStart2"
+                            tabIndex={-1}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              aria-label=""
+                              className="default icon iconBlock"
+                              height={12}
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width={12}
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <ul
+                    className="ulItem"
+                    id=":ri:"
+                  >
+                    <li
+                      className="liItem"
+                    >
+                      <a
+                        className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                        href="#"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        rel=""
+                        tabIndex={0}
+                        target={null}
+                      >
+                        <div
+                          className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
+                          style={
+                            Object {
+                              "minHeight": 44,
+                              "paddingInlineEnd": "16px",
+                              "paddingInlineStart": "var(--space-1200)",
+                              "width": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            <div
+                              className="FlexItem flexGrow selfCenter"
+                            >
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                Luxury Christmas
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </a>
+                    </li>
+                    <li
+                      className="liItem"
+                    >
+                      <div
+                        aria-controls=":rm:"
+                        aria-disabled={false}
+                        aria-expanded={true}
+                        className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchCancel={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        role="button"
+                        tabIndex={0}
+                      >
+                        <div
+                          className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
+                          style={
+                            Object {
+                              "height": undefined,
+                              "minHeight": 44,
+                              "paddingInlineEnd": "var(--space-400)",
+                              "paddingInlineStart": "var(--space-1200)",
+                              "width": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="Flex rowGap2 columnGap0 xsDirectionRow"
+                            style={
+                              Object {
+                                "height": "100%",
+                                "width": "100%",
+                              }
+                            }
+                          >
+                            <div
+                              className="FlexItem flexGrow selfCenter"
+                            >
+                              <span
+                                className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                              >
+                                Classic Christmas
+                              </span>
+                            </div>
+                            <div
+                              className="FlexItem flexNone selfCenter"
+                            >
+                              <div
+                                aria-hidden={true}
+                                className="box circle marginEndN2 marginStart2"
+                                tabIndex={-1}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-label=""
+                                  className="default icon iconBlock"
+                                  height={12}
+                                  role="img"
+                                  viewBox="0 0 24 24"
+                                  width={12}
+                                >
+                                  <path
+                                    d="test-file-stub"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <ul
+                        className="ulItem"
+                        id=":rm:"
+                      >
+                        <li
+                          className="liItem"
+                        >
+                          <a
+                            className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                            href="#"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyPress={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            rel=""
+                            tabIndex={0}
+                            target={null}
+                          >
+                            <div
+                              className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
+                              style={
+                                Object {
+                                  "minHeight": 44,
+                                  "paddingInlineEnd": "16px",
+                                  "paddingInlineStart": "68px",
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="Flex rowGap2 columnGap0 xsDirectionRow"
+                                style={
+                                  Object {
+                                    "height": "100%",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="FlexItem flexGrow selfCenter"
+                                >
+                                  <span
+                                    className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                                  >
+                                    West Coast
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </a>
+                        </li>
+                        <li
+                          className="liItem"
+                        >
+                          <a
+                            className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
+                            href="#"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyPress={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchCancel={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            rel=""
+                            tabIndex={0}
+                            target={null}
+                          >
+                            <div
+                              className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
+                              style={
+                                Object {
+                                  "minHeight": 44,
+                                  "paddingInlineEnd": "16px",
+                                  "paddingInlineStart": "68px",
+                                  "width": undefined,
+                                }
+                              }
+                            >
+                              <div
+                                className="Flex rowGap2 columnGap0 xsDirectionRow"
+                                style={
+                                  Object {
+                                    "height": "100%",
+                                    "width": "100%",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="FlexItem flexGrow selfCenter"
+                                >
+                                  <span
+                                    className="Text fontSize300 default alignStart breakWord fontWeightNormal"
+                                  >
+                                    East Coast
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </a>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`SideNavigation renders static group 1`] = `
+<div
+  className="box overflowAuto paddingX0 paddingY0 relative"
+  style={
+    Object {
+      "height": "100%",
+      "width": undefined,
+    }
+  }
+>
+  <nav
+    aria-label="Static items example"
+    className="box default relative"
+    style={
+      Object {
+        "height": "100%",
+        "minWidth": 280,
+        "width": undefined,
+      }
+    }
+  >
+    <div
+      className="fullHeight overflowAutoY"
+      style={
+        Object {
+          "width": undefined,
+        }
+      }
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "width": undefined,
+          }
+        }
+      >
+        <div
+          className="box paddingX2 paddingY2"
+          style={
+            Object {
+              "paddingBottom": 24,
+              "width": undefined,
+            }
+          }
+        >
+          <div
+            className="Flex rowGap0 columnGap4 xsDirectionColumn"
+          >
+            <div
+              className="FlexItem"
+            >
+              <ul
+                className="ulItem"
+              >
+                <li
+                  className="liItem"
                 >
                   <div
                     className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
@@ -1412,407 +1871,11 @@ exports[`SideNavigation renders expanded group 1`] = `
                           Christmas
                         </span>
                       </div>
-                      <div
-                        className="FlexItem flexNone selfCenter"
-                      >
-                        <div
-                          aria-hidden={true}
-                          className="box circle marginEndN2 marginStart2"
-                          tabIndex={-1}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            aria-label=""
-                            className="default icon iconBlock"
-                            height={12}
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width={12}
-                          >
-                            <path
-                              d="test-file-stub"
-                            />
-                          </svg>
-                        </div>
-                      </div>
                     </div>
                   </div>
-                </div>
-                <ul
-                  className="ulItem"
-                  id=":ri:"
-                >
-                  <li
-                    className="liItem"
-                  >
-                    <a
-                      className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                      href="#"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      rel=""
-                      tabIndex={0}
-                      target={null}
-                    >
-                      <div
-                        className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "minHeight": 44,
-                            "paddingInlineEnd": "16px",
-                            "paddingInlineStart": "var(--space-1200)",
-                            "width": undefined,
-                          }
-                        }
-                      >
-                        <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
-                          style={
-                            Object {
-                              "height": "100%",
-                              "width": "100%",
-                            }
-                          }
-                        >
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              Luxury Christmas
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </a>
-                  </li>
-                  <li
-                    className="liItem"
-                  >
-                    <div
-                      aria-controls=":rm:"
-                      aria-disabled={false}
-                      aria-expanded={true}
-                      className="hideOutline tapTransition rounding2 accessibilityOutline fullWidth pointer"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyPress={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      role="button"
-                      tabIndex={0}
-                    >
-                      <div
-                        className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
-                        style={
-                          Object {
-                            "height": undefined,
-                            "minHeight": 44,
-                            "paddingInlineEnd": "var(--space-400)",
-                            "paddingInlineStart": "var(--space-1200)",
-                            "width": undefined,
-                          }
-                        }
-                      >
-                        <div
-                          className="Flex rowGap2 columnGap0 xsDirectionRow"
-                          style={
-                            Object {
-                              "height": "100%",
-                              "width": "100%",
-                            }
-                          }
-                        >
-                          <div
-                            className="FlexItem flexGrow selfCenter"
-                          >
-                            <span
-                              className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                            >
-                              Classic Christmas
-                            </span>
-                          </div>
-                          <div
-                            className="FlexItem flexNone selfCenter"
-                          >
-                            <div
-                              aria-hidden={true}
-                              className="box circle marginEndN2 marginStart2"
-                              tabIndex={-1}
-                            >
-                              <svg
-                                aria-hidden={true}
-                                aria-label=""
-                                className="default icon iconBlock"
-                                height={12}
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width={12}
-                              >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <ul
-                      className="ulItem"
-                      id=":rm:"
-                    >
-                      <li
-                        className="liItem"
-                      >
-                        <a
-                          className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                          href="#"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyPress={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchCancel={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          rel=""
-                          tabIndex={0}
-                          target={null}
-                        >
-                          <div
-                            className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                            style={
-                              Object {
-                                "minHeight": 44,
-                                "paddingInlineEnd": "16px",
-                                "paddingInlineStart": "68px",
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <div
-                              className="Flex rowGap2 columnGap0 xsDirectionRow"
-                              style={
-                                Object {
-                                  "height": "100%",
-                                  "width": "100%",
-                                }
-                              }
-                            >
-                              <div
-                                className="FlexItem flexGrow selfCenter"
-                              >
-                                <span
-                                  className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                                >
-                                  West Coast
-                                </span>
-                              </div>
-                            </div>
-                          </div>
-                        </a>
-                      </li>
-                      <li
-                        className="liItem"
-                      >
-                        <a
-                          className="link noUnderline hideOutline tapTransition rounding2 accessibilityOutline block fullWidth pointer"
-                          href="#"
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onKeyPress={[Function]}
-                          onMouseDown={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
-                          onMouseUp={[Function]}
-                          onTouchCancel={[Function]}
-                          onTouchEnd={[Function]}
-                          onTouchMove={[Function]}
-                          onTouchStart={[Function]}
-                          rel=""
-                          tabIndex={0}
-                          target={null}
-                        >
-                          <div
-                            className="box paddingY2 relative rounding2 xsDisplayFlex xsItemsCenter"
-                            style={
-                              Object {
-                                "minHeight": 44,
-                                "paddingInlineEnd": "16px",
-                                "paddingInlineStart": "68px",
-                                "width": undefined,
-                              }
-                            }
-                          >
-                            <div
-                              className="Flex rowGap2 columnGap0 xsDirectionRow"
-                              style={
-                                Object {
-                                  "height": "100%",
-                                  "width": "100%",
-                                }
-                              }
-                            >
-                              <div
-                                className="FlexItem flexGrow selfCenter"
-                              >
-                                <span
-                                  className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                                >
-                                  East Coast
-                                </span>
-                              </div>
-                            </div>
-                          </div>
-                        </a>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </nav>
-</div>
-`;
-
-exports[`SideNavigation renders static group 1`] = `
-<div
-  className="box overflowAuto paddingX0 paddingY0 relative"
-  style={
-    Object {
-      "height": "100%",
-      "width": undefined,
-    }
-  }
->
-  <nav
-    aria-label="Static items example"
-    className="box default relative"
-    style={
-      Object {
-        "height": "100%",
-        "minWidth": 280,
-        "width": undefined,
-      }
-    }
-  >
-    <div
-      className="fullHeight borderBox"
-      style={
-        Object {
-          "width": undefined,
-        }
-      }
-    >
-      <div
-        className="box paddingX2 paddingY2"
-        style={
-          Object {
-            "paddingBottom": 24,
-            "width": undefined,
-          }
-        }
-      >
-        <div
-          className="Flex rowGap0 columnGap4 xsDirectionColumn"
-        >
-          <div
-            className="FlexItem"
-          >
-            <ul
-              className="ulItem"
-            >
-              <li
-                className="liItem"
-              >
-                <div
-                  className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
-                  style={
-                    Object {
-                      "height": undefined,
-                      "minHeight": 44,
-                      "paddingInlineEnd": "var(--space-400)",
-                      "paddingInlineStart": "var(--space-400)",
-                      "width": undefined,
-                    }
-                  }
-                >
-                  <div
-                    className="Flex rowGap2 columnGap0 xsDirectionRow"
-                    style={
-                      Object {
-                        "height": "100%",
-                        "width": "100%",
-                      }
-                    }
-                  >
-                    <div
-                      className="FlexItem selfCenter"
-                    >
-                      <div
-                        aria-hidden={true}
-                        className="box"
-                      >
-                        <svg
-                          aria-hidden={true}
-                          aria-label=""
-                          className="default icon"
-                          height={20}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={20}
-                        >
-                          <path
-                            d="test-file-stub"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div
-                      className="FlexItem flexGrow selfCenter"
-                    >
-                      <span
-                        className="Text fontSize300 default alignStart breakWord fontWeightNormal"
-                      >
-                        Christmas
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </li>
-            </ul>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Summary

When SideNavigation content overflowed, the scrollbar was appearing on top of the items. Because the wrapper responsible for scrolling had a static width. I separated the wrapper into 2:
- 1st one is responsible for scrolling
- 2nd is for preserving the width

This way the scrolling wrapper doesn't take up the space preserved only for SideNavigation content.

However, it was not enough. Now that the outermost wrapper has a dynamic width, when SideNavigation is expanded AS OVERLAY, it pushed the page content like it does in expanded state (which it shouldn't).

That's why, with the power of JavaScript, the "calculated" width (by browser) of the SidaNavigation is recorded just before it is exapanded as overlay. Then it is set as a static width to it, so that 
1. Sidenavigation doesn't push the page content when expanded as overlay
2. the inner wrapper can overflow it and appear as overlay

**BEFORE**

https://github.com/pinterest/gestalt/assets/29589560/129be8e2-2c80-4e37-a1ff-953109f98445

**AFTER**

https://github.com/pinterest/gestalt/assets/29589560/852a89b9-0b95-4140-ad0a-02456ad7fc65

### Links

- [Jira](https://jira.pinadmin.com/browse/GWEB-89)
- [TDD](link to Paper doc)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
