### PR TITLE
Docs: Update contributions image

### DIFF
--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -31,4 +31,3 @@ Are you the type of person who wants all of the details? Then head over to:
 - [Contribution types and criteria](team_support/design_contributions/contribution_levels_and_criteria)
 - [Process deep dive](team_support/design_contributions/process_deep_dive)
 - [Process flow visualizations](team_support/design_contributions/process_diagrams)
-

--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -5,7 +5,7 @@ description: A design contribution is any design proposal that's completed and a
 fullwidth: true
 ---
 
-<ImgContainer noPadding color="background-default" src="https://www.pinterest-assets.com/AssetLink/827rbd1qx67v7dw578m4a103058ufw61/process-slack-png.png" alt="Screenshot of the Slack interface with the link to the contribution form circled in red."/>
+<ImgContainer noPadding color="background-default" src="https://www.pinterest-assets.com/AssetLink/xp1o28h7ds7al708l06t13q76m2ruo85/updated-hero-png.png" alt="Screenshot of the Slack interface with the link to the contribution form circled in red."/>
 <br/>
 
 **Note: Design contributions can only be made by Pinterest employees at the moment.**

--- a/playwright/accessibility/team_support__design_contributions__process_deep_dive.spec.mjs
+++ b/playwright/accessibility/team_support__design_contributions__process_deep_dive.spec.mjs
@@ -4,7 +4,7 @@ import expectAccessiblePage from './expectAccessiblePage.mjs';
 
 test('Design handoff Accessibility check', async ({ page }) => {
   await page.goto(
-    '/team_support/design_contributions/design_process_deep_dive'
+    '/team_support/design_contributions/process_deep_dive'
   );
   await expectAccessiblePage({ page });
 });

--- a/playwright/accessibility/team_support__design_contributions__process_deep_dive.spec.mjs
+++ b/playwright/accessibility/team_support__design_contributions__process_deep_dive.spec.mjs
@@ -3,8 +3,6 @@ import { test } from '@playwright/test';
 import expectAccessiblePage from './expectAccessiblePage.mjs';
 
 test('Design handoff Accessibility check', async ({ page }) => {
-  await page.goto(
-    '/team_support/design_contributions/process_deep_dive'
-  );
+  await page.goto('/team_support/design_contributions/process_deep_dive');
   await expectAccessiblePage({ page });
 });


### PR DESCRIPTION
### Summary
Added a new overview image.

#### What changed?

New image.
<img width="950" alt="image" src="https://github.com/pinterest/gestalt/assets/96082362/7e7ba00b-4193-4667-a360-14e119ca90f2">


#### Why?

To make the new page more exciting, less drab with just a screenshot of Slack.

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
