### PR TITLE
Accordion: support borderStyles prop

### DIFF
--- a/packages/gestalt/dist/index.d.ts
+++ b/packages/gestalt/dist/index.d.ts
@@ -1441,7 +1441,7 @@ interface MasonryProps<T = any> {
   virtualBufferFactor?: number | undefined;
   virtualize?: boolean | undefined;
   _twoColItems?: boolean | undefined;
-  _logTwoColWhitespace?: (number) => void;
+  _logTwoColWhitespace?: (arg: number) => void;
 }
 
 interface MasonryV2Props<T = any> extends MasonryProps<T> {
@@ -1506,6 +1506,7 @@ interface ModalAlertProps {
 interface AccordionProps {
   id: string;
   badge?: BadgeObject | undefined;
+  borderStyle?: 'sm' | 'shadow' | 'none';
   children?: Node | undefined;
   icon?: Icons | undefined;
   iconAccessibilityLabel?: string | undefined;
@@ -1518,6 +1519,7 @@ interface AccordionProps {
 interface AccordionExpandableProps {
   accessibilityCollapseLabel: string;
   accessibilityExpandLabel: string;
+  borderStyle?: 'sm' | 'shadow' | 'none';
   id: string;
   items: ReadonlyArray<{
     title: string;

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -31,7 +31,7 @@ type Props = {
   /**
    * Specify a border. See [Box's border options](https://gestalt.pinterest.systems/web/box#Borders)
    */
-  borderStyle: 'sm' | 'shadow' | 'none',
+  borderStyle?: 'sm' | 'shadow' | 'none',
   /**
    * Content to display underneath Accordion title.
    */

--- a/packages/gestalt/src/Accordion.js
+++ b/packages/gestalt/src/Accordion.js
@@ -29,6 +29,10 @@ type Props = {
    */
   badge?: BadgeType,
   /**
+   * Specify a border. See [Box's border options](https://gestalt.pinterest.systems/web/box#Borders)
+   */
+  borderStyle: 'sm' | 'shadow' | 'none',
+  /**
    * Content to display underneath Accordion title.
    */
   children?: ReactNode,
@@ -71,6 +75,7 @@ type Props = {
  */
 export default function Accordion({
   badge,
+  borderStyle = 'shadow',
   children,
   icon,
   iconAccessibilityLabel,
@@ -87,7 +92,7 @@ export default function Accordion({
 
   return (
     <Box
-      borderStyle="shadow"
+      borderStyle={borderStyle !== 'none' ? borderStyle : undefined}
       color={isDarkMode ? 'elevationFloating' : 'default'}
       id={id}
       padding={padding}

--- a/packages/gestalt/src/AccordionExpandable.js
+++ b/packages/gestalt/src/AccordionExpandable.js
@@ -46,7 +46,7 @@ type Props = {
   /**
    * Specify a border. See [Box's border options](https://gestalt.pinterest.systems/web/box#Borders)
    */
-  borderStyle: 'sm' | 'shadow' | 'none',
+  borderStyle?: 'sm' | 'shadow' | 'none',
   /**
    * The 0-based index indicating the item that should currently be expanded. This must be updated via `onExpandedChange` to ensure the correct item is expanded. See [Expandable](https://gestalt.pinterest.systems/web/accordion#Expandable) variant to learn more.
    */

--- a/packages/gestalt/src/AccordionExpandable.js
+++ b/packages/gestalt/src/AccordionExpandable.js
@@ -44,9 +44,14 @@ type Props = {
    */
   accessibilityExpandLabel?: string,
   /**
+   * Specify a border. See [Box's border options](https://gestalt.pinterest.systems/web/box#Borders)
+   */
+  borderStyle: 'sm' | 'shadow' | 'none',
+  /**
    * The 0-based index indicating the item that should currently be expanded. This must be updated via `onExpandedChange` to ensure the correct item is expanded. See [Expandable](https://gestalt.pinterest.systems/web/accordion#Expandable) variant to learn more.
    */
   expandedIndex?: ?number,
+
   /**
    * Unique id to identify this Accordion. See [Expandable](https://gestalt.pinterest.systems/web/accordion#Expandable) variant to learn more.
    */
@@ -80,6 +85,7 @@ type Props = {
 export default function AccordionExpandable({
   accessibilityExpandLabel,
   accessibilityCollapseLabel,
+  borderStyle = 'shadow',
   expandedIndex,
   id,
   items,
@@ -114,7 +120,7 @@ export default function AccordionExpandable({
 
   return (
     <Box
-      borderStyle="shadow"
+      borderStyle={borderStyle !== 'none' ? borderStyle : undefined}
       color={isDarkMode ? 'elevationFloating' : 'default'}
       rounding={rounding}
     >


### PR DESCRIPTION
Accordion, support borderStyles prop

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/4d14883f-2eac-45d1-8482-d9de1d4f2609)

They supports requests like 
![image](https://github.com/pinterest/gestalt/assets/10593890/29078b11-a480-43bc-ab28-8eb3f347cdd1)
