### PR TITLE
Docs: update design contributions image

### DIFF
--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -5,7 +5,7 @@ description: A design contribution is any design proposal that's completed and a
 fullwidth: true
 ---
 
-<ImgContainer noPadding color="background-default" src="[https://www.pinterest-assets.com/AssetLink/827rbd1qx67v7dw578m4a103058ufw61/process-slack-png.png](https://www.pinterest-assets.com/AssetLink/ecc4b1k0a1tw7wuaj7ch5ty21c01j4m8/updated-hero-png.png)" alt="Screenshot of the Slack interface with the link to the contribution form circled in red."/>
+<ImgContainer noPadding color="background-default" src="[https://www.pinterest-assets.com/AssetLink/827rbd1qx67v7dw578m4a103058ufw61/process-slack-png.png]([https://www.pinterest-assets.com/AssetLink/ecc4b1k0a1tw7wuaj7ch5ty21c01j4m8/updated-hero-png.png](https://www.pinterest-assets.com/AssetLink/xp1o28h7ds7al708l06t13q76m2ruo85/updated-hero-png.png))" alt="Illustration of a gift box of UI components being sent to Slack, followed by Figma, followed by two puzzle-pieces smiling and connected under a disco ball."/>
 <br/>
 
 **Note: Design contributions can only be made by Pinterest employees at the moment.**

--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -5,7 +5,7 @@ description: A design contribution is any design proposal that's completed and a
 fullwidth: true
 ---
 
-<ImgContainer noPadding color="background-default" src="https://www.pinterest-assets.com/AssetLink/827rbd1qx67v7dw578m4a103058ufw61/process-slack-png.png" alt="Screenshot of the Slack interface with the link to the contribution form circled in red."/>
+<ImgContainer noPadding color="background-default" src="[https://www.pinterest-assets.com/AssetLink/827rbd1qx67v7dw578m4a103058ufw61/process-slack-png.png](https://www.pinterest-assets.com/AssetLink/ecc4b1k0a1tw7wuaj7ch5ty21c01j4m8/updated-hero-png.png)" alt="Screenshot of the Slack interface with the link to the contribution form circled in red."/>
 <br/>
 
 **Note: Design contributions can only be made by Pinterest employees at the moment.**


### PR DESCRIPTION
Updated Contributions overview image.


#### What changed?
![Uploading image.png…]()


At a high level, what changes does this PR introduce?

#### Why?

Needed a nicer image to introdcue contributions



### Checklist

- [x] Added unit and Flow Tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
