### PR TITLE
Popover: Flip direction after shifting

### DIFF
--- a/packages/gestalt/src/Popover/Contents.js
+++ b/packages/gestalt/src/Popover/Contents.js
@@ -60,6 +60,7 @@ export default function Contents({
   const { refs, placement, floatingStyles, middlewareData, context, isPositioned } = usePopover({
     anchor,
     caretElement: caretRef.current,
+    caretPadding: rounding && rounding * 4,
     direction: idealPlacement,
     scrollBoundary,
     hideWhenReferenceHidden,

--- a/packages/gestalt/src/Popover/usePopover.js
+++ b/packages/gestalt/src/Popover/usePopover.js
@@ -43,6 +43,10 @@ interface Props {
    */
   caretElement?: HTMLElement | null;
   /**
+   * Padding between caret and the *edges* of Popover. This will prevent caret from overflowing the corners
+   */
+  caretPadding?: number;
+  /**
    * Container element in which Popover flips directions or shifts itself upon reaching its viewport boundaries.
    * Default is window viewport.
    */
@@ -69,6 +73,7 @@ interface Props {
 export default function usePopover({
   anchor,
   caretElement,
+  caretPadding,
   direction,
   strategy,
   scrollBoundary,
@@ -85,7 +90,7 @@ export default function usePopover({
   // Hides popover when anchor is outside of viewport. Padding is negative so that it compensates for `popoverOffset`
   const popoverHide = hideWhenReferenceHidden && hide({ padding: -POPOVER_OFFSET_VALUE });
   // Calculates the positon of caret
-  const popoverArrow = caretElement && arrow({ element: caretElement });
+  const popoverArrow = caretElement && arrow({ element: caretElement, padding: caretPadding });
   // Flips popover direction based on available space
   const popoverFlip = flip({
     boundary: scrollBoundary,
@@ -94,7 +99,6 @@ export default function usePopover({
   // Shifts popover to prevent clipping near viewport edges
   const popoverShift = shift({
     padding: 8,
-    crossAxis: false,
     boundary: scrollBoundary,
     limiter: limitShift({
       offset: 5,
@@ -111,8 +115,8 @@ export default function usePopover({
     // Do not reorder middlewares! Order is important as the calculations are passed along
     middleware: [
       popoverOffset,
-      isForceDown ? undefined : popoverFlip,
       popoverShift,
+      isForceDown ? undefined : popoverFlip,
       popoverArrow,
       popoverHide,
     ],


### PR DESCRIPTION
### Summary

Popover is getting flipped before it can shift as much as it can. Popover needs to "shift" itself relative to the anchor to stay in the viewport. However, Popover is getting "flipped" to other direction because "flip" calculation is done BEFORE "shift". 

That's why "flip" middleware needs to be put after "shift". So that Popover can stay in the initial direction as long as possible before it flips.

### Before
![ezgif-3-e40ba9eb99](https://github.com/pinterest/gestalt/assets/29589560/4045c97a-e46e-4452-8995-b70fa256682c)

### After
![ezgif-6-439a6bed9a](https://github.com/pinterest/gestalt/assets/29589560/d1040882-ec92-49d1-b58e-a1871cc49d48)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit and Flow Tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
