### PR TITLE
Docs: Update Android component status to reflect the latest

### DIFF
--- a/docs/docs-components/data/components.js
+++ b/docs/docs-components/data/components.js
@@ -219,7 +219,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'ready',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {
@@ -282,7 +282,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'ready',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {
@@ -565,7 +565,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'ready',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {
@@ -1504,7 +1504,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'ready',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {
@@ -2017,7 +2017,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'partial',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {
@@ -2128,7 +2128,7 @@ const componentData: $ReadOnlyArray<ComponentData> = [
         status: {
           documentation: 'ready',
           figmaStatus: 'ready',
-          status: 'planned',
+          status: 'ready',
         },
       },
       ios: {


### PR DESCRIPTION
### Summary
Update component data to reflect the latest Android gestalt component code status

#### What changed?

Mark all component listed in https://gestalt.pinterest.systems/android/component_status as Ready

#### Why?

The components list wasn't reflecting the real world status

### Links

- [Jira](https://jira.pinadmin.com/browse/ANDX-19589)
