### PR TITLE
SideNavigation: Use TransitionEvent

### DIFF
--- a/packages/gestalt/src/SideNavigation/NavigationContent.js
+++ b/packages/gestalt/src/SideNavigation/NavigationContent.js
@@ -43,8 +43,8 @@ export default function NavigationContent({
   } = useSideNavigation();
 
   const mainContainer = useRef<HTMLElement | null>(null);
-  const transitionContainer = useRef<HTMLElement | null>(null);
   const scrollContainer = useRef<HTMLDivElement | null>(null);
+  const transitionContainer = useRef<HTMLElement | null>(null);
   const [isScrolled, setIsScrolled] = useState(false);
   const [collapsedContainerWidth, setCollapsedContainerWidth] = useState<number | void>();
   const previewTimeoutRef = useRef<?Timeout>();

--- a/packages/gestalt/src/SideNavigation/NavigationContent.js
+++ b/packages/gestalt/src/SideNavigation/NavigationContent.js
@@ -39,13 +39,27 @@ export default function NavigationContent({
     overlayPreview,
     setOverlayPreview,
     transitioning,
+    setTransitioning,
   } = useSideNavigation();
 
   const mainContainer = useRef<HTMLElement | null>(null);
+  const transitionContainer = useRef<HTMLElement | null>(null);
   const scrollContainer = useRef<HTMLDivElement | null>(null);
   const [isScrolled, setIsScrolled] = useState(false);
   const [collapsedContainerWidth, setCollapsedContainerWidth] = useState<number | void>();
   const previewTimeoutRef = useRef<?Timeout>();
+
+  useEffect(() => {
+    const element = transitionContainer.current;
+
+    const transitionEndHandler = ({ target }: Event) => {
+      if (target === element) setTransitioning(false);
+    };
+
+    element?.addEventListener('transitionend', transitionEndHandler);
+
+    return () => element?.removeEventListener('transitionend', transitionEndHandler);
+  }, [setTransitioning]);
 
   useEffect(() => {
     const element = scrollContainer.current;
@@ -71,7 +85,6 @@ export default function NavigationContent({
     element?.addEventListener('mouseleave', mouseLeaveHandler);
 
     return () => {
-      clearTimeout(previewTimeoutRef.current);
       element?.removeEventListener('scroll', scrollHandler);
       element?.removeEventListener('mouseenter', mouseEnterHandler);
       element?.removeEventListener('mouseleave', mouseLeaveHandler);
@@ -112,13 +125,13 @@ export default function NavigationContent({
         className={classnames(styles.fullHeight, layoutStyles.overflowAutoY, {
           [borderStyles.borderRight]: showBorder && !overlayPreview,
           [borderStyles.raisedBottom]: overlayPreview,
-          [styles.contentWidthTransition]: collapsible,
           [boxStyles.default]: collapsible,
         })}
         style={{ width: collapsible ? 'max-content' : undefined }}
       >
         {/* 3rd wrapper - when collapsible=true, it has static width and responsible for expand/collpase transition */}
         <div
+          ref={transitionContainer}
           className={classnames({ [styles.contentWidthTransition]: collapsible })}
           style={{ width: collapsible ? contentWidth : undefined }}
         >

--- a/packages/gestalt/src/contexts/SideNavigationProvider.js
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.js
@@ -5,15 +5,12 @@ import {
   type Element,
   type Node as ReactNode,
   useContext,
-  useRef,
   useState,
 } from 'react';
 
 export interface Indexable {
   index(): number;
 }
-
-type Timeout = ReturnType<typeof setTimeout>;
 
 type SideNavigationContextType = {
   selectedItemId: string,
@@ -28,6 +25,7 @@ type SideNavigationContextType = {
   collapsed?: boolean,
   onCollapse?: (boolean) => void,
   transitioning?: boolean,
+  setTransitioning: (boolean) => void,
   dismissButton?: {
     accessibilityLabel?: string,
     onDismiss: () => void,
@@ -48,8 +46,6 @@ type Props = {
   onPreview?: (boolean) => void,
 };
 
-const COLLAPSE_TRANSITION_DURATION = 200; // .2s
-
 const SideNavigationContext: Context<SideNavigationContextType> =
   createContext<SideNavigationContextType>({
     selectedItemId: '',
@@ -60,6 +56,7 @@ const SideNavigationContext: Context<SideNavigationContextType> =
     setHideActiveChildren: () => {},
     overlayPreview: false,
     setOverlayPreview: () => {},
+    setTransitioning: () => {},
   });
 
 const { Provider, Consumer: SideNavigationConsumer } = SideNavigationContext;
@@ -78,25 +75,13 @@ function SideNavigationProvider({
   const [overlayPreview, setOverlayPreviewCb] = useState(false);
   const [transitioning, setTransitioning] = useState(false);
 
-  const transitionTimeoutRef = useRef<?Timeout>();
-
-  const handleTransition = () => {
-    setTransitioning(true);
-    clearTimeout(transitionTimeoutRef.current);
-
-    transitionTimeoutRef.current = setTimeout(
-      () => setTransitioning(false),
-      COLLAPSE_TRANSITION_DURATION,
-    );
-  };
-
   const onCollapse = (state: boolean) => {
-    if (collapsed !== state) handleTransition();
+    if (collapsed !== state) setTransitioning(true);
     onCollapseProp?.(state);
   };
 
   const setOverlayPreview = (state: boolean) => {
-    if (overlayPreview !== state) handleTransition();
+    if (overlayPreview !== state) setTransitioning(true);
     setOverlayPreviewCb(state);
     onPreview?.(state);
   };
@@ -115,6 +100,7 @@ function SideNavigationProvider({
     collapsed,
     onCollapse,
     transitioning,
+    setTransitioning,
   };
 
   return <Provider value={sideNavigationContext}>{children}</Provider>;


### PR DESCRIPTION
### Summary

Replaced `setTimeout` logic with `transitionend` event. So that the transition duration is independent from JS code.
This also ensures that `transitioning` is set to `true` only when the transition is indeed ended (not when the timer signals so).

#### Why?

So that the transition duration is kept only in the CSS code.

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
