### PR TITLE
Enable multiple multi column items2

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -485,13 +485,8 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 
     if (hasMultiColumnItems) {
       // Currently we only support one two column item at the same time, more items will be supporped soon
-      const itemsToPosition =
-        multiColumnItems.length > 1
-          ? itemsWithoutPositions.slice(0, itemsWithoutPositions.indexOf(multiColumnItems[1]))
-          : itemsWithoutPositions;
-
-      const multiColumnIndex = itemsToPosition.indexOf(multiColumnItems[0]);
-      const oneColumnItems = itemsToPosition.filter(
+      const multiColumnIndex = itemsWithoutPositions.indexOf(multiColumnItems[0]);
+      const oneColumnItems = itemsWithoutPositions.filter(
         (item) => !item.columnSpan || item.columnSpan === 1,
       );
 
@@ -572,7 +567,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       const positionedItems = new Set(winningPositions.map(({ item }) => item));
       // depending on where the multi column item is positioned, there may be items that are still not positioned
       // calculate the remaining items and add them to the list of final positions
-      const remainingItems = itemsToPosition.filter((item) => !positionedItems.has(item));
+      const remainingItems = items.filter((item) => !positionedItems.has(item));
       const { heights: finalHeights, positions: remainingItemPositions } =
         getOneColumnItemPositions<T>({
           items: remainingItems,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -704,61 +704,6 @@ describe('multi column layout test cases', () => {
     expect(positionCache.get(mockItems[multiColumnModuleIndex])?.width).toEqual(1002);
   });
 
-  test('correctly position multiple multi column items', () => {
-    const measurementStore = new MeasurementStore<{ ... }, number>();
-    const positionCache = new MeasurementStore<{ ... }, Position>();
-    const heightsCache = new HeightsStore();
-    const items = [
-      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
-      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
-      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032', columnSpan: 2 },
-      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
-      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509', columnSpan: 2 },
-      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
-      { 'name': 'Pin 6', 'height': 300, 'color': '#AB032E' },
-      { 'name': 'Pin 7', 'height': 310, 'color': '#DF21DC' },
-      { 'name': 'Pin 8', 'height': 280, 'color': '#F45098' },
-      { 'name': 'Pin 9', 'height': 170, 'color': '#F67076' },
-      { 'name': 'Pin 10', 'height': 220, 'color': '#67076F' },
-      { 'name': 'Pin 11', 'height': 280, 'color': '#AB032E' },
-      { 'name': 'Pin 12', 'height': 150, 'color': '#DF21DC' },
-    ];
-    items.forEach((item) => {
-      measurementStore.set(item, item.height);
-    });
-
-    const layout = defaultTwoColumnModuleLayout({
-      columnWidth: 240,
-      measurementCache: measurementStore,
-      heightsCache,
-      justify: 'start',
-      minCols: 5,
-      positionCache,
-      rawItemCount: items.length,
-      width: 1440,
-    });
-
-    items.forEach((item) => {
-      measurementStore.set(item, item.height);
-    });
-    let positions = layout(items);
-
-    // First we only should position until we find the second multi column
-    expect(positions.length).toEqual(4);
-
-    // The second time we should position all the items
-    positions = layout(items);
-    expect(positions.length).toEqual(13);
-
-    // Confirm that the second item had the correct width
-    expect(positionCache.get(items[4])).toEqual({
-      height: 204,
-      left: 600,
-      top: 216,
-      width: 494,
-    });
-  });
-
   test.each([
     [5, 2],
     [4, 3],

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -704,6 +704,56 @@ describe('multi column layout test cases', () => {
     expect(positionCache.get(mockItems[multiColumnModuleIndex])?.width).toEqual(1002);
   });
 
+  test('correctly position multiple multi column items', () => {
+    const measurementStore = new MeasurementStore<{ ... }, number>();
+    const positionCache = new MeasurementStore<{ ... }, Position>();
+    const heightsCache = new HeightsStore();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032', columnSpan: 2 },
+      { 'name': 'Pin 3', 'height': 203, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 204, 'color': '#CF4509', columnSpan: 2 },
+      { 'name': 'Pin 5', 'height': 205, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 300, 'color': '#AB032E' },
+      { 'name': 'Pin 7', 'height': 310, 'color': '#DF21DC' },
+      { 'name': 'Pin 8', 'height': 280, 'color': '#F45098' },
+      { 'name': 'Pin 9', 'height': 170, 'color': '#F67076' },
+      { 'name': 'Pin 10', 'height': 220, 'color': '#67076F' },
+      { 'name': 'Pin 11', 'height': 280, 'color': '#AB032E' },
+      { 'name': 'Pin 12', 'height': 150, 'color': '#DF21DC' },
+    ];
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultTwoColumnModuleLayout({
+      columnWidth: 240,
+      measurementCache: measurementStore,
+      heightsCache,
+      justify: 'start',
+      minCols: 5,
+      positionCache,
+      rawItemCount: items.length,
+      width: 1440,
+    });
+
+    items.forEach((item) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const positions = layout(items);
+    expect(positions.length).toEqual(13);
+
+    // Confirm that the second multi column item had the correct width
+    expect(positionCache.get(items[4])).toEqual({
+      height: 204,
+      left: 600,
+      top: 216,
+      width: 494,
+    });
+  });
+
   test.each([
     [5, 2],
     [4, 3],


### PR DESCRIPTION
# Summary

We didn't have support for multiple multi column items on one pass of the layout logic, the impact is that in the case of multiple multi column items only the first one has the correct width since all others are treated as one col items.

Previously I fixed this by only processing the items up to the second multi column item and the layout function only returned those, this was an iddue because masonry expects to receive the positions for all the items sent.

This new approach calculates all the positions by extracting the multi column item logic and using a loop.

## Notes

- I also changed a little bit the `getMultiColItemPosition` to support multiple multi column items on the first row

## Tests

Added unit test for new case, manually tested with pinboard on v1 and v2