### PR TITLE
Maronsy: Correctly set width when multi column item is set to scale to fit

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -433,13 +433,13 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 
   return (items): $ReadOnlyArray<Position> => {
     if (isNil(width) || !items.every((item) => measurementCache.has(item))) {
-      return items.map((item) =>
-        offscreen(
-          typeof item.columnSpan === 'number'
-            ? columnWidth * item.columnSpan + gutter * (item.columnSpan - 1)
-            : columnWidth,
-        ),
-      );
+      return items.map((item) => {
+        if (typeof item.columnSpan === 'number' && item.columnSpan > 1) {
+          const columnSpan = Math.min(item.columnSpan, columnCount);
+          return offscreen(columnWidth * columnSpan + gutter * (columnSpan - 1));
+        }
+        return offscreen(columnWidth);
+      });
     }
 
     const centerOffset =
@@ -499,7 +499,10 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       // items already positioned from previous batches
       const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
-      const multiColumnItemColumnSpan = parseInt(multiColumnItems[0].columnSpan, 10);
+      const multiColumnItemColumnSpan = Math.min(
+        parseInt(multiColumnItems[0].columnSpan, 10),
+        columnCount,
+      );
 
       // Skip the graph logic if the two column item can be displayed on the first row,
       // this means graphBatch is empty and multi column item is positioned on its

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -608,6 +608,102 @@ describe('multi column layout test cases', () => {
     });
   });
 
+  test('set correct offscreen position when multi column item has to be scaled to fit', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032', columnSpan: 5 },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+    ];
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1200,
+    });
+
+    const multiColumnModuleIndex = 2;
+
+    // Correct position when two column module is on the start of the batch
+    const positions = layout(items);
+
+    expect(positions[multiColumnModuleIndex].width).toEqual(1002);
+  });
+
+  test('set correct width for multi col item that is scaled to fit', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 3,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1200,
+    });
+
+    const columnSpan = 5;
+    let mockItems;
+    let multiColumnModuleIndex;
+
+    // Correct position when two column module is on the start of the batch
+    multiColumnModuleIndex = 0;
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // First slot
+    expect(positionCache.get(mockItems[multiColumnModuleIndex]).width).toEqual(1002);
+
+    // Correct position when two column module is at the middle of the batch and fits on the row
+    measurementStore.reset();
+    positionCache.reset();
+    heightsCache.reset();
+
+    multiColumnModuleIndex = 4;
+    mockItems = [
+      ...items.slice(0, multiColumnModuleIndex),
+      { ...items[multiColumnModuleIndex], columnSpan },
+      ...items.slice(multiColumnModuleIndex + 1),
+    ];
+    mockItems.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+    layout(mockItems);
+    // First row third position
+    expect(positionCache.get(mockItems[multiColumnModuleIndex]).width).toEqual(1002);
+  });
+
   test('correctly position multiple multi column items', () => {
     const measurementStore = new MeasurementStore<{ ... }, number>();
     const positionCache = new MeasurementStore<{ ... }, Position>();


### PR DESCRIPTION
### Summary

We are enabling the feature for multi column items to be more than two columns, this creates a new scenario were the multi column item can have a column span greater than the available columns. This PR addresses this situation for the when setting the width of the item on the positions.

This is separated on two different cases:

- When the items have already being measured, we have the assumption that the stored height is the values corresponding to the scaled width, in that case we just set the value of the column span to the number of columns
- When we don't have the height on the cache, we return the offscreen position with the column span set to the number of columns

#### Tests

Added unit test for both cases. Manually tested on pinboard for module on first row and on second row

https://github.com/pinterest/gestalt/assets/700818/01274344-e59a-4228-a3a7-85663d665df8


https://github.com/pinterest/gestalt/assets/700818/21023f81-3e99-4424-87ca-162a99287762


