### PR TITLE
Masonry: Enable n-column modules on first row

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -6,7 +6,7 @@ import styles from './Masonry.css';
 import { type Cache } from './Masonry/Cache';
 import defaultLayout from './Masonry/defaultLayout';
 import defaultTwoColumnModuleLayout, {
-  TWO_COL_ITEMS_MEASURE_BATCH_SIZE,
+  MULTI_COL_ITEMS_MEASURE_BATCH_SIZE,
 } from './Masonry/defaultTwoColumnModuleLayout';
 import fullWidthLayout from './Masonry/fullWidthLayout';
 import HeightsStore, { type HeightsStoreInterface } from './Masonry/HeightsStore';
@@ -576,13 +576,16 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       // Full layout is possible
       const itemsToRender = items.filter((item) => item && measurementStore.has(item));
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
-      const hasTwoColumnItems =
-        _twoColItems && itemsWithoutPositions.some((item) => item.columnSpan === 2);
+      const hasMultiColumnItems =
+        _twoColItems &&
+        itemsWithoutPositions.some(
+          (item) => typeof item.columnSpan === 'number' && item.columnSpan > 2,
+        );
 
       // If there are 2-col items, we need to measure more items to ensure we have enough possible layouts to find a suitable one
       // we need the batch size (number of one column items for the graph) + 1 (two column item)
-      const itemsToMeasureCount = hasTwoColumnItems
-        ? TWO_COL_ITEMS_MEASURE_BATCH_SIZE + 1
+      const itemsToMeasureCount = hasMultiColumnItems
+        ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE + 1
         : minCols;
       const itemsToMeasure = items
         .filter((item) => item && !measurementStore.has(item))

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -510,6 +510,83 @@ describe('two column layout test cases', () => {
     });
   });
 
+  test('correctly position multi column item when initial heights are 0', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 5,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1440,
+    });
+
+    let mockItems;
+    let multiColumnModuleIndex;
+    let columnSpan;
+
+    // Correct position when multi column module is on the start of the first row
+    multiColumnModuleIndex = 0;
+    columnSpan = 3;
+
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // First slot
+    expect(positionCache.get(mockItems[multiColumnModuleIndex])).toEqual({
+      height: 200,
+      left: 92,
+      top: 0,
+      width: 748,
+    });
+
+    // Correct position when multi column module is at the end of the first row
+    measurementStore.reset();
+    positionCache.reset();
+    heightsCache.reset();
+
+    multiColumnModuleIndex = 1;
+    columnSpan = 4;
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // Starting on second position until end of first row
+    expect(positionCache.get(mockItems[multiColumnModuleIndex])).toEqual({
+      height: 201,
+      left: 346,
+      top: 0,
+      width: 1002,
+    });
+  });
+
   test('fills in remaining columns in the first row when multi column item cannot fit', () => {
     const measurementStore = new MeasurementStore<{ ... }, number>();
     const positionCache = new MeasurementStore<{ ... }, Position>();

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -16,7 +16,7 @@ import {
 import debounce from './debounce';
 import styles from './Masonry.css';
 import { type Cache } from './Masonry/Cache';
-import { TWO_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/defaultTwoColumnModuleLayout';
+import { MULTI_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/defaultTwoColumnModuleLayout';
 import getLayoutAlgorithm from './Masonry/getLayoutAlgorithm';
 import HeightsStore, { type HeightsStoreInterface } from './Masonry/HeightsStore';
 import MeasurementStore from './Masonry/MeasurementStore';
@@ -313,10 +313,12 @@ function useLayout<T: { +[string]: mixed }>({
   positions: $ReadOnlyArray<?Position>,
   updateMeasurement: (T, number) => void,
 } {
-  const hasTwoColumnItems =
+  const hasMultiColumnItems =
     _twoColItems &&
-    items.filter((item) => item && !positionStore.has(item)).some((item) => item.columnSpan === 2);
-  const itemToMeasureCount = hasTwoColumnItems ? TWO_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
+    items
+      .filter((item) => item && !positionStore.has(item))
+      .some((item) => typeof item.columnSpan === 'number' && item.columnSpan > 2);
+  const itemToMeasureCount = hasMultiColumnItems ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
   const layoutFunction = getLayoutAlgorithm({
     columnWidth,
     gutter,


### PR DESCRIPTION
### Summary

This is the first PR that enables an initial support for n-modules on masonry (3+ columnSpan). This PR enables the positioning of the multi colmn items on the first row, this does't require any change on the graph logic, mainly this changes the logic on the following functions:

- `getAdjacentColumnHeightDeltas`: If two columns returns the deltas between columns, if multi column returns the averages of the deltas required to position the multi column item, f.e. a 3 column item will return the avg of two deltas. This number is the used to determine the best position.
- `getMultiColItemPosition`: Updated to consider that a delta can imply more than two colums, to determine the tallest column it creates a split with the heights for each possible placement
- `calculateMultiColumnModuleWidth`: Updated to return multi column width
- Chage var and function names from `twoCol` to `multiCol`

#### Notes

- This only enables multi column if it fits on first row, multi column on any other behavior is not supported
- All the two colum features are the same
- The flags to enable two col modules are the same

#### Tests

A unit test was added, the visual result of the added tests are:
