### PR TITLE
Internal: add temporary files to ignore lists

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+coverage
 docs/.next
 docs/docs-components/metadata.js
 flow-typed

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ playwright/test-results
 
 .rollup.cache/
 
+# TypeScript build info file https://www.typescriptlang.org/tsconfig#tsBuildInfoFile
+*.tsbuildinfo
+
 # Local Netlify folder
 .netlify

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ packages/gestalt-design-tokens/dist
 
 playwright/test-results
 
+.rollup.cache/
+
 # Local Netlify folder
 .netlify

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,4 @@ flow-typed
 node_modules
 package.json
 docs/graphics/year-in-review-2023/lottie/*.json
-
+.rollup.cache/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         },
         "testPathIgnorePatterns": [
           "/node_modules/",
+          "/.rollup.cache/",
           "<rootDir>/scripts/templates/",
           "jsdom.test.js",
           "<rootDir>/packages/gestalt-codemods/generic-codemods/__tests__/utils.js"
@@ -164,6 +165,7 @@
         },
         "testPathIgnorePatterns": [
           "/node_modules/",
+          "/.rollup.cache/",
           "<rootDir>/scripts/templates/",
           "<rootDir>/packages/gestalt-codemods",
           "<rootDir>/packages/gestalt-core"


### PR DESCRIPTION
## What changed?

Add temporary files to ignore list:

- `coverage/`
- `.rollup.cache/`
- `*.tsbuildinfo`

## Why?

These files get auto-generated when we run CI commands (or `tsc` for TypeScript type checking) locally, and we should generally ignore these files (when we lint, format, commit, ...etc)
