### PR TITLE
Revert "ComboBox: Use Popover v2"

### DIFF
--- a/docs/docs-components/contexts/DocsExperimentProvider.js
+++ b/docs/docs-components/contexts/DocsExperimentProvider.js
@@ -10,6 +10,7 @@ import { useAppContext } from '../appContext';
  * */
 
 const enabledExperiments = {
+  ComboBox: ['web_gestalt_popover_v2_combobox', 'mweb_gestalt_popover_v2_combobox'],
   Dropdown: ['web_gestalt_popover_v2_dropdown', 'mweb_gestalt_popover_v2_dropdown'],
   Popover: ['web_gestalt_popover_v2', 'mweb_gestalt_popover_v2'],
   Tooltip: ['web_gestalt_tooltip_v2', 'mweb_gestalt_tooltip_v2'],

--- a/docs/pages/web/combobox.js
+++ b/docs/pages/web/combobox.js
@@ -1,6 +1,7 @@
 // @flow strict
 import { type Node as ReactNode } from 'react';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
+import { BannerSlimExperiment } from '../../docs-components/BannerSlimExperiment';
 import docGen, { type DocGen } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
@@ -27,7 +28,17 @@ const PREVIEW_HEIGHT = 320;
 export default function ComboBoxPage({ generatedDocGen }: { generatedDocGen: DocGen }): ReactNode {
   return (
     <Page title={generatedDocGen?.displayName}>
-      <PageHeader description={generatedDocGen?.description} name={generatedDocGen?.displayName}>
+      <PageHeader
+        bannerSlimExperiment={
+          <BannerSlimExperiment
+            componentName="ComboBox"
+            description="fix and improve underlying Popover component behavior. No visual updates"
+            pullRequest={3244}
+          />
+        }
+        description={generatedDocGen?.description}
+        name={generatedDocGen?.displayName}
+      >
         <SandpackExample
           code={main}
           hideEditor

--- a/packages/gestalt/src/ComboBox.js
+++ b/packages/gestalt/src/ComboBox.js
@@ -19,11 +19,12 @@ import ComboBoxItem, { type ComboBoxItemType } from './ComboBox/Item';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
 import { DOWN_ARROW, ENTER, ESCAPE, TAB, UP_ARROW } from './keyCodes';
 import Layer from './Layer';
-import InternalPopover from './Popover/InternalPopover';
+import Popover from './Popover';
 import Tag from './Tag';
 import Text from './Text';
 import InternalTextField from './TextField/InternalTextField';
 import InternalTextFieldIconButton from './TextField/InternalTextFieldIconButton';
+import useInExperiment from './useInExperiment';
 import handleContainerScrolling, {
   type DirectionOptionType,
   KEYS,
@@ -432,6 +433,11 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
     ],
   );
 
+  const isInExperiment = useInExperiment({
+    webExperimentName: 'web_gestalt_popover_v2_combobox',
+    mwebExperimentName: 'mweb_gestalt_popover_v2_combobox',
+  });
+
   return (
     <Fragment>
       <Box
@@ -497,15 +503,15 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
       </Box>
       {showOptionsList && innerRef.current ? (
         <Layer zIndex={zIndex}>
-          <InternalPopover
+          <Popover
+            key={isInExperiment ? undefined : suggestedOptions.length}
+            __experimentalPopover={isInExperiment}
             anchor={innerRef.current}
-            color="white"
             disablePortal
-            hideWhenReferenceHidden
             idealDirection="down"
             onDismiss={handleOnDismiss}
             onKeyDown={handleKeyDown}
-            role="dialog"
+            positionRelativeToAnchor={false}
             shouldFocus={false}
             size="flexible"
           >
@@ -534,7 +540,7 @@ const ComboBoxWithForwardRef: AbstractComponent<Props, HTMLInputElement> = forwa
                 </Box>
               )}
             </Box>
-          </InternalPopover>
+          </Popover>
         </Layer>
       ) : null}
     </Fragment>


### PR DESCRIPTION
Reverts pinterest/gestalt#3512

Reverting to unblock newer bumps as the v2 release caused some test to fail in Pinboard (which will take a while to fix).