### PR TITLE
Masonry: Fix incorrect node to solve graph positioning for two column items

### DIFF
--- a/packages/gestalt/src/Masonry/Graph.js
+++ b/packages/gestalt/src/Masonry/Graph.js
@@ -85,12 +85,12 @@ export default class Graph<T> implements GraphInterface<T> {
       }
       const scores = edges.map((edge) => edge.score);
       const minScore = Math.min(...scores);
-      if (lowestScore === null || minScore < lowestScore) {
-        lowestScore = minScore;
-        lowestScoreNode = node.data;
-      }
 
       edges.forEach((edge) => {
+        if (edge.score === minScore && (lowestScore === null || minScore < lowestScore)) {
+          lowestScore = minScore;
+          lowestScoreNode = edge.node.data;
+        }
         findLowestScoreRecursive(edge.node);
       });
     }

--- a/packages/gestalt/src/Masonry/Graph.js
+++ b/packages/gestalt/src/Masonry/Graph.js
@@ -78,22 +78,16 @@ export default class Graph<T> implements GraphInterface<T> {
     let lowestScore = null;
     let lowestScoreNode = startNode;
 
-    function findLowestScoreRecursive(node: GraphNodeInterface<T>): void {
-      const edges = node.getEdges();
-      if (edges.length === 0) {
-        return;
-      }
-      const scores = edges.map((edge) => edge.score);
-      const minScore = Math.min(...scores);
-
-      edges.forEach((edge) => {
-        if (edge.score === minScore && (lowestScore === null || minScore < lowestScore)) {
-          lowestScore = minScore;
-          lowestScoreNode = edge.node.data;
+    const findLowestScoreRecursive = (node: GraphNodeInterface<T>) => {
+      node.getEdges().forEach((edge) => {
+        const { score, node: edgeNode } = edge;
+        if (lowestScore === null || score < lowestScore) {
+          lowestScore = score;
+          lowestScoreNode = edgeNode.data;
         }
-        findLowestScoreRecursive(edge.node);
+        findLowestScoreRecursive(edgeNode);
       });
-    }
+    };
 
     const startGraphNode = this.nodes.get(startNode);
     if (startGraphNode) {

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -256,24 +256,29 @@ describe('two column layout test cases', () => {
       measurementStore.set(item, item.height);
     });
     const updatedItems = items.concat(newItems);
-    const positions = layout(updatedItems);
+
+    // perform positioning of batch with two column item
+    layout(updatedItems);
+
+    const positions = updatedItems.map((item) => positionCache.get(item));
     expect(positions.length).toEqual(updatedItems.length);
     expect(positions).toEqual([
-      { 'height': 210, 'left': 607, 'top': 436, 'width': 240 },
-      { 'height': 212, 'left': 861, 'top': 438, 'width': 240 },
-      { 'height': 214, 'left': 99, 'top': 654, 'width': 240 },
-      { 'height': 213, 'left': 353, 'top': 660, 'width': 494 },
-      { 'height': 200, 'left': 99, 'top': 0, 'width': 240 },
-      { 'height': 201, 'left': 353, 'top': 0, 'width': 240 },
-      { 'height': 202, 'left': 607, 'top': 0, 'width': 240 },
-      { 'height': 203, 'left': 861, 'top': 0, 'width': 240 },
-      { 'height': 204, 'left': 99, 'top': 214, 'width': 240 },
-      { 'height': 205, 'left': 353, 'top': 215, 'width': 240 },
-      { 'height': 206, 'left': 607, 'top': 216, 'width': 240 },
-      { 'height': 207, 'left': 861, 'top': 217, 'width': 240 },
-      { 'height': 208, 'left': 99, 'top': 432, 'width': 240 },
-      { 'height': 209, 'left': 353, 'top': 434, 'width': 240 },
-      { 'height': 211, 'left': 861, 'top': 664, 'width': 240 },
+      { 'top': 0, 'left': 99, 'width': 240, 'height': 200 },
+      { 'top': 0, 'left': 353, 'width': 240, 'height': 201 },
+      { 'top': 0, 'left': 607, 'width': 240, 'height': 202 },
+      { 'top': 0, 'left': 861, 'width': 240, 'height': 203 },
+      { 'top': 214, 'left': 99, 'width': 240, 'height': 204 },
+      { 'top': 215, 'left': 353, 'width': 240, 'height': 205 },
+      { 'top': 216, 'left': 607, 'width': 240, 'height': 206 },
+      { 'top': 217, 'left': 861, 'width': 240, 'height': 207 },
+      { 'top': 432, 'left': 99, 'width': 240, 'height': 208 },
+      { 'top': 434, 'left': 353, 'width': 240, 'height': 209 },
+      { 'top': 436, 'left': 607, 'width': 240, 'height': 210 },
+      { 'top': 657, 'left': 353, 'width': 240, 'height': 211 },
+      { 'top': 438, 'left': 861, 'width': 240, 'height': 212 },
+      // Position of two col item
+      { 'top': 882, 'left': 99, 'width': 494, 'height': 213 },
+      { 'top': 654, 'left': 99, 'width': 240, 'height': 214 },
     ]);
   });
 


### PR DESCRIPTION
### Summary

Currently to determine the optimal position of a two column item we create a graph that stores a certain combination of one column items and the whitespace that it has, we saw that in fact this was not the case because sometimes the two column item was positioned on very strange places.

The problem was that on the graph the node that was being returned as winner was not the one with the lowest whitespace but the parent of that node. This pr fixes that going through all the edges to find the lowest score and return the edge node, not the current node.

#### Tests

With this change I found one test that didn't have an optimal solution, the whitespace on the previous test was 3px, while with this fix the whitespace is in fact 0px.

Before fix

<img width="1055" alt="Screenshot 2024-04-08 at 5 36 56 p m" src="https://github.com/pinterest/gestalt/assets/700818/3e67d7d3-e277-41d7-ae35-c7a438bec0a3">

After fix

<img width="906" alt="Screenshot 2024-04-08 at 5 44 22 p m" src="https://github.com/pinterest/gestalt/assets/700818/9886fc5d-4861-4f08-82dc-0492f2097cef">


