### PR TITLE
Masonry: Implement graph early bailout feature

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -388,6 +388,55 @@ describe('two column layout test cases', () => {
     });
   });
 
+  test('bails out graph when whitespace threshold is found', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+
+    // Placing the first one col item after first line we have a whitespace of 10
+    // so we break early although the next combination has 0 whitespace
+    const items = [
+      { 'name': 'Pin 0', 'height': 300, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 150, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 350, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 140, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 200, 'color': '#CF4509', columnSpan: 2 },
+      { 'name': 'Pin 5', 'height': 200, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 150, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 207, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 209, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 200, 'color': '#F45098' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1000,
+      gutter: 0,
+      whitespaceThreshold: 11,
+    });
+
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(items);
+
+    expect(positionCache.get(items[4])).toEqual({
+      height: 200,
+      left: 500,
+      top: 350,
+      width: 480,
+    });
+  });
+
   test('correctly position two column item when initial heights are 0', () => {
     const measurementStore = new MeasurementStore<{ ... }, number>();
     const positionCache = new MeasurementStore<{ ... }, Position>();


### PR DESCRIPTION
### Summary

Tho determine the best position for the two column item the current behavior creates all the possible combinations of items on the graphBatch and then looks for the one with the minimum whitespace, although this works is very inneficient since we could have a good enough answer. To improve it this PR implements a new feature to exit early the algorithm when a certain whitespace threshold is found. 

#### Tests

Manual tests showed a really awesome improvement using a threshold of gutter*2 px, reducing the number of iterationr from 326 to ~4* (limited manual tests)

Unit test added

#### Notes

- To enable this a `whitespaceThreshold` must be set, but this PR doesn't set one, that would be on another pr to determine the best threshold
- The future of this feature is very related to the implementation of a dynamic batch size and used together to create a better positioning
- The process to track metrics with the improvements will come on a future PR


