### PR TITLE
Masonry: Fix multi-column issues

### DIFF
--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -637,7 +637,7 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
         (acc, itemsInBatch, i) =>
           getPositionsWithMultiColumnItem({
             multiColumnItem: multiColumnItems[i],
-            itemsToPosition: itemsInBatch.filter((item) => !positionCache.get(item)),
+            itemsToPosition: itemsInBatch.filter((item) => !positionCache.has(item)),
             heights: acc.heights,
             prevPositions: acc.positions,
             whitespaceThreshold,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -613,12 +613,12 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
       const batchSize = multiColumnItems.length;
       const batches = Array.from({ length: batchSize }, (): $ReadOnlyArray<T> => []).map(
         (batch, i) => {
-          const startIndex = i === 0 ? 0 : items.indexOf(multiColumnItems[i]);
+          const startIndex = i === 0 ? 0 : itemsWithoutPositions.indexOf(multiColumnItems[i]);
           const endIndex =
             i + 1 === multiColumnItems.length
-              ? items.length
-              : items.indexOf(multiColumnItems[i + 1]);
-          return items.slice(startIndex, endIndex);
+              ? itemsWithoutPositions.length
+              : itemsWithoutPositions.indexOf(multiColumnItems[i + 1]);
+          return itemsWithoutPositions.slice(startIndex, endIndex);
         },
       );
       const { positions: paintedItemPositions, heights: paintedItemHeights } =
@@ -634,10 +634,10 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
         heights: $ReadOnlyArray<number>,
         positions: $ReadOnlyArray<{ item: T, position: Position }>,
       } = batches.reduce(
-        (acc, itemsInBatch, i) =>
+        (acc, itemsToPosition, i) =>
           getPositionsWithMultiColumnItem({
             multiColumnItem: multiColumnItems[i],
-            itemsToPosition: itemsInBatch.filter((item) => !positionCache.has(item)),
+            itemsToPosition,
             heights: acc.heights,
             prevPositions: acc.positions,
             whitespaceThreshold,

--- a/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
+++ b/packages/gestalt/src/Masonry/defaultTwoColumnModuleLayout.js
@@ -634,10 +634,10 @@ const defaultTwoColumnModuleLayout = <T: { +[string]: mixed }>({
         heights: $ReadOnlyArray<number>,
         positions: $ReadOnlyArray<{ item: T, position: Position }>,
       } = batches.reduce(
-        (acc, itemsToPosition, i) =>
+        (acc, itemsInBatch, i) =>
           getPositionsWithMultiColumnItem({
             multiColumnItem: multiColumnItems[i],
-            itemsToPosition,
+            itemsToPosition: itemsInBatch.filter((item) => !positionCache.get(item)),
             heights: acc.heights,
             prevPositions: acc.positions,
             whitespaceThreshold,

--- a/packages/gestalt/src/MasonryV2.js
+++ b/packages/gestalt/src/MasonryV2.js
@@ -330,7 +330,7 @@ function useLayout<T: { +[string]: mixed }>({
     items
       .filter((item) => item && !positionStore.has(item))
       .some((item) => typeof item.columnSpan === 'number' && item.columnSpan > 1);
-  const itemToMeasureCount = hasMultiColumnItems ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE : minCols;
+  const itemToMeasureCount = hasMultiColumnItems ? MULTI_COL_ITEMS_MEASURE_BATCH_SIZE + 1 : minCols;
   const layoutFunction = getLayoutAlgorithm({
     columnWidth,
     gutter,


### PR DESCRIPTION
# Summary
This PR addresses two issues I noticed with the multi-column layout, specifically on MasonryV2

## Positioning was inconsistent with V1
In https://github.com/pinterest/gestalt/pull/3530/, we updated the measure batch size for multi-column to be `MULTI_COL_ITEMS_MEASURE_BATCH_SIZE` + 1 for `Masonry` but did not apply the same change to V2. This was causing multi-column positioning to be different between the two

## Incorrect layout on resize
I also noticed that https://github.com/pinterest/gestalt/pull/3545 introduced a scenario where the layout function can return _more_ positions than items, depending on what's already in the position cache. 
![image](https://github.com/pinterest/gestalt/assets/6487551/47cf5b68-d4ea-4c0d-99b9-062288ada425)

This is not a big deal for Masonry but it does affect V2 since we assume that if there are no items in the positionCache, we fall back to position by index. This PR addresses the issue by filtering out items that are already in the position cache - this was actually the original intent, but was lost after the post-code review refactor: https://github.com/pinterest/gestalt/pull/3545/files/c5b9ed65188629c036fa5db23af3eb88d1cc727c

![image](https://github.com/pinterest/gestalt/assets/6487551/df43d22f-eccf-49a2-bc50-7ae6df3e2b2c)
