### PR TITLE
Docs: Contributions

### DIFF
--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -15,7 +15,7 @@ fullwidth: true
 ### One step to contribute
 
 - One step to get started: **[complete the intake form](http://pinch.pinadmin.com/design-contribution-form)**
-- All you need is a Figma link for your design—your contribution doesn't need to be finalized or componentized. You’ll have a chance to answer “how done is this design” when submitting. For further tips on getting your design closer to completion, go to [Contribution levels and criteria](team_support/design_contributions/contribution_levels_and_criteria)
+- All you need is a Figma link for your design—your contribution doesn't need to be finalized or componentized. You’ll have a chance to answer “how done is this design” when submitting. For further tips on getting your design closer to completion, go to [Contribution types and criteria](team_support/design_contributions/contribution_types_and_criteria)
 <br/>
 
 ### What happens next?
@@ -28,6 +28,6 @@ fullwidth: true
 
 ## Contribution deep dive
 Are you the type of person who wants all of the details? Then head over to:
-- [Contribution types and criteria](team_support/design_contributions/contribution_levels_and_criteria)
+- [Contribution types and criteria](team_support/design_contributions/contribution_types_and_criteria)
 - [Process deep dive](team_support/design_contributions/process_deep_dive)
 - [Process flow visualizations](team_support/design_contributions/process_diagrams)

--- a/docs/markdown/team_support/design_contributions/process_deep_dive.md
+++ b/docs/markdown/team_support/design_contributions/process_deep_dive.md
@@ -7,7 +7,7 @@ fullwidth: true
 <ImgContainer noPadding color="background-default" src="https://www.pinterest-assets.com/AssetLink/832itu8mf6vv12u8ahol4ef8oht84776/process-main-png.png" alt="Diagram of the contribution process flow from design to submit to review to approval to publish in Figma."/>
 
 ## Before submitting a contribution
-- To speed up the process, review our [validation guidance](team_support/design_contributions/about_design_contributions#Types_of_valid_component_contributions).
+- To speed up the process, review our [validation guidance](team_support/design_contributions/contribution_types_and_criteria#Types-of-valid-component-contributions).
 - If you need help organizing your contribution, go to our [Figma contribution templates](http://pinch.pinadmin.com/contribution-templates).
 
 ## Submit via Slack


### PR DESCRIPTION
### Summary
Fixed broken urls

#### What changed?

URL to Contribution types and criteria on the overview page. URL to the same on the Process deep dive page.

#### Why?

URLs were wrong and leading to 404 pages.
