### PR TITLE
Masonry: Update useElementWidth for MasonryV2

### DIFF
--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -569,7 +569,7 @@ function Masonry<T: { +[string]: mixed }>(
 
   const gridBody =
     isServerRenderOrHydration || canPerformFullLayout
-      ? items.map((item, i) => {
+      ? items.filter(Boolean).map((item, i) => {
           const key = `item-${i}`;
           const position = canPerformFullLayout
             ? positions[i]

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -13,6 +13,7 @@ import {
   useSyncExternalStore,
   useTransition,
 } from 'react';
+import debounce from './debounce';
 import styles from './Masonry.css';
 import { type Cache } from './Masonry/Cache';
 import { TWO_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/defaultTwoColumnModuleLayout';
@@ -22,6 +23,8 @@ import MeasurementStore from './Masonry/MeasurementStore';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
 import { type Layout, type Position } from './Masonry/types';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
+
+const RESIZE_DEBOUNCE = 300;
 
 const layoutNumberToCssDimension = (n: ?number) => (n !== Infinity ? n : undefined);
 
@@ -138,26 +141,45 @@ function createMeasurementStore<T1: { ... }, T2>(): MeasurementStore<T1, T2> {
   return new MeasurementStore();
 }
 
-function subscribeToResizeEvent(callback: () => void) {
-  window.addEventListener('resize', callback);
-  return () => {
-    window.removeEventListener('resize', callback);
-  };
-}
-
 // helper hook to force update a component
 function useForceUpdate() {
   const [, forceUpdate] = useReducer<number, void>((x) => x + 1, 0);
   return forceUpdate;
 }
 
+// useElementWidth returns the width of the gridWrapper element
+// and uses useSyncExternalStore to subscribe to window resize events
 function useElementWidth(element: ?HTMLDivElement) {
-  const getElementWidth = useCallback(() => {
-    const elWidth = element?.clientWidth;
-    return elWidth;
-  }, [element]);
+  const prevElementRef = useRef<?HTMLDivElement>(null);
+  const elementWidthRef = useRef<?number>(null);
 
-  const width = useSyncExternalStore(subscribeToResizeEvent, getElementWidth, () => null);
+  // update elementWidthRef whenever element changes
+  if (element && element !== prevElementRef.current) {
+    elementWidthRef.current = element.clientWidth;
+    prevElementRef.current = element;
+  }
+
+  const subscribeToResizeEvent = useCallback(
+    (callback: () => void) => {
+      const handler = debounce(() => {
+        // update elementWidthRef whenever we have a resize event
+        elementWidthRef.current = element?.clientWidth;
+        callback();
+      }, RESIZE_DEBOUNCE);
+      window.addEventListener('resize', handler);
+      return () => {
+        window.removeEventListener('resize', handler);
+      };
+    },
+    [element],
+  );
+
+  const width = useSyncExternalStore(
+    subscribeToResizeEvent,
+    () => elementWidthRef.current,
+    () => null,
+  );
+
   return width;
 }
 
@@ -547,7 +569,7 @@ function Masonry<T: { +[string]: mixed }>(
 
   const gridBody =
     isServerRenderOrHydration || canPerformFullLayout
-      ? items.filter(Boolean).map((item, i) => {
+      ? items.map((item, i) => {
           const key = `item-${i}`;
           const position = canPerformFullLayout
             ? positions[i]


### PR DESCRIPTION

### Summary

#### What changed?

This PR address two issues I noticed with `MasonryV2` while doing some more testing webapp:
1) resize was not being debounced which caused a very jarring user experience while resizing the browser
This is addressed by ensuring that we debounce the callback to the resize event listener

2) useElementWidth was calling element.clientWidth every render which was causing unnecessary layout
I noticed while doing some more profiling that useElementWidth was calling `element.clientWidth` unnecessarily, every render. This is because the `getSnapshot` function of useSyncExternalStore is always called during render. 

To address this (and handle the resize debounce), I made the following changes to `useElementWidth`:
- Store element width in a ref and use this as the source of truth (i.e. what gets returned via getSnapshot)
- When the (debounced) resize event is fired, update the ref with the current element width
- If we detect a change in element (this should never happen but handling anyways), then update the ref accordingly
