### PR TITLE
Masonry: Resize multi column module when larger than column count

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -608,6 +608,82 @@ describe('multi column layout test cases', () => {
     });
   });
 
+  test('correctly resizes multi column module when column span is larger than column count', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 200, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1200,
+    });
+
+    let mockItems;
+    let multiColumnModuleIndex;
+    const columnSpan = 5;
+    const resizedHeight = 159.55414012738854;
+
+    // Correctly resizes and position multi column module when is on the start of the batch
+    multiColumnModuleIndex = 0;
+
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // First slot
+    expect(positionCache.get(mockItems[multiColumnModuleIndex])).toEqual({
+      height: resizedHeight,
+      left: 99,
+      top: 0,
+      width: 1002,
+    });
+
+    // Correctly resizes and position multi column module when is on the second row
+    measurementStore.reset();
+    positionCache.reset();
+    heightsCache.reset();
+
+    multiColumnModuleIndex = 4;
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // Second row
+    expect(positionCache.get(mockItems[multiColumnModuleIndex])).toEqual({
+      height: resizedHeight,
+      left: 99,
+      top: 217,
+      width: 1002,
+    });
+  });
+
   test.each([
     [5, 2],
     [4, 3],


### PR DESCRIPTION
### Summary

To enable the feature for multi column modules on masonry we need to handle an special case when the column span of the module is larger than the column count of masonry. There are several ways on how we could handle that, on this approach we calculate the resize ratio comparing the original width of the element and the with calculated with the new column span, the important part is to overwrite the column span for the new one (hence changing the width) and overwriting the height using the calculated ratio. 

#### Notes

- This is an initial implementation that forces the width and height as css props, in my testing on pinboard the text components keep their original proportions but the image resizes, this seems like a good behavior but could change on the future depending on the product requirements

#### Testing

Added unit tests to position module on the first and the second row. Manually tested on pinboard for different scenarios.