### PR TITLE
Internal: change runs-on from macos-12 to ubuntu-latest

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,7 +10,7 @@ jobs:
   playwright-run:
     name: Test (${{ matrix.shard }})
     timeout-minutes: 60
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed?

Change the OS which the playwright tests run on from MacOS 12 (Mac) to Ubuntu (Linux).

## Why?

In [TypeScript migration](https://github.com/pinterest/gestalt/pull/3567), `yarn build` in CI consistently finished, but not in Playwright. The `yarn build` for playwright sometimes get stuck. After some investigation, I realized that this is not independent to which tests we run, and only depends on which OS the `yarn build` runs on. Regardlessly if it's Playwright workflow (`playwright.yml`) or CI workflow (`ci.yml`), the build would get stuck MacOS 12 and MacOS 14 but consistently finish in Ubuntu.

To unblock TypeScript migration, I'd like to change the OS which Playwright tests run on from MacOS to Ubuntu. 
