### PR TITLE
Docs: Removed deprecated links from accessibility

### DIFF
--- a/docs/pages/foundations/accessibility.js
+++ b/docs/pages/foundations/accessibility.js
@@ -147,12 +147,6 @@ export default function AccessibilityGuidelinesPage(): ReactNode {
       <MainSection name="Further learning">
         <MainSection.Subsection
           description={`
-        **[Web Accessibility Wiki](https://w.pinadmin.com/display/WT/Accessibility)**
-        Learn more about or web accessibility efforts, best practices, and [Web Accessibility Integration Tests](https://w.pinadmin.com/display/WT/Web+Accessibility+Integration+Tests).
-
-        **[Product Accessibility Working Group](http://pinch.pinadmin.com/productAccessibilityWorkingGroup)**
-        Details about the accessibility working group, including success metrics and project statuses.
-
         **[Accessible Design](https://docs.google.com/presentation/d/1b-L0tuzaMTIf1xX7j86g46QfDW3_C0Ep_Ca4TEmXPz8/edit#slide=id.gcf38b911e3_0_750)**
         Checkout our Accessible Design deck for examples and recommendations regarding accessibility at the design phase.
 


### PR DESCRIPTION
#### What changed?

Removed deprecated links from accessibility docs (Web Accessibility Wiki, Product Accessibility Working Group)

![Screenshot 2024-05-16 at 12 58 39 PM](https://github.com/pinterest/gestalt/assets/99108792/2a465a13-85c5-44bb-9cf3-62949bf9d39e)
