### PR TITLE
PageHeader: update heading to BreakAll to split on long titles

### DIFF
--- a/packages/gestalt/src/PageHeader/components.js
+++ b/packages/gestalt/src/PageHeader/components.js
@@ -29,7 +29,7 @@ export function PageHeaderTitle({
   return (
     <Fragment>
       <Box display="block" smDisplay="none">
-        <Heading accessibilityLevel={1} lineClamp={1} size="400">
+        <Heading accessibilityLevel={1} lineClamp={1} overflow="breakAll" size="400">
           {title}
         </Heading>
       </Box>
@@ -40,7 +40,7 @@ export function PageHeaderTitle({
         display="none"
         smDisplay="block"
       >
-        <Heading accessibilityLevel={1} lineClamp={1} size="500">
+        <Heading accessibilityLevel={1} lineClamp={1} overflow="breakAll" size="500">
           {title}
         </Heading>
       </Box>

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.js.snap
@@ -58,7 +58,7 @@ exports[`PageHeader renders 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -73,7 +73,7 @@ exports[`PageHeader renders 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -179,7 +179,7 @@ exports[`PageHeader renders badge with type 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -194,7 +194,7 @@ exports[`PageHeader renders badge with type 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -327,7 +327,7 @@ exports[`PageHeader renders primary action 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -342,7 +342,7 @@ exports[`PageHeader renders primary action 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -550,7 +550,7 @@ exports[`PageHeader renders secondary action 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -565,7 +565,7 @@ exports[`PageHeader renders secondary action 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -804,7 +804,7 @@ exports[`PageHeader renders subtext 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -819,7 +819,7 @@ exports[`PageHeader renders subtext 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -938,7 +938,7 @@ exports[`PageHeader renders within a max width 1`] = `
                         className="box smDisplayNone xsDisplayBlock"
                       >
                         <h1
-                          className="Heading fontSize400 default alignStart breakWord lineClamp"
+                          className="Heading fontSize400 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,
@@ -953,7 +953,7 @@ exports[`PageHeader renders within a max width 1`] = `
                         className="box smDisplayBlock xsDisplayNone"
                       >
                         <h1
-                          className="Heading fontSize500 default alignStart breakWord lineClamp"
+                          className="Heading fontSize500 default alignStart breakAll lineClamp"
                           style={
                             Object {
                               "WebkitLineClamp": 1,


### PR DESCRIPTION
# Pull Request Instructions

Moving to `BreakAll` for PageHeader title to solve this [issue](https://pinterest.slack.com/archives/C13KLG5P0/p1710181944469399) 


BEFORE 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/417807c2-0633-4bb5-82cd-86def06bf2d5)

AFTER

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/b87e957f-8ad0-4acd-9d19-042a4469b750)


To test use 

`        title="Pinterest_app_Pinterest _app_Pinterest_app_Pinterest_app_Pinterest_app_Pinterest_app_Pinterest_app_Pinterest_app_Pinterest_app_Pinterest_app"
`

## Pull Request Template

### Summary

#### What changed?

This fixes text wrapping on really long titles.

#### Why?


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-7698)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
