### PR TITLE
Accordion: Fix size type inconsistency with the Accordion component

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1441,7 +1441,7 @@ interface AccordionProps {
   icon?: Icons | undefined;
   iconAccessibilityLabel?: string | undefined;
   iconButton?: React.ReactElement<typeof IconButton> | undefined;
-  size: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg';
   title?: string | undefined;
   type?: 'error' | 'info' | undefined;
 }


### PR DESCRIPTION
## Summary

The Accordion component [size type props](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Accordion.js#L54) and [its default behavior](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/Accordion.js#L80) indicates the prop is an optional prop, but the `dist/index.d.ts` file has it defined as mandatory causing an inconsistency.

The following PR change fixes it

## Checklist
- [ ]  Added unit and Flow Tests
- [ ]  Added documentation + accessibility tests
- [ ]  Verified accessibility: keyboard & screen reader interaction
- [ ]  Checked dark mode, responsiveness, and right-to-left support
- [ ]  Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
