### PR TITLE
SideNavigation: add type fixes based on component prop definition

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1846,6 +1846,9 @@ interface SideNavigationProps {
   header?: Node | undefined;
   showBorder?: boolean | undefined;
   mobileTitle?: string | undefined;
+  collapsed?: boolean;
+  onCollapse?: (isCollapsed: boolean) => void;
+  onPreview?: (isOnPreview: boolean) => void;
 }
 
 interface SideNavigationSectionProps {


### PR DESCRIPTION
## Summary

The [SideNavigation props](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/dist/index.d.ts#L1841) in the index.d.ts file has missing types that are declared in the [component](https://github.com/pinterest/gestalt/blob/master/packages/gestalt/src/SideNavigation.js#L47) causing inconsistency

The missing props are:
 - collapsed
 - onCollapse
 - onPreview

The following PR change fixes it

## Checklist
- [ ]  Added unit and Flow Tests
- [ ]  Added documentation + accessibility tests
- [ ]  Verified accessibility: keyboard & screen reader interaction
- [ ]  Checked dark mode, responsiveness, and right-to-left support
- [ ]  Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)

