### PR TITLE
OverlayPanel: Use ConfirmationPopover v2 #3501

### DIFF
--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -13,10 +13,6 @@ const enabledExperiments = {
   ComboBox: ['web_gestalt_popover_v2_combobox', 'mweb_gestalt_popover_v2_combobox'],
   Dropdown: ['web_gestalt_popover_v2_dropdown', 'mweb_gestalt_popover_v2_dropdown'],
   HelpButton: ['web_gestalt_popover_v2_helpbutton', 'mweb_gestalt_popover_v2_helpbutton'],
-  OverlayPanel: [
-    'web_gestalt_popover_v2_confirmationpopover',
-    'mweb_gestalt_popover_v2_confirmationpopover',
-  ],
   Popover: ['web_gestalt_popover_v2', 'mweb_gestalt_popover_v2'],
   PopoverEducational: [
     'web_gestalt_popover_v2_popovereducational',

--- a/docs/pages/web/overlaypanel.js
+++ b/docs/pages/web/overlaypanel.js
@@ -2,7 +2,6 @@
 import { type Node as ReactNode } from 'react';
 import { BannerSlim, Link, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { BannerSlimExperiment } from '../../docs-components/BannerSlimExperiment';
 import { type DocGen, multipleDocGen } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
@@ -31,13 +30,6 @@ export default function SheetPage({
   return (
     <Page title={generatedDocGen?.OverlayPanel.displayName}>
       <PageHeader
-        bannerSlimExperiment={
-          <BannerSlimExperiment
-            componentName="OverlayPanel"
-            description="fix and improve underlying Popover component behavior. No visual updates"
-            pullRequest={3244}
-          />
-        }
         description={generatedDocGen?.OverlayPanel.description}
         name={generatedDocGen?.OverlayPanel.displayName}
       >

--- a/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
+++ b/packages/gestalt/src/OverlayPanel/ConfirmationPopover.js
@@ -8,9 +8,8 @@ import Button from '../Button';
 import { useDefaultLabelContext } from '../contexts/DefaultLabelProvider';
 import Flex from '../Flex';
 import { ESCAPE } from '../keyCodes';
-import Popover from '../Popover';
+import InternalPopover from '../Popover/InternalPopover';
 import Text from '../Text';
-import useInExperiment from '../useInExperiment';
 
 type Props = {
   anchor: ?HTMLElement,
@@ -78,20 +77,17 @@ export default function ConfirmationPopover({
     };
   }, []);
 
-  const isInExperiment = useInExperiment({
-    webExperimentName: 'web_gestalt_popover_v2_confirmationpopover',
-    mwebExperimentName: 'mweb_gestalt_popover_v2_confirmationpopover',
-  });
-
   return (
-    <Popover
-      __experimentalPopover={isInExperiment}
+    <InternalPopover
+      accessibilityLabel="Popover"
       anchor={anchor}
+      color="white"
       disablePortal
       idealDirection="down"
       onDismiss={() => onDismiss()}
-      positionRelativeToAnchor
       role="dialog"
+      shouldFocus
+      showCaret={false}
       size="md"
     >
       <TrapFocusBehavior>
@@ -131,6 +127,6 @@ export default function ConfirmationPopover({
           </Flex>
         </Box>
       </TrapFocusBehavior>
-    </Popover>
+    </InternalPopover>
   );
 }

--- a/packages/gestalt/src/__snapshots__/OverlayPanel.jsdom.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/OverlayPanel.jsdom.test.js.snap
@@ -9,12 +9,14 @@ exports[`OverlayPanel renders OverlayPanel with confirmation modal 1`] = `
       class="container"
     >
       <div
+        aria-hidden="true"
         class="backdrop zoomOut"
+        data-floating-ui-inert=""
       />
       <div
         aria-label="Test OverlayPanel"
         class="wrapper hideOutline"
-        id=":rf:"
+        id=":ri:"
         role="dialog"
         style="width: 540px;"
         tabindex="-1"
@@ -24,14 +26,16 @@ exports[`OverlayPanel renders OverlayPanel with confirmation modal 1`] = `
           style="width: 100%;"
         >
           <div
+            aria-hidden="true"
             class="box flexGrow justifyEnd marginBottom8 xsDisplayFlex"
+            data-floating-ui-inert=""
           >
             <div
               class="absolute box flexNone paddingX6 paddingY7"
               style="z-index: 1;"
             >
               <button
-                aria-controls=":rf:"
+                aria-controls=":ri:"
                 aria-label="Dismiss"
                 class="parentButton"
                 type="button"
@@ -62,7 +66,9 @@ exports[`OverlayPanel renders OverlayPanel with confirmation modal 1`] = `
             </div>
           </div>
           <div
+            aria-hidden="true"
             class="box flexGrow paddingX0 paddingY0 relative xsDirectionColumn xsDisplayFlex"
+            data-floating-ui-inert=""
             style="height: 100%; width: 100%;"
           >
             <div
@@ -73,16 +79,25 @@ exports[`OverlayPanel renders OverlayPanel with confirmation modal 1`] = `
             </div>
           </div>
           <div>
+            <span
+              aria-hidden="true"
+              data-floating-ui-focus-guard=""
+              data-floating-ui-inert=""
+              data-type="inside"
+              role="button"
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
+              tabindex="0"
+            />
             <div
               class="container rounding4 contents maxDimensions minDimensions"
-              style="visibility: visible; top: 8px; left: -10px;"
+              style="position: absolute; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
               tabindex="-1"
             >
               <div
                 aria-label="Popover"
                 class="border rounding4 innerContents maxDimensions minDimensions primary"
                 role="dialog"
-                style="max-width: 284px; max-height: 691.1999999999999px;"
+                style="max-width: 284px;"
               >
                 <div
                   name="trap-focus"
@@ -179,6 +194,15 @@ exports[`OverlayPanel renders OverlayPanel with confirmation modal 1`] = `
                 </div>
               </div>
             </div>
+            <span
+              aria-hidden="true"
+              data-floating-ui-focus-guard=""
+              data-floating-ui-inert=""
+              data-type="inside"
+              role="button"
+              style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: fixed; white-space: nowrap; width: 1px; top: 0px; left: 0px;"
+              tabindex="0"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Summary

Removed all the experiment related code from ConfirmationPopover of OverlayPanel.

![Brave Browser - OverlayPanel - Gestalt 2024-04-02 at 4 31 18 PM](https://github.com/pinterest/gestalt/assets/10593890/5d223191-d592-4c3e-981d-adeccfbafe89)

### Links

- [Jira](https://jira.pinadmin.com/browse/GWEB-67)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
