### PR TITLE
Tag: fix padding in mobile browsers in button tag

### DIFF
--- a/packages/gestalt/src/Tag.css
+++ b/packages/gestalt/src/Tag.css
@@ -37,6 +37,8 @@
 .closeButton {
   composes: noBorder from "./Borders.css";
   composes: pointer from "./Cursor.css";
+  composes: paddingX0 from "./boxWhitespace.css";
+  composes: paddingY0 from "./boxWhitespace.css";
   height: 100%;
   outline: none;
   position: absolute;


### PR DESCRIPTION
Tag: fix padding in mobile browsers in button tag
## Pull Request Template

### Summary

#### What changed?

BEFORE

![image](https://github.com/pinterest/gestalt/assets/10593890/f6f7ec8b-5938-44c5-ace7-53d507d69c39)
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/829524ac-7e2c-419d-94b0-ec2f35fb6ae2)

AFTER
 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/c5cf91ba-cf5f-4942-bc78-1e3a8a9d743e)

#### Why?
BUG: https://jira.pinadmin.com/browse/BUG-179079

On mobile browsers, button tag has a default padding. We reset it in Button but we didn't on Tag
 
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/b49c5ed5-10bd-4658-aa92-1b5461604bbb)


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
