### PR TITLE
Masonry: Bug fix, "basic" layout not left aligning 

### DIFF
--- a/docs/examples/masonry/align.js
+++ b/docs/examples/masonry/align.js
@@ -1,0 +1,198 @@
+// @flow strict
+import { type Node as ReactNode, useEffect, useId, useRef, useState } from 'react';
+import { Box, Flex, Image, Label, Masonry, RadioGroup, Text } from 'gestalt';
+
+type Pin = {
+  color: string,
+  height: number,
+  name: string,
+  src: string,
+  width: number,
+};
+
+function getPins(): Promise<$ReadOnlyArray<Pin>> {
+  const pins: $ReadOnlyArray<Pin> = [
+    {
+      color: '#2b3938',
+      height: 316,
+      src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+      width: 474,
+      name: 'the Hang Son Doong cave in Vietnam',
+    },
+    {
+      color: '#8e7439',
+      height: 1081,
+      src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+      width: 474,
+      name: 'La Gran Muralla, Pekín, China',
+    },
+    {
+      color: '#698157',
+      height: 711,
+      src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+      width: 474,
+      name: 'Plitvice Lakes National Park, Croatia',
+    },
+    {
+      color: '#4e5d50',
+      height: 632,
+      src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+      width: 474,
+      name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+    },
+    {
+      color: '#6d6368',
+      height: 710,
+      src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+      width: 474,
+      name: 'Border of China and Vietnam',
+    },
+  ];
+
+  const pinList = Array.from({ length: 1 }, () => pins).flat();
+  return Promise.resolve(pinList);
+}
+
+function GridComponent({ data }: { data: Pin, ... }) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.height}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+      <Text>{data.name}</Text>
+    </Flex>
+  );
+}
+
+export default function Example(): ReactNode {
+  const [layout, setLayout] = useState<'basic' | 'basicCentered'>('basic');
+  const [align, setAlign] = useState<'start' | 'center' | 'end'>('center');
+  const [pins, setPins] = useState<$ReadOnlyArray<Pin>>([]);
+  const [width, setWidth] = useState<number>(700);
+  const scrollContainerRef = useRef<?HTMLDivElement>();
+  const gridRef = useRef<?Masonry<Pin>>();
+
+  const labelId = useId();
+
+  useEffect(() => {
+    getPins().then((startPins) => {
+      setPins(startPins);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (gridRef.current) {
+      gridRef.current.handleResize();
+    }
+  }, [width]);
+
+  const updateWidth = ({ target }: { target: HTMLInputElement }) => {
+    setWidth(Number(target.value));
+  };
+
+  return (
+    <Box padding={2}>
+      <Flex direction="column" gap={4}>
+        <Flex alignItems="center" direction="column">
+          <Flex.Item>
+            <Label htmlFor={labelId}>
+              <Text>Container Width</Text>
+            </Label>
+          </Flex.Item>
+          <input
+            defaultValue={800}
+            id={labelId}
+            max={8000}
+            min={200}
+            onChange={updateWidth}
+            step={5}
+            style={{ width: '400px', display: 'block', margin: '10px auto' }}
+            type="range"
+          />
+        </Flex>
+
+        <div
+          ref={(el) => {
+            scrollContainerRef.current = el;
+          }}
+          style={{
+            height: '300px',
+            margin: '0 auto',
+            outline: '3px solid #ddd',
+            overflowY: 'scroll',
+            width: `${width}px`,
+          }}
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={0}
+        >
+          {scrollContainerRef.current && (
+            <Masonry
+              ref={(ref) => {
+                gridRef.current = ref;
+              }}
+              align={align}
+              columnWidth={170}
+              gutterWidth={20}
+              items={pins}
+              layout={layout}
+              minCols={1}
+              renderItem={({ data }) => <GridComponent data={data} />}
+              // $FlowFixMe[incompatible-type]
+              scrollContainer={() => scrollContainerRef.current}
+            />
+          )}
+        </div>
+      </Flex>
+      <Flex gap={12} justifyContent="center">
+        <RadioGroup id="layoutOptions" legend="Layout">
+          <RadioGroup.RadioButton
+            checked={layout === 'basic'}
+            id="basic"
+            label="basic"
+            name="layout"
+            onChange={() => setLayout('basic')}
+            value="basic"
+          />
+          <RadioGroup.RadioButton
+            checked={layout === 'basicCentered'}
+            id="basicCentered"
+            label="basicCentered"
+            name="layout"
+            onChange={() => setLayout('basicCentered')}
+            value="basicCentered"
+          />
+        </RadioGroup>
+        <RadioGroup id="alignOptions" legend="Align">
+          <RadioGroup.RadioButton
+            checked={align === 'start'}
+            id="start"
+            label="Start"
+            name="align"
+            onChange={() => setAlign('start')}
+            value="start"
+          />
+          <RadioGroup.RadioButton
+            checked={align === 'center'}
+            id="center"
+            label="Center (default)"
+            name="align"
+            onChange={() => setAlign('center')}
+            value="center"
+          />
+          <RadioGroup.RadioButton
+            checked={align === 'end'}
+            id="end"
+            label="End"
+            name="align"
+            onChange={() => setAlign('end')}
+            value="end"
+          />
+        </RadioGroup>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -9,6 +9,7 @@ import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
+import justify from '../../examples/masonry/justify';
 import main from '../../examples/masonry/main';
 import variantsBasic from '../../examples/masonry/variantsBasic';
 import variantsFlexible from '../../examples/masonry/variantsFlexible';
@@ -88,6 +89,26 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
                 code={variantsUniform}
                 layout="column"
                 name="Variants - Uniform example"
+                previewHeight={PREVIEW_HEIGHT}
+              />
+            }
+          />
+        </MainSection.Subsection>
+      </MainSection>
+
+      <MainSection name="Justify">
+        <MainSection.Subsection
+          description={`
+          The justify property controls the horizontal alignment of items within the Masonry grid, determining how items are distributed across the available horizontal space of the container. The justify options allow you to align items to the start, center, or end of the container.
+        `}
+          title="Justify options"
+        >
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample
+                code={justify}
+                layout="column"
+                name="Variants - Basic example"
                 previewHeight={PREVIEW_HEIGHT}
               />
             }

--- a/docs/pages/web/masonry.js
+++ b/docs/pages/web/masonry.js
@@ -9,7 +9,7 @@ import Page from '../../docs-components/Page';
 import PageHeader from '../../docs-components/PageHeader';
 import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
-import justify from '../../examples/masonry/justify';
+import align from '../../examples/masonry/align';
 import main from '../../examples/masonry/main';
 import variantsBasic from '../../examples/masonry/variantsBasic';
 import variantsFlexible from '../../examples/masonry/variantsFlexible';
@@ -96,17 +96,19 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
         </MainSection.Subsection>
       </MainSection>
 
-      <MainSection name="Justify">
+      <MainSection name="Align">
         <MainSection.Subsection
           description={`
-          The justify property controls the horizontal alignment of items within the Masonry grid, determining how items are distributed across the available horizontal space of the container. The justify options allow you to align items to the start, center, or end of the container.
+          The align property controls the horizontal alignment of items within the Masonry grid, determining how items are distributed across the available horizontal space of the container. The align options allow you to align items to the start, center, or end of the container.
+
+          Align only works when layout='basic'.
         `}
-          title="Justify options"
+          title="Align options"
         >
           <MainSection.Card
             sandpackExample={
               <SandpackExample
-                code={justify}
+                code={align}
                 layout="column"
                 name="Variants - Basic example"
                 previewHeight={PREVIEW_HEIGHT}

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -12,7 +12,7 @@ import fullWidthLayout from './Masonry/fullWidthLayout';
 import MeasurementStore from './Masonry/MeasurementStore';
 import ScrollContainer from './Masonry/ScrollContainer';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
-import { type Justify, type Layout, type Position } from './Masonry/types';
+import { type Align, type Layout, type Position } from './Masonry/types';
 import uniformRowLayout from './Masonry/uniformRowLayout';
 import throttle, { type ThrottleReturn } from './throttle';
 
@@ -21,6 +21,14 @@ const RESIZE_DEBOUNCE = 300;
 const layoutNumberToCssDimension = (n: ?number) => (n !== Infinity ? n : undefined);
 
 type Props<T> = {
+  /**
+   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
+   * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
+   * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
+   * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
+   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   */
+  align?: Align,
   /**
    * The preferred/target item width in pixels. If `layout="flexible"` is set, the item width will
    * grow to fill column space, and shrink to fit if below the minimum number of columns.
@@ -34,14 +42,6 @@ type Props<T> = {
    * An array of items to display that contains the data to be rendered by `renderItem`.
    */
   items: $ReadOnlyArray<T>,
-  /**
-   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
-   * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
-   * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
-   * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
-   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
-   */
-  justify?: Justify,
   /**
    * `basic`: Left-aligned, fixed-column-width masonry layout.
    * `basicCentered`: Center-aligned, fixed-column-width masonry layout.
@@ -139,8 +139,8 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
   }
 
   static defaultProps: {
+    align?: Align,
     columnWidth?: number,
-    justify?: Justify,
     layout?: Layout,
     loadItems?: (
       ?{
@@ -152,7 +152,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
     virtualize?: boolean,
   } = {
     columnWidth: 236,
-    justify: 'center',
+    align: 'center',
     minCols: 3,
     layout: 'basic',
     loadItems: () => {},
@@ -468,11 +468,11 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
 
   render(): ReactNode {
     const {
+      align = 'center',
       columnWidth,
       gutterWidth: gutter,
       items,
-      justify = 'center',
-      layout,
+      layout = 'basic',
       minCols,
       renderItem,
       scrollContainer,
@@ -506,7 +506,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
         positionCache: positionStore,
         columnWidth,
         gutter,
-        justify,
+        justify: layout === 'basicCentered' ? 'center' : 'start',
         logWhitespace: _logTwoColWhitespace,
         minCols,
         rawItemCount: items.length,
@@ -517,7 +517,8 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
         cache: measurementStore,
         columnWidth,
         gutter,
-        justify,
+        justify: align,
+        layout,
         minCols,
         rawItemCount: items.length,
         width,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -22,11 +22,13 @@ const layoutNumberToCssDimension = (n: ?number) => (n !== Infinity ? n : undefin
 
 type Props<T> = {
   /**
-   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
+   * Controls the horizontal alignment of items within the Masonry grid. The `align` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
    * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
    * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
    * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
-   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   * Using the `align` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   *
+   * _Note that layout='basic' must be set for align to take effect._
    */
   align?: Align,
   /**

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -504,11 +504,11 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       });
     } else if (_twoColItems === true) {
       getPositions = defaultTwoColumnModuleLayout({
+        align: layout === 'basicCentered' ? 'center' : 'start',
         measurementCache: measurementStore,
         positionCache: positionStore,
         columnWidth,
         gutter,
-        justify: layout === 'basicCentered' ? 'center' : 'start',
         logWhitespace: _logTwoColWhitespace,
         minCols,
         rawItemCount: items.length,
@@ -516,10 +516,10 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       });
     } else {
       getPositions = defaultLayout({
+        align,
         cache: measurementStore,
         columnWidth,
         gutter,
-        justify: align,
         layout,
         minCols,
         rawItemCount: items.length,

--- a/packages/gestalt/src/Masonry.js
+++ b/packages/gestalt/src/Masonry.js
@@ -12,7 +12,7 @@ import fullWidthLayout from './Masonry/fullWidthLayout';
 import MeasurementStore from './Masonry/MeasurementStore';
 import ScrollContainer from './Masonry/ScrollContainer';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
-import { type Layout, type Position } from './Masonry/types';
+import { type Justify, type Layout, type Position } from './Masonry/types';
 import uniformRowLayout from './Masonry/uniformRowLayout';
 import throttle, { type ThrottleReturn } from './throttle';
 
@@ -34,6 +34,14 @@ type Props<T> = {
    * An array of items to display that contains the data to be rendered by `renderItem`.
    */
   items: $ReadOnlyArray<T>,
+  /**
+   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
+   * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
+   * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
+   * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
+   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   */
+  justify?: Justify,
   /**
    * `basic`: Left-aligned, fixed-column-width masonry layout.
    * `basicCentered`: Center-aligned, fixed-column-width masonry layout.
@@ -132,6 +140,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
 
   static defaultProps: {
     columnWidth?: number,
+    justify?: Justify,
     layout?: Layout,
     loadItems?: (
       ?{
@@ -143,6 +152,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
     virtualize?: boolean,
   } = {
     columnWidth: 236,
+    justify: 'center',
     minCols: 3,
     layout: 'basic',
     loadItems: () => {},
@@ -461,6 +471,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
       columnWidth,
       gutterWidth: gutter,
       items,
+      justify = 'center',
       layout,
       minCols,
       renderItem,
@@ -495,7 +506,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
         positionCache: positionStore,
         columnWidth,
         gutter,
-        justify: layout === 'basicCentered' ? 'center' : 'start',
+        justify,
         logWhitespace: _logTwoColWhitespace,
         minCols,
         rawItemCount: items.length,
@@ -506,7 +517,7 @@ export default class Masonry<T: { +[string]: mixed }> extends ReactComponent<Pro
         cache: measurementStore,
         columnWidth,
         gutter,
-        justify: layout === 'basicCentered' ? 'center' : 'start',
+        justify,
         minCols,
         rawItemCount: items.length,
         width,

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { type Justify } from 'gestalt/src//Masonry/types';
+import { type Align, type Layout } from 'gestalt/src//Masonry/types';
 import { type Cache } from './Cache';
 import mindex from './mindex';
 import { type Position } from './types';
@@ -11,19 +11,51 @@ const offscreen = (width: number, height: number = Infinity) => ({
   height,
 });
 
+const calculateCenterOffset = ({
+  columnCount,
+  columnWidthAndGutter,
+  gutter,
+  justify,
+  layout,
+  rawItemCount,
+  width,
+}: {
+  columnCount: number,
+  columnWidthAndGutter: number,
+  gutter: number,
+  justify: Align,
+  layout: Layout,
+  rawItemCount: number,
+  width: number,
+}): number => {
+  if (layout === 'basicCentered') {
+    const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter;
+    return Math.max(Math.floor((width - contentWidth) / 2), 0);
+  }
+  if (justify === 'center') {
+    return Math.max(Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2), 0);
+  }
+  if (justify === 'end') {
+    return width - (columnWidthAndGutter * columnCount - gutter);
+  }
+  return 0;
+};
+
 const defaultLayout =
   <T>({
+    justify,
     cache,
     columnWidth = 236,
     gutter = 14,
-    justify,
+    layout,
     minCols = 2,
     rawItemCount,
     width,
   }: {
     columnWidth?: number,
     gutter?: number,
-    justify: Justify,
+    justify: Align,
+    layout: Layout,
     cache: Cache<T, number>,
     minCols?: number,
     rawItemCount: number,
@@ -39,16 +71,15 @@ const defaultLayout =
     // the total height of each column
     const heights = new Array<number>(columnCount).fill(0);
 
-    let centerOffset;
-    if (justify === 'center') {
-      const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter - gutter;
-
-      centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
-    } else if (justify === 'start') {
-      centerOffset = 0;
-    } else if (justify === 'end') {
-      centerOffset = width - (columnWidthAndGutter * columnCount - gutter);
-    }
+    const centerOffset = calculateCenterOffset({
+      columnCount,
+      columnWidthAndGutter,
+      gutter,
+      justify,
+      layout,
+      rawItemCount,
+      width,
+    });
 
     return items.reduce((acc, item) => {
       const positions = acc;

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -41,7 +41,7 @@ const defaultLayout =
 
     let centerOffset;
     if (justify === 'center') {
-      const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter;
+      const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter - gutter;
 
       centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
     } else if (justify === 'start') {

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -12,18 +12,18 @@ const offscreen = (width: number, height: number = Infinity) => ({
 });
 
 const calculateCenterOffset = ({
+  align,
   columnCount,
   columnWidthAndGutter,
   gutter,
-  justify,
   layout,
   rawItemCount,
   width,
 }: {
+  align: Align,
   columnCount: number,
   columnWidthAndGutter: number,
   gutter: number,
-  justify: Align,
   layout: Layout,
   rawItemCount: number,
   width: number,
@@ -32,10 +32,10 @@ const calculateCenterOffset = ({
     const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter;
     return Math.max(Math.floor((width - contentWidth) / 2), 0);
   }
-  if (justify === 'center') {
+  if (align === 'center') {
     return Math.max(Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2), 0);
   }
-  if (justify === 'end') {
+  if (align === 'end') {
     return width - (columnWidthAndGutter * columnCount - gutter);
   }
   return 0;
@@ -43,7 +43,7 @@ const calculateCenterOffset = ({
 
 const defaultLayout =
   <T>({
-    justify,
+    align,
     cache,
     columnWidth = 236,
     gutter = 14,
@@ -54,7 +54,7 @@ const defaultLayout =
   }: {
     columnWidth?: number,
     gutter?: number,
-    justify: Align,
+    align: Align,
     layout: Layout,
     cache: Cache<T, number>,
     minCols?: number,
@@ -75,7 +75,7 @@ const defaultLayout =
       columnCount,
       columnWidthAndGutter,
       gutter,
-      justify,
+      align,
       layout,
       rawItemCount,
       width,

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -44,10 +44,7 @@ const defaultLayout =
 
       centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
     } else {
-      centerOffset = Math.max(
-        Math.floor((width - columnWidthAndGutter * columnCount + gutter) / 2),
-        0,
-      );
+      centerOffset = 0;
     }
 
     return items.reduce((acc, item) => {

--- a/packages/gestalt/src/Masonry/defaultLayout.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.js
@@ -1,4 +1,5 @@
 // @flow strict
+import { type Justify } from 'gestalt/src//Masonry/types';
 import { type Cache } from './Cache';
 import mindex from './mindex';
 import { type Position } from './types';
@@ -22,7 +23,7 @@ const defaultLayout =
   }: {
     columnWidth?: number,
     gutter?: number,
-    justify: 'center' | 'start',
+    justify: Justify,
     cache: Cache<T, number>,
     minCols?: number,
     rawItemCount: number,
@@ -43,8 +44,10 @@ const defaultLayout =
       const contentWidth = Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter;
 
       centerOffset = Math.max(Math.floor((width - contentWidth) / 2), 0);
-    } else {
+    } else if (justify === 'start') {
       centerOffset = 0;
+    } else if (justify === 'end') {
+      centerOffset = width - (columnWidthAndGutter * columnCount - gutter);
     }
 
     return items.reduce((acc, item) => {

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 import defaultLayout from './defaultLayout';
 
-const stubCache = (measurements?: { [item: string]: number, ... } = { }) => {
+const stubCache = (measurements?: { [item: string]: number, ... } = {}) => {
   let cache = measurements;
 
   return {
@@ -64,6 +64,24 @@ test('wrapping items', () => {
   ]);
 });
 
+test('left-aligns grid within the viewport', () => {
+  const measurements = { a: 100, b: 120, c: 80, d: 100 };
+  const items = ['a', 'b', 'c', 'd'];
+  const layout = defaultLayout({
+    cache: stubCache(measurements),
+    justify: 'start',
+    minCols: 2,
+    rawItemCount: items.length,
+    width: 8000,
+  });
+  expect(layout(items)).toEqual([
+    { top: 0, height: 100, left: 0, width: 236 },
+    { top: 0, height: 120, left: 250, width: 236 },
+    { top: 0, height: 80, left: 500, width: 236 },
+    { top: 0, height: 100, left: 750, width: 236 },
+  ]);
+});
+
 test('centers grid within the viewport', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
@@ -82,20 +100,21 @@ test('centers grid within the viewport', () => {
   ]);
 });
 
-test('left align grid within the viewport', () => {
+test('right-aligns grid within the viewport', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
-    justify: 'start',
+    justify: 'end',
+    minCols: 2,
     rawItemCount: items.length,
-    width: 501,
+    width: 8000,
   });
   expect(layout(items)).toEqual([
-    { top: 0, height: 100, left: 0, width: 236 },
-    { top: 0, height: 120, left: 250, width: 236 },
-    { top: 114, height: 80, left: 0, width: 236 },
-    { top: 134, height: 100, left: 250, width: 236 },
+    { top: 0, height: 100, left: 14, width: 236 },
+    { top: 0, height: 120, left: 264, width: 236 },
+    { top: 0, height: 80, left: 514, width: 236 },
+    { top: 0, height: 100, left: 764, width: 236 },
   ]);
 });
 

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -86,7 +86,7 @@ test('left-aligns grid within the viewport', () => {
   ]);
 });
 
-test('centers grid within the viewport', () => {
+test('centers grid within the viewport, left align', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
@@ -102,6 +102,25 @@ test('centers grid within the viewport', () => {
     { top: 0, height: 120, left: 257, width: 236 },
     { top: 0, height: 80, left: 507, width: 236 },
     { top: 0, height: 100, left: 757, width: 236 },
+  ]);
+});
+
+test('centers grid within the viewport, center align', () => {
+  const measurements = { a: 100, b: 120, c: 80, d: 100 };
+  const items = ['a', 'b', 'c', 'd'];
+  const layout = defaultLayout({
+    cache: stubCache(measurements),
+    justify: 'center',
+    layout: 'basicCentered',
+    minCols: 2,
+    rawItemCount: items.length,
+    width: 8000,
+  });
+  expect(layout(items)).toEqual([
+    { top: 0, height: 100, left: 3493, width: 236 },
+    { top: 0, height: 120, left: 3743, width: 236 },
+    { top: 0, height: 80, left: 3993, width: 236 },
+    { top: 0, height: 100, left: 4243, width: 236 },
   ]);
 });
 

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -23,8 +23,8 @@ const stubCache = (measurements?: { [item: string]: number, ... } = {}) => {
 test('empty', () => {
   const items: Array<string> = [];
   const layout = defaultLayout({
+    align: 'start',
     cache: stubCache(),
-    justify: 'start',
     layout: 'basic',
     rawItemCount: items.length,
     width: 486,
@@ -36,8 +36,8 @@ test('one row', () => {
   const measurements = { a: 100, b: 120, c: 80 };
   const items = ['a', 'b', 'c'];
   const layout = defaultLayout({
+    align: 'start',
     cache: stubCache(measurements),
-    justify: 'start',
     layout: 'basic',
     rawItemCount: items.length,
     width: 736,
@@ -53,8 +53,8 @@ test('wrapping items', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'start',
     cache: stubCache(measurements),
-    justify: 'start',
     layout: 'basic',
     rawItemCount: items.length,
     width: 486,
@@ -71,8 +71,8 @@ test('left-aligns grid within the viewport', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'start',
     cache: stubCache(measurements),
-    justify: 'start',
     layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
@@ -90,8 +90,8 @@ test('centers grid within the viewport, left align', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'center',
     cache: stubCache(measurements),
-    justify: 'center',
     layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
@@ -109,8 +109,8 @@ test('centers grid within the viewport, center align', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'center',
     cache: stubCache(measurements),
-    justify: 'center',
     layout: 'basicCentered',
     minCols: 2,
     rawItemCount: items.length,
@@ -128,8 +128,8 @@ test('right-aligns grid within the viewport', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'end',
     cache: stubCache(measurements),
-    justify: 'end',
     layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
@@ -147,8 +147,8 @@ test('floors values when centering', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
+    align: 'start',
     cache: stubCache(measurements),
-    justify: 'start',
     layout: 'basic',
     rawItemCount: items.length,
     width: 501,
@@ -166,7 +166,7 @@ test('only centers when theres extra space', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
-    justify: 'start',
+    align: 'start',
     layout: 'basic',
     rawItemCount: items.length,
     width: 200,
@@ -183,13 +183,13 @@ test('justify', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
 
-  const makeLayout = (justify: 'center' | 'start') =>
+  const makeLayout = (align: 'center' | 'start') =>
     defaultLayout({
+      align,
       cache: stubCache(measurements),
       columnWidth: 100,
       gutter: 0,
-      justify,
-      layout: justify === 'center' ? 'basicCentered' : 'basic',
+      layout: align === 'center' ? 'basicCentered' : 'basic',
       width: 1000,
       rawItemCount: items.length,
     })(items);

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -93,10 +93,10 @@ test('centers grid within the viewport', () => {
     width: 8000,
   });
   expect(layout(items)).toEqual([
-    { top: 0, height: 100, left: 3493, width: 236 },
-    { top: 0, height: 120, left: 3743, width: 236 },
-    { top: 0, height: 80, left: 3993, width: 236 },
-    { top: 0, height: 100, left: 4243, width: 236 },
+    { top: 0, height: 100, left: 3507, width: 236 },
+    { top: 0, height: 120, left: 3757, width: 236 },
+    { top: 0, height: 80, left: 4007, width: 236 },
+    { top: 0, height: 100, left: 4257, width: 236 },
   ]);
 });
 

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 import defaultLayout from './defaultLayout';
 
-const stubCache = (measurements?: { [item: string]: number, ... } = {}) => {
+const stubCache = (measurements?: { [item: string]: number, ... } = { }) => {
   let cache = measurements;
 
   return {
@@ -69,20 +69,20 @@ test('centers grid within the viewport', () => {
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
-    justify: 'start',
+    justify: 'center',
     minCols: 2,
     rawItemCount: items.length,
     width: 8000,
   });
   expect(layout(items)).toEqual([
-    { top: 0, height: 100, left: 7, width: 236 },
-    { top: 0, height: 120, left: 257, width: 236 },
-    { top: 0, height: 80, left: 507, width: 236 },
-    { top: 0, height: 100, left: 757, width: 236 },
+    { top: 0, height: 100, left: 3493, width: 236 },
+    { top: 0, height: 120, left: 3743, width: 236 },
+    { top: 0, height: 80, left: 3993, width: 236 },
+    { top: 0, height: 100, left: 4243, width: 236 },
   ]);
 });
 
-test('floors values when centering', () => {
+test('left align grid within the viewport', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
@@ -92,10 +92,10 @@ test('floors values when centering', () => {
     width: 501,
   });
   expect(layout(items)).toEqual([
-    { top: 0, height: 100, left: 7, width: 236 },
-    { top: 0, height: 120, left: 257, width: 236 },
-    { top: 114, height: 80, left: 7, width: 236 },
-    { top: 134, height: 100, left: 257, width: 236 },
+    { top: 0, height: 100, left: 0, width: 236 },
+    { top: 0, height: 120, left: 250, width: 236 },
+    { top: 114, height: 80, left: 0, width: 236 },
+    { top: 134, height: 100, left: 250, width: 236 },
   ]);
 });
 

--- a/packages/gestalt/src/Masonry/defaultLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.js
@@ -25,6 +25,7 @@ test('empty', () => {
   const layout = defaultLayout({
     cache: stubCache(),
     justify: 'start',
+    layout: 'basic',
     rawItemCount: items.length,
     width: 486,
   });
@@ -37,6 +38,7 @@ test('one row', () => {
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'start',
+    layout: 'basic',
     rawItemCount: items.length,
     width: 736,
   });
@@ -53,6 +55,7 @@ test('wrapping items', () => {
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'start',
+    layout: 'basic',
     rawItemCount: items.length,
     width: 486,
   });
@@ -70,6 +73,7 @@ test('left-aligns grid within the viewport', () => {
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'start',
+    layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
     width: 8000,
@@ -88,15 +92,16 @@ test('centers grid within the viewport', () => {
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'center',
+    layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
     width: 8000,
   });
   expect(layout(items)).toEqual([
-    { top: 0, height: 100, left: 3507, width: 236 },
-    { top: 0, height: 120, left: 3757, width: 236 },
-    { top: 0, height: 80, left: 4007, width: 236 },
-    { top: 0, height: 100, left: 4257, width: 236 },
+    { top: 0, height: 100, left: 7, width: 236 },
+    { top: 0, height: 120, left: 257, width: 236 },
+    { top: 0, height: 80, left: 507, width: 236 },
+    { top: 0, height: 100, left: 757, width: 236 },
   ]);
 });
 
@@ -106,6 +111,7 @@ test('right-aligns grid within the viewport', () => {
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'end',
+    layout: 'basic',
     minCols: 2,
     rawItemCount: items.length,
     width: 8000,
@@ -118,12 +124,31 @@ test('right-aligns grid within the viewport', () => {
   ]);
 });
 
+test('floors values when centering', () => {
+  const measurements = { a: 100, b: 120, c: 80, d: 100 };
+  const items = ['a', 'b', 'c', 'd'];
+  const layout = defaultLayout({
+    cache: stubCache(measurements),
+    justify: 'start',
+    layout: 'basic',
+    rawItemCount: items.length,
+    width: 501,
+  });
+  expect(layout(items)).toEqual([
+    { top: 0, height: 100, left: 0, width: 236 },
+    { top: 0, height: 120, left: 250, width: 236 },
+    { top: 114, height: 80, left: 0, width: 236 },
+    { top: 134, height: 100, left: 250, width: 236 },
+  ]);
+});
+
 test('only centers when theres extra space', () => {
   const measurements = { a: 100, b: 120, c: 80, d: 100 };
   const items = ['a', 'b', 'c', 'd'];
   const layout = defaultLayout({
     cache: stubCache(measurements),
     justify: 'start',
+    layout: 'basic',
     rawItemCount: items.length,
     width: 200,
   });
@@ -145,6 +170,7 @@ test('justify', () => {
       columnWidth: 100,
       gutter: 0,
       justify,
+      layout: justify === 'center' ? 'basicCentered' : 'basic',
       width: 1000,
       rawItemCount: items.length,
     })(items);

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -2,7 +2,7 @@
 import { type Cache } from './Cache';
 import Graph from './Graph';
 import mindex from './mindex';
-import { type Justify, type NodeData, type Position } from './types';
+import { type Align, type NodeData, type Position } from './types';
 
 // When there's a multi column item in the most recently fetched batch of items, we need to measure more items to ensure we have enough possible layouts to minimize whitespace above the 2-col item
 // This may need to be tweaked to balance the tradeoff of delayed rendering vs having enough possible layouts
@@ -535,9 +535,9 @@ function getPositionsWithMultiColumnItem<T: { +[string]: mixed }>({
 }
 
 const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
+  align,
   columnWidth = 236,
   gutter = 14,
-  justify,
   logWhitespace,
   measurementCache,
   minCols = 2,
@@ -546,9 +546,9 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
   width,
   whitespaceThreshold,
 }: {
+  align: Align,
   columnWidth?: number,
   gutter?: number,
-  justify: Justify,
   logWhitespace?: (number) => void,
   measurementCache: Cache<T, number>,
   minCols?: number,
@@ -574,7 +574,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
     }
 
     const centerOffset =
-      justify === 'center'
+      align === 'center'
         ? Math.max(
             Math.floor(
               (width - (Math.min(rawItemCount, columnCount) * columnWidthAndGutter + gutter)) / 2,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -2,7 +2,7 @@
 import { type Cache } from './Cache';
 import Graph from './Graph';
 import mindex from './mindex';
-import { type NodeData, type Position } from './types';
+import { type Justify, type NodeData, type Position } from './types';
 
 // When there's a multi column item in the most recently fetched batch of items, we need to measure more items to ensure we have enough possible layouts to minimize whitespace above the 2-col item
 // This may need to be tweaked to balance the tradeoff of delayed rendering vs having enough possible layouts
@@ -548,7 +548,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
 }: {
   columnWidth?: number,
   gutter?: number,
-  justify: 'center' | 'start',
+  justify: Justify,
   logWhitespace?: (number) => void,
   measurementCache: Cache<T, number>,
   minCols?: number,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.test.js
@@ -19,9 +19,9 @@ describe('defaultLayout test cases', () => {
     const items: $ReadOnlyArray<Item> = [];
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       rawItemCount: items.length,
       width: 486,
     });
@@ -41,9 +41,9 @@ describe('defaultLayout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       rawItemCount: items.length,
       width: 736,
     });
@@ -68,9 +68,9 @@ describe('defaultLayout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       rawItemCount: items.length,
       width: 486,
     });
@@ -96,9 +96,9 @@ describe('defaultLayout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       minCols: 2,
       rawItemCount: items.length,
       width: 8000,
@@ -125,9 +125,9 @@ describe('defaultLayout test cases', () => {
       measurementStore.set(item, item.height);
     });
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       rawItemCount: items.length,
       width: 501,
     });
@@ -153,9 +153,9 @@ describe('defaultLayout test cases', () => {
       measurementStore.set(item, item.height);
     });
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       measurementCache: measurementStore,
       positionCache,
-      justify: 'start',
       rawItemCount: items.length,
       width: 200,
     });
@@ -181,13 +181,13 @@ describe('defaultLayout test cases', () => {
       measurementStore.set(item, item.height);
     });
 
-    const makeLayout = (justify: 'center' | 'start') =>
+    const makeLayout = (align: 'center' | 'start') =>
       defaultTwoColumnModuleLayout({
+        align,
         measurementCache: measurementStore,
         positionCache,
         columnWidth: 100,
         gutter: 0,
-        justify,
         width: 1000,
         rawItemCount: items.length,
       })(items);
@@ -233,9 +233,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -329,9 +329,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -427,9 +427,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -467,9 +467,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -537,9 +537,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 5,
       positionCache,
       rawItemCount: items.length,
@@ -608,9 +608,9 @@ describe('multi column layout test cases', () => {
     ];
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -641,9 +641,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -709,9 +709,9 @@ describe('multi column layout test cases', () => {
     });
 
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth: 240,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 5,
       positionCache,
       rawItemCount: items.length,
@@ -771,10 +771,10 @@ describe('multi column layout test cases', () => {
       const screenWidth = 1500;
 
       const layout = defaultTwoColumnModuleLayout({
+        align: 'start',
         columnWidth,
         gutter: 0,
         measurementCache: measurementStore,
-        justify: 'start',
         minCols: 3,
         positionCache,
         rawItemCount: items.length,
@@ -826,10 +826,10 @@ describe('multi column layout test cases', () => {
       const screenWidth = 720;
 
       const layout = defaultTwoColumnModuleLayout({
+        align: 'start',
         columnWidth,
         gutter: 0,
         measurementCache: measurementStore,
-        justify: 'start',
         minCols: 3,
         positionCache,
         rawItemCount: items.length,
@@ -890,7 +890,7 @@ describe('initializeHeightsArray', () => {
       columnWidth,
       gutter,
       measurementCache: measurementStore,
-      justify: 'start',
+      align: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,
@@ -970,10 +970,10 @@ describe('initializeHeightsArray', () => {
       measurementStore.set(item, item.height);
     });
     const layout = defaultTwoColumnModuleLayout({
+      align: 'start',
       columnWidth,
       gutter,
       measurementCache: measurementStore,
-      justify: 'start',
       minCols: 3,
       positionCache,
       rawItemCount: items.length,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.js
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.js
@@ -51,11 +51,11 @@ export default function getLayoutAlgorithm<T: { +[string]: mixed }>({
   }
   if (_twoColItems === true) {
     return defaultTwoColumnModuleLayout({
+      align: layout === 'basicCentered' ? 'center' : 'start',
       measurementCache: measurementStore,
       positionCache: positionStore,
       columnWidth,
       gutter,
-      justify: layout === 'basicCentered' ? 'center' : 'start',
       logWhitespace: _logTwoColWhitespace,
       minCols,
       rawItemCount: items.length,
@@ -63,10 +63,10 @@ export default function getLayoutAlgorithm<T: { +[string]: mixed }>({
     });
   }
   return defaultLayout({
+    align,
     cache: measurementStore,
     columnWidth,
     gutter,
-    justify: align,
     layout,
     minCols,
     rawItemCount: items.length,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.js
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.js
@@ -3,10 +3,11 @@ import { type Cache } from './Cache';
 import defaultLayout from './defaultLayout';
 import defaultTwoColumnModuleLayout from './defaultTwoColumnModuleLayout';
 import fullWidthLayout from './fullWidthLayout';
-import { type Layout, type Position } from './types';
+import { type Align, type Layout, type Position } from './types';
 import uniformRowLayout from './uniformRowLayout';
 
 export default function getLayoutAlgorithm<T: { +[string]: mixed }>({
+  align,
   columnWidth,
   gutter,
   items,
@@ -18,6 +19,7 @@ export default function getLayoutAlgorithm<T: { +[string]: mixed }>({
   _twoColItems,
   _logTwoColWhitespace,
 }: {
+  align: Align,
   columnWidth: number,
   gutter?: number,
   items: $ReadOnlyArray<T>,
@@ -64,7 +66,8 @@ export default function getLayoutAlgorithm<T: { +[string]: mixed }>({
     cache: measurementStore,
     columnWidth,
     gutter,
-    justify: layout === 'basicCentered' ? 'center' : 'start',
+    justify: align,
+    layout,
     minCols,
     rawItemCount: items.length,
     width,

--- a/packages/gestalt/src/Masonry/types.js
+++ b/packages/gestalt/src/Masonry/types.js
@@ -13,6 +13,11 @@ export type NodeData<T> = {
   positions: $ReadOnlyArray<{ item: T, position: Position }>,
 };
 
+export type Justify = 
+  | 'start'
+  | 'center'
+  | 'end'
+
 export type Layout =
   | 'basic'
   | 'basicCentered'

--- a/packages/gestalt/src/Masonry/types.js
+++ b/packages/gestalt/src/Masonry/types.js
@@ -13,10 +13,7 @@ export type NodeData<T> = {
   positions: $ReadOnlyArray<{ item: T, position: Position }>,
 };
 
-export type Align =
-  | 'start'
-  | 'center'
-  | 'end'
+export type Align = 'start' | 'center' | 'end';
 
 export type Layout =
   | 'basic'

--- a/packages/gestalt/src/Masonry/types.js
+++ b/packages/gestalt/src/Masonry/types.js
@@ -13,7 +13,7 @@ export type NodeData<T> = {
   positions: $ReadOnlyArray<{ item: T, position: Position }>,
 };
 
-export type Justify = 
+export type Align =
   | 'start'
   | 'center'
   | 'end'

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -31,11 +31,13 @@ const layoutNumberToCssDimension = (n: ?number) => (n !== Infinity ? n : undefin
 
 type Props<T> = {
   /**
-   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
+   * Controls the horizontal alignment of items within the Masonry grid. The `align` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
    * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
    * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
    * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
-   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   * Using the `align` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   *
+   * _Note that layout='basic' must be set for align to take effect._
    */
   align?: Align,
   /**

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -21,7 +21,7 @@ import { MULTI_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/defaultTwoColumnMo
 import getLayoutAlgorithm from './Masonry/getLayoutAlgorithm';
 import MeasurementStore from './Masonry/MeasurementStore';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
-import { type Layout, type Position } from './Masonry/types';
+import { type Align, type Layout, type Position } from './Masonry/types';
 import throttle from './throttle';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
@@ -30,6 +30,14 @@ const RESIZE_DEBOUNCE = 300;
 const layoutNumberToCssDimension = (n: ?number) => (n !== Infinity ? n : undefined);
 
 type Props<T> = {
+  /**
+   * Controls the horizontal alignment of items within the Masonry grid. The `justify` property determines how items are aligned along the main-axis (horizontally) across multiple columns.
+   * `start`: Aligns items to the start of the Masonry container. This is the default behavior where items are placed starting from the left side of the container.
+   * `center`: Centers items in the Masonry grid. This will adjust the spacing on either side of the grid to ensure that the items are centered within the container.
+   * `end`: Aligns items to the end of the Masonry container. Items will be placed starting from the right, moving leftwards, which may leave space on the left side of the container.
+   * Using the `justify` property can help control the visual balance and alignment of the grid, especially in responsive layouts or when dealing with varying item widths.
+   */
+  align?: Align,
   /**
    * The preferred/target item width in pixels. If `layout="flexible"` is set, the item width will
    * grow to fill column space, and shrink to fit if below the minimum number of columns.
@@ -296,6 +304,7 @@ function useFetchOnScroll({
 }
 
 function useLayout<T: { +[string]: mixed }>({
+  align,
   columnWidth,
   gutter,
   items,
@@ -308,6 +317,7 @@ function useLayout<T: { +[string]: mixed }>({
   _logTwoColWhitespace,
   _measureAll,
 }: {
+  align: Align,
   columnWidth: number,
   gutter?: number,
   items: $ReadOnlyArray<T>,
@@ -332,6 +342,7 @@ function useLayout<T: { +[string]: mixed }>({
       .some((item) => typeof item.columnSpan === 'number' && item.columnSpan > 1);
   const itemToMeasureCount = hasMultiColumnItems ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
   const layoutFunction = getLayoutAlgorithm({
+    align,
     columnWidth,
     gutter,
     items,
@@ -530,6 +541,7 @@ const MasonryItemMemo = memo(MasonryItem);
 
 function Masonry<T: { +[string]: mixed }>(
   {
+    align = 'center',
     columnWidth = 236,
     gutterWidth: gutter,
     items,
@@ -618,6 +630,7 @@ function Masonry<T: { +[string]: mixed }>(
   }, [width]);
 
   const { hasPendingMeasurements, height, positions, updateMeasurement } = useLayout({
+    align,
     columnWidth,
     gutter,
     items,


### PR DESCRIPTION
## Pull Request Template

### Summary
#### Issue
When layout is set to `basic`, the docs state that the grid will be "Left-aligned, fixed-column-width masonry layout." This wasn't the case, due to `gutterWidth` pushing the items away from the left side. When `gutterWidth` is set to `0`, it is appropriately left aligned, but then you have no gutter spacing between pins. 

Additionally, center alignment was miscalculated due to the inclusion of an extra gutter (e.g. when you have 4 columns, you should only calculate 3 `gutterWidths` for the `contentWidth`)

#### What changed?

I've introduced a new optional prop `justify` which controls the horizontal alignment of items within the Masonry grid.
This change affects both Masonry and MasonryV2

## Center Alignment
Center alignment was slightly off, due to an extra `gutter` being calculated
| Before | After |
|--------|--------|
| ![Kapture 2024-05-13 at 15 20 07](https://github.com/pinterest/gestalt/assets/6954364/8dc2437b-f904-4452-8bf0-7a528f4cc4db) | ![Kapture 2024-05-13 at 15 17 52](https://github.com/pinterest/gestalt/assets/6954364/3b155907-a295-48e0-9975-b7ef4879882c) | 

## Start Alignment
We were center aligning before, we are now properly start aligning when `justify='start'` is set
| Before | After |
|--------|--------|
| ![Kapture 2024-05-13 at 15 20 07](https://github.com/pinterest/gestalt/assets/6954364/8dc2437b-f904-4452-8bf0-7a528f4cc4db)| ![Kapture 2024-05-13 at 15 22 06](https://github.com/pinterest/gestalt/assets/6954364/77f31057-35ee-4934-aad3-c00a5e6df98c)|

## End Alignment
End alignment didn't exist previously
| Before | After |
|--------|--------|
| Did not exist | ![Kapture 2024-05-13 at 15 23 56](https://github.com/pinterest/gestalt/assets/6954364/64c83637-ee94-4b0b-b07c-99c2370d0899) | 

#### Why?

This change is needed for situations where we need the Masonry to be left aligned to match other Pin Grid formats (e.g. aligning Modules with PinReps with the Masonry).

This image highlights an issue we have, where the left aligned title looks disjointed from the Masonry grid.
<img width="462" alt="image" src="https://github.com/pinterest/gestalt/assets/6954364/365bec9b-c845-48ee-93f7-a86eae87485c">


### Links

- [Jira](https://jira.pinadmin.com/browse/CLOSEUP-1896)
- [Figma](https://www.figma.com/design/oB4UJiu8pONgAakK1tgPte/%F0%9F%90%B6-dWeb-Closeup-N-Column-Grid?node-id=159-96421&t=Ovx4hMTU2958Ot89-0)

### Checklist

- [x] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
