### PR TITLE
Masonry: Enable multiple multi column items on layout logic

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -485,8 +485,13 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 
     if (hasMultiColumnItems) {
       // Currently we only support one two column item at the same time, more items will be supporped soon
-      const multiColumnIndex = itemsWithoutPositions.indexOf(multiColumnItems[0]);
-      const oneColumnItems = itemsWithoutPositions.filter(
+      const itemsToPosition =
+        multiColumnItems.length > 1
+          ? itemsWithoutPositions.slice(0, itemsWithoutPositions.indexOf(multiColumnItems[1]))
+          : itemsWithoutPositions;
+
+      const multiColumnIndex = itemsToPosition.indexOf(multiColumnItems[0]);
+      const oneColumnItems = itemsToPosition.filter(
         (item) => !item.columnSpan || item.columnSpan === 1,
       );
 
@@ -564,7 +569,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       const positionedItems = new Set(winningPositions.map(({ item }) => item));
       // depending on where the multi column item is positioned, there may be items that are still not positioned
       // calculate the remaining items and add them to the list of final positions
-      const remainingItems = items.filter((item) => !positionedItems.has(item));
+      const remainingItems = itemsToPosition.filter((item) => !positionedItems.has(item));
       const { heights: finalHeights, positions: remainingItemPositions } =
         getOneColumnItemPositions<T>({
           items: remainingItems,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -655,7 +655,7 @@ describe('multi column layout test cases', () => {
     expect(positions.length).toEqual(13);
 
     // Confirm that the second item had the correct width
-    expect(positionCache.get(items.filter((item) => item.columnSpan > 1)[1])).toEqual({
+    expect(positionCache.get(items[4])).toEqual({
       height: 204,
       left: 600,
       top: 216,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -608,6 +608,61 @@ describe('multi column layout test cases', () => {
     });
   });
 
+  test('correctly position multiple multi column items', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032', columnSpan: 2 },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509', columnSpan: 2 },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 300, 'color': '#AB032E' },
+      { 'name': 'Pin 7', 'height': 310, 'color': '#DF21DC' },
+      { 'name': 'Pin 8', 'height': 280, 'color': '#F45098' },
+      { 'name': 'Pin 9', 'height': 170, 'color': '#F67076' },
+      { 'name': 'Pin 10', 'height': 220, 'color': '#67076F' },
+      { 'name': 'Pin 11', 'height': 280, 'color': '#AB032E' },
+      { 'name': 'Pin 12', 'height': 150, 'color': '#DF21DC' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 5,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1440,
+    });
+
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    let positions = layout(items);
+
+    // First we only should position until we find the second multi column
+    expect(positions.length).toEqual(4);
+
+    // The second time we should position all the items
+    positions = layout(items);
+    expect(positions.length).toEqual(13);
+
+    // Confirm that the second item had the correct width
+    expect(positionCache.get(items.filter((item) => item.columnSpan > 1)[1])).toEqual({
+      height: 204,
+      left: 600,
+      top: 216,
+      width: 494,
+    });
+  });
+
   test.each([
     [5, 2],
     [4, 3],


### PR DESCRIPTION
### Summary

We didn't have support for multiple multi column items on one pass of the layout logic, the impact is that in the case of multiple multi column items only the first one has the correct width since all others are treated as one col items.

The solution on this PR checks if there are more than one multi column item, in that case trim the items to position so we position the next multi column item on the next round.

#### Notes

- Previously there were discussions of not skiping items on the layout logic because that means an extra render to position the items, in this case I think is not so bad because: 1 - is a strange case, 2 - Is possible that we don't have enough items to have a good position of the second multi column item, this gives us a chance to have more
- In my testing if the multi column items are close to each other the algorithm always choses to position the second multi col item bellow the first one since the difference in heights is 0 (only if the modules have the same column span), not sure if this is a problem but something to have an eye on

### Tests

Added unit test, manually tested on pinboard

<img width="1093" alt="Screenshot 2024-04-25 at 3 19 32 p m" src="https://github.com/pinterest/gestalt/assets/700818/c3b5b416-9929-4e3c-875b-0c42863fe12d">

