### PR TITLE
Masonry: Bug fix, enable layout not returning positions of all items

### DIFF
--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -601,15 +601,17 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       gridBody = (
         <div ref={this.setGridWrapperRef} style={{ width: '100%' }}>
           <div className={styles.Masonry} role="list" style={{ height, width }}>
-            {itemsToRender.map((item, i) =>
-              this.renderMasonryComponent(
-                item,
-                i,
-                // If we have items in the positionStore (newer way of tracking positions used for 2-col support), use that. Otherwise fall back to the classic way of tracking positions
-                // this is only required atm because the two column layout doesn't not return positions in their original item order
-                positionStore.get(item) ?? positions[i],
-              ),
-            )}
+            {itemsToRender
+              .filter((item, i) => positionStore.get(item) || positions[i])
+              .map((item, i) =>
+                this.renderMasonryComponent(
+                  item,
+                  i,
+                  // If we have items in the positionStore (newer way of tracking positions used for 2-col support), use that. Otherwise fall back to the classic way of tracking positions
+                  // this is only required atm because the two column layout doesn't not return positions in their original item order
+                  positionStore.get(item) ?? positions[i],
+                ),
+              )}
           </div>
           <div className={styles.Masonry} style={{ width }}>
             {itemsToMeasure.map((data, i) => {

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -322,12 +322,13 @@ function useLayout<T: { +[string]: mixed }>({
   positions: $ReadOnlyArray<?Position>,
   updateMeasurement: (T, number) => void,
 } {
-  const hasMultiColumnItems =
-    _twoColItems &&
-    items
-      .filter((item) => item && !positionStore.has(item))
-      .some((item) => typeof item.columnSpan === 'number' && item.columnSpan > 1);
-  const itemToMeasureCount = hasMultiColumnItems ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
+  const multiColumnItemsCount = _twoColItems
+    ? items
+        .filter((item) => item && !positionStore.has(item))
+        .filter((item) => typeof item.columnSpan === 'number' && item.columnSpan > 1).length
+    : 0;
+  const itemToMeasureCount =
+    multiColumnItemsCount > 0 ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
   const layoutFunction = getLayoutAlgorithm({
     columnWidth,
     gutter,
@@ -382,7 +383,7 @@ function useLayout<T: { +[string]: mixed }>({
     // - itemMeasurementsCount: if we have a change in the number of items we've measured, we should always recalculage
     // - canPerformLayout: if we don't have a width, we can't calculate positions yet. so recalculate once we're able to
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemMeasurementsCount, items, canPerformLayout]);
+  }, [itemMeasurementsCount, items, canPerformLayout, multiColumnItemsCount]);
 
   const updateMeasurement = useCallback(
     (item: T, itemHeight: number) => {


### PR DESCRIPTION
### Summary

We found a bug after enabling multiple multi column items on masonry here https://github.com/pinterest/gestalt/pull/3537, this was because masonry expects that the layout functions return all the positions in one run, but for multiple multi column items we do not calculate the position of the items after the second multi column item. This broke masonry although strangely enough the bug was not consistent, that's why it was not immediately obvious. The bug was different on V1 and on V2.

On V1 there was an exception because it tried to render something without a position, to fix it we filter the items with positions before render.

On V2 the layout function was not triggered again after positioning the first multi column item because there was no a condition for that. To fix it we added the multi column items count as dependency.