### PR TITLE
Internal: playwright TypeScript types fixup

### DIFF
--- a/playwright/accessibility/expectAccessiblePage.ts
+++ b/playwright/accessibility/expectAccessiblePage.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 
 export default async function expectAccessiblePage(
   // @ts-expect-error - TS7031 - Binding element 'page' implicitly has an 'any' type. | TS7031 - Binding element 'rules' implicitly has an 'any' type.
-  { page, rules } /*: {| page: any, rules?: any |} */,
+  { page, rules },
 ) {
   const { violations } = await new AxeBuilder({ page })
     .options({ rules })

--- a/playwright/masonry/fetch-more.spec.ts
+++ b/playwright/masonry/fetch-more.spec.ts
@@ -7,7 +7,6 @@ test.describe('Masonry: fetch more', () => {
   test('trigger a call to "fetchMore" when container resizes', async ({ page }) => {
     // Start with a small screen.
     await page.setViewportSize({ width: 400, height: 400 });
-    // @ts-expect-error - TS2554 - Expected 1 arguments, but got 0.
     await page.goto(getServerURL());
     await waitForRenderedItems(page, { targetItemsGTE: 20 });
 

--- a/playwright/masonry/flexible-resize.spec.ts
+++ b/playwright/masonry/flexible-resize.spec.ts
@@ -6,7 +6,7 @@ import selectors from './utils/selectors';
 import waitForRenderedItems from './utils/waitForRenderedItems';
 
 // @ts-expect-error - TS7006 - Parameter 'gridItems' implicitly has an 'any' type.
-async function getItemColumnMap(gridItems /*: any */) {
+async function getItemColumnMap(gridItems) {
   const itemLeftMap: Record<string, any> = {};
   for (let i = 0; i < gridItems.length; i += 1) {
     const boundingBox = await gridItems[i].boundingBox();
@@ -34,11 +34,10 @@ test.describe('Masonry: flexible resize', () => {
     expect(gridItemsBefore.length).toBe(40);
 
     const itemRectsBefore = await Promise.all(
-      // @ts-expect-error - TS7006 - Parameter 'gridItemBefore' implicitly has an 'any' type.
       gridItemsBefore.map((gridItemBefore) => gridItemBefore.boundingBox()),
     );
     // expect(itemRectsBefore[0].width).toBe(266);
-    expect(itemRectsBefore[0].height).toBe(216);
+    expect(itemRectsBefore[0]?.height).toBe(216);
 
     // Check size of initial grid items.
     const originalItemMap = await getItemColumnMap(gridItemsBefore);
@@ -62,7 +61,7 @@ test.describe('Masonry: flexible resize', () => {
       },
       {
         selector: selectors.gridItem,
-        previousItemWidth: itemRectsBefore[0].width,
+        previousItemWidth: itemRectsBefore[0]?.width,
       },
       { polling: 'raf' },
     );
@@ -75,11 +74,10 @@ test.describe('Masonry: flexible resize', () => {
     expect(gridItemsAfter.length).toBe(40);
 
     const itemRectsAfter = await Promise.all(
-      // @ts-expect-error - TS7006 - Parameter 'gridItemAfter' implicitly has an 'any' type.
       gridItemsAfter.map((gridItemAfter) => gridItemAfter.boundingBox()),
     );
-    expect(itemRectsAfter[0].width).toBe(273);
-    expect(itemRectsAfter[0].height).toBe(216);
+    expect(itemRectsAfter[0]?.width).toBe(273);
+    expect(itemRectsAfter[0]?.height).toBe(216);
 
     // Get new sizes of grid items.
     const newItemMap = await getItemColumnMap(gridItemsAfter);
@@ -89,7 +87,7 @@ test.describe('Masonry: flexible resize', () => {
       const originalCol = originalItemMap[originalColumns[i]];
       const newCol = newItemMap[newColumns[i]];
       // @ts-expect-error - TS7006 - Parameter 'item' implicitly has an 'any' type. | TS7006 - Parameter 'row' implicitly has an 'any' type.
-      originalCol.forEach((item, row /*: number */) => {
+      originalCol.forEach((item, row) => {
         const newItem = newCol[row];
         expect(newItem).not.toBeUndefined();
         expect(item.text).toEqual(newItem.text);

--- a/playwright/masonry/handle-item-updates.spec.ts
+++ b/playwright/masonry/handle-item-updates.spec.ts
@@ -24,7 +24,8 @@ test.describe('Masonry: handle item updates', () => {
     const itemRect2 = await gridItems2[0].boundingBox();
 
     // verify that the first element has grown in height
-    expect(itemRect2.height).toBeGreaterThan(itemRect1.height);
+    // eslint-disable-next-line playwright/no-conditional-in-test
+    expect(itemRect2?.height).toBeGreaterThan(itemRect1?.height ?? Infinity);
 
     // trigger item collapse
     await pushTrigger.click();
@@ -34,6 +35,6 @@ test.describe('Masonry: handle item updates', () => {
     const itemRect3 = await gridItems3[0].boundingBox();
 
     // item height should have reverted to original
-    expect(itemRect3.height).toEqual(itemRect1.height);
+    expect(itemRect3?.height).toEqual(itemRect1?.height);
   });
 });

--- a/playwright/masonry/parent-sizing.spec.ts
+++ b/playwright/masonry/parent-sizing.spec.ts
@@ -14,7 +14,7 @@ test.describe('Masonry: Parent Sizing', () => {
 
     for (let i = 0; i < gridItems.length; i += 1) {
       const itemRect = await gridItems[i].boundingBox();
-      expect(itemRect.x).toBeGreaterThanOrEqual(EXPECTED_LEFT_MARGIN);
+      expect(itemRect?.x).toBeGreaterThanOrEqual(EXPECTED_LEFT_MARGIN);
     }
   });
 });

--- a/playwright/masonry/reflow-item-prop-changes.spec.ts
+++ b/playwright/masonry/reflow-item-prop-changes.spec.ts
@@ -47,10 +47,10 @@ test.describe('Masonry: Item prop changes', () => {
     expect(newItems.length).toBeGreaterThan(0);
 
     for (let i = 0; i < newItems.length; i += 1) {
-      const { height: renderedheight } = await newItems[i].boundingBox();
+      const renderedBoundingBox = await newItems[i].boundingBox();
       const expectedHeight = masonryItemData[i].height + 16; /* border size + padding */
       // `item ${i} has a height of ${expectedHeight}`
-      expect(renderedheight).toEqual(expectedHeight);
+      expect(renderedBoundingBox?.height).toEqual(expectedHeight);
     }
   });
 

--- a/playwright/masonry/render-height.spec.ts
+++ b/playwright/masonry/render-height.spec.ts
@@ -14,7 +14,7 @@ test.describe('Masonry: Render height', () => {
     for (let i = 0; i < gridItems.length; i += 1) {
       const itemRect = await gridItems[i].boundingBox();
       // eslint-disable-next-line playwright/no-conditional-in-test
-      if (itemRect.y > bottomItem) {
+      if (itemRect && itemRect.y > bottomItem) {
         bottomItem = itemRect.y + itemRect.height;
       }
     }

--- a/playwright/masonry/server-render-layout.spec.ts
+++ b/playwright/masonry/server-render-layout.spec.ts
@@ -20,8 +20,11 @@ test.describe('Masonry: Server Render Layout', () => {
     const serverItem1Text = await serverItems[0].textContent();
     const serverItem2Text = await serverItems[1].textContent();
 
-    expect(serverItem1Rect.x).toBeGreaterThanOrEqual(0);
-    expect(serverItem2Rect.x).toBeGreaterThanOrEqual(serverItem1Rect.x + serverItem1Rect.width);
+    expect(serverItem1Rect?.x).toBeGreaterThanOrEqual(0);
+    expect(serverItem2Rect?.x).toBeGreaterThanOrEqual(
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      serverItem1Rect ? serverItem1Rect.x + serverItem1Rect.width : Infinity,
+    );
 
     await page.evaluate(() => {
       window.dispatchEvent(new CustomEvent('trigger-mount'));
@@ -35,12 +38,12 @@ test.describe('Masonry: Server Render Layout', () => {
     const gridItem1Text = await gridItems[0].textContent();
     const gridItem2Text = await gridItems[1].textContent();
 
-    expect(gridItem1Rect.x).toEqual(serverItem1Rect.x);
+    expect(gridItem1Rect?.x).toEqual(serverItem1Rect?.x);
     // key shouldn't change.  slotIdx shouldn't change
     expect(gridItem1Text).toEqual(serverItem1Text);
     expect(gridItem2Text).toEqual(serverItem2Text);
     // Simple placement assertion for now because we position masonry with transforms.
-    expect(gridItem2Rect.x).toBeGreaterThan(0);
+    expect(gridItem2Rect?.x).toBeGreaterThan(0);
   });
 
   test('[flexible] items rendered on the server start with columnWidth', async ({ page }) => {
@@ -52,8 +55,11 @@ test.describe('Masonry: Server Render Layout', () => {
     const serverItem1Rect = await serverItems[0].boundingBox();
     const serverItem2Rect = await serverItems[1].boundingBox();
 
-    expect(serverItem1Rect.x).toBeGreaterThanOrEqual(0);
-    expect(serverItem2Rect.x).toBeGreaterThanOrEqual(serverItem1Rect.x + serverItem1Rect.width);
+    expect(serverItem1Rect?.x).toBeGreaterThanOrEqual(0);
+    expect(serverItem2Rect?.x).toBeGreaterThanOrEqual(
+      // eslint-disable-next-line playwright/no-conditional-in-test
+      serverItem1Rect ? serverItem1Rect.x + serverItem1Rect.width : Infinity,
+    );
 
     await page.evaluate(() => {
       window.dispatchEvent(new CustomEvent('trigger-mount'));
@@ -64,8 +70,8 @@ test.describe('Masonry: Server Render Layout', () => {
 
     const gridItem1Rect = await gridItems[0].boundingBox();
     const gridItem2Rect = await gridItems[1].boundingBox();
-    expect(gridItem1Rect.x).toEqual(serverItem1Rect.x);
-    expect(gridItem1Rect.width).toEqual(serverItem1Rect.width);
-    expect(gridItem2Rect.width).toEqual(serverItem2Rect.width);
+    expect(gridItem1Rect?.x).toEqual(serverItem1Rect?.x);
+    expect(gridItem1Rect?.width).toEqual(serverItem1Rect?.width);
+    expect(gridItem2Rect?.width).toEqual(serverItem2Rect?.width);
   });
 });

--- a/playwright/masonry/shuffle-items.spec.ts
+++ b/playwright/masonry/shuffle-items.spec.ts
@@ -1,28 +1,23 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import getGridItems from './utils/getGridItems';
 import getServerURL from './utils/getServerURL';
 import selectors from './utils/selectors';
 import waitForRenderedItems from './utils/waitForRenderedItems';
 
-const getItemColumnMap = async (
-  // @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-  page /*: { locator: (string) => { all: () => Promise<$ReadOnlyArray<{|
-  innerText: () => void,
-  textContent: () => void,
-  boundingBox: () => Promise<{| [string]: number |}>,
-|}>> } } */,
-) => {
+const getItemColumnMap = async (page: Page) => {
   const gridItems = await getGridItems(page);
-  const itemLeftMap: Record<string, any> /*: any */ = {};
+  const itemLeftMap: Record<string, any> = {};
 
   for (let i = 0; i < gridItems.length; i += 1) {
     const boundingBox = await gridItems[i].boundingBox();
-    itemLeftMap[boundingBox.x] = itemLeftMap[boundingBox.x] || [];
-    itemLeftMap[boundingBox.x].push({
-      ...boundingBox,
-      itemIndex: i,
-      text: await gridItems[i].textContent(),
-    });
+    if (boundingBox) {
+      itemLeftMap[boundingBox.x] = itemLeftMap[boundingBox.x] || [];
+      itemLeftMap[boundingBox.x].push({
+        ...boundingBox,
+        itemIndex: i,
+        text: await gridItems[i].textContent(),
+      });
+    }
   }
 
   return itemLeftMap;

--- a/playwright/masonry/utils/clickButton.ts
+++ b/playwright/masonry/utils/clickButton.ts
@@ -1,11 +1,8 @@
-export default async function clickButton(
-  // @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-  page /*: Object */,
-  // @ts-expect-error - TS7006 - Parameter 'selector' implicitly has an 'any' type.
-  selector /*: string */,
-) /*: Promise<any> */ {
-  // @ts-expect-error - TS7006 - Parameter 'elementSelector' implicitly has an 'any' type.
+import { Page } from '@playwright/test';
+
+export default async function clickButton(page: Page, selector: string): Promise<any> {
   await page.evaluate((elementSelector) => {
+    // @ts-expect-error - TS2339
     document.querySelector(elementSelector)?.click();
   }, selector);
 }

--- a/playwright/masonry/utils/countColumns.ts
+++ b/playwright/masonry/utils/countColumns.ts
@@ -1,14 +1,11 @@
+import { Page } from '@playwright/test';
 import selectors from './selectors';
 
 // Count the number of columns of items in the grid by iterating over all items
 // and counting the number of unique x-offsets.
-// @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-export default async function countColumns(page /*: Object */) /*: Promise<any> */ {
-  // @ts-expect-error - TS7006 - Parameter 'gridItemsSelector' implicitly has an 'any' type.
+export default async function countColumns(page: Page): Promise<number> {
   return await page.evaluate((gridItemsSelector) => {
-    const itemLeftMap: Record<string, any> /*: {
-      [number]: $ReadOnlyArray<ClientRect>,
-    } */ = {};
+    const itemLeftMap: Record<string, ReadonlyArray<DOMRect>> = {};
     const gridItems = document.querySelectorAll(gridItemsSelector);
 
     for (let i = 0; i < gridItems.length; i += 1) {

--- a/playwright/masonry/utils/getGridItems.ts
+++ b/playwright/masonry/utils/getGridItems.ts
@@ -1,16 +1,6 @@
+import { Locator, Page } from '@playwright/test';
 import selectors from './selectors';
 
-/*::
-type GridItems = $ReadOnlyArray<{|
-  innerText: () => void,
-  textContent: () => void,
-  boundingBox: () => Promise<{| [string]: number |}>,
-|}>;
-
-type Page = { locator: (string) => { all: () => Promise<GridItems> } };
-*/
-
-// @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-export default function getGridItems(page /*: Page */) /*: Promise<GridItems> */ {
+export default function getGridItems(page: Page): Promise<Array<Locator>> {
   return page.locator(selectors.gridItem).all();
 }

--- a/playwright/masonry/utils/getServerURL.ts
+++ b/playwright/masonry/utils/getServerURL.ts
@@ -1,7 +1,6 @@
 const BASE_PATH = '/integration-test/masonry';
 
-// @ts-expect-error - TS7006 - Parameter 'val' implicitly has an 'any' type.
-const normalizeValue = (val /*: boolean | number */) => {
+const normalizeValue = (val: boolean | number) => {
   if (typeof val === 'boolean') {
     return val ? '1' : '0';
   }
@@ -9,34 +8,31 @@ const normalizeValue = (val /*: boolean | number */) => {
 };
 
 // These are used in docs/pages/integration-test/masonry.tsx
-/*::
-type Options = ?{|
-  constrained?: boolean,
-  deferMount?: boolean,
-  externalCache?: boolean,
-  finiteLength?: boolean,
-  flexible?: boolean,
-  logWhitespace?: boolean,
-  manualFetch?: boolean,
-  noScroll?: boolean,
-  offsetTop?: number,
-  realisticPinHeights?: boolean,
-  scrollContainer?: boolean,
-  twoColItems?: boolean,
-  virtualize?: boolean,
-  virtualBoundsTop?: number,
-  virtualBoundsBottom?: number,
-|};
-*/
+type Options = {
+  constrained?: boolean;
+  deferMount?: boolean;
+  externalCache?: boolean;
+  finiteLength?: boolean;
+  flexible?: boolean;
+  logWhitespace?: boolean;
+  manualFetch?: boolean;
+  noScroll?: boolean;
+  offsetTop?: number;
+  realisticPinHeights?: boolean;
+  scrollContainer?: boolean;
+  twoColItems?: boolean;
+  virtualize?: boolean;
+  virtualBoundsTop?: number;
+  virtualBoundsBottom?: number;
+};
 
-// @ts-expect-error - TS7006 - Parameter 'options' implicitly has an 'any' type.
-const getServerURL = (options /*: Options */) /*: string */ => {
+const getServerURL = (options?: Options | null): string => {
   let serializedOptions = '';
 
   if (options) {
-    serializedOptions = Object.keys(options ?? {})
-      .map((key) =>
-        typeof options[key] !== 'undefined' ? `${key}=${normalizeValue(options[key])}` : '',
+    serializedOptions = Object.entries(options)
+      .map(([key, value]) =>
+        typeof value !== 'undefined' ? `${key}=${normalizeValue(value)}` : '',
       )
       .filter((item) => !!item)
       .join('&');

--- a/playwright/masonry/utils/getStaticGridItems.ts
+++ b/playwright/masonry/utils/getStaticGridItems.ts
@@ -1,6 +1,6 @@
+import { Locator, Page } from '@playwright/test';
 import selectors from './selectors';
 
-// @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-export default function getStaticGridItems(page /*: Object */) /*: Promise<any> */ {
+export default function getStaticGridItems(page: Page): Promise<Array<Locator>> {
   return page.locator(selectors.staticItem).all();
 }

--- a/playwright/masonry/utils/resizeWidth.ts
+++ b/playwright/masonry/utils/resizeWidth.ts
@@ -2,9 +2,9 @@
 // page because the page may have CSS breakpoints causing the grid to be fixed
 // widths at certain page sizes.
 
-// @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type. | TS7006 - Parameter 'newWidth' implicitly has an 'any' type.
-export default async function resizeWidth(page /*: Object */, newWidth /*: number */) {
-  // @ts-expect-error - TS7006 - Parameter '_newWidth' implicitly has an 'any' type.
+import { Page } from '@playwright/test';
+
+export default async function resizeWidth(page: Page, newWidth: number) {
   await page.evaluate((_newWidth) => {
     // Mock out the window width for the next resize calculation.
     const gridWrapper = document.getElementById('gridWrapper');

--- a/playwright/masonry/utils/selectors.ts
+++ b/playwright/masonry/utils/selectors.ts
@@ -3,12 +3,10 @@ const selectors = {
   afterGrid: '.afterGrid',
   expandGridItems: '#expand-grid-items',
   gridItem: '[data-grid-item]',
-  // @ts-expect-error - TS7006 - Parameter 'id' implicitly has an 'any' type.
-  incrementItemCounter: (id /*: number */) /*: string */ => `#increment-counter-${id}`,
+  incrementItemCounter: (id: number): string => `#increment-counter-${id}`,
   insertItem: '#insert-item',
   insertNullItems: '#insert-null-items',
-  // @ts-expect-error - TS7006 - Parameter 'id' implicitly has an 'any' type.
-  itemCounter: (id /*: number */) /*: string */ => `#item-counter-${id}`,
+  itemCounter: (id: number): string => `#item-counter-${id}`,
   pushFirstItemDown: '#push-first-down',
   pushGridDown: '#push-grid-down',
   scrollContainer: '[data-scroll-container]',

--- a/playwright/masonry/utils/tracingEvents.ts
+++ b/playwright/masonry/utils/tracingEvents.ts
@@ -1,27 +1,23 @@
-/*::
 type Event = {
-  name: string,
-  ts: number,
-  fps?: number,
+  name: string;
+  ts: number;
+  fps?: number;
 };
 
-type Metric = { avg: number, max: number, min: number };
-*/
+type Metric = { avg: number; max: number; min: number };
 
 // @ts-expect-error - TS7006 - Parameter 'events' implicitly has an 'any' type.
-export const eventsToCsv = (events /*: $ReadOnlyArray<Event> */) /*: string */ =>
+export const eventsToCsv = (events: ReaoOnlyArray<Event>): string =>
   // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
   events.map((e) => (e.name.includes('clock_sync') ? e.name : e.fps)).join('\n');
 
-// @ts-expect-error - TS7006 - Parameter 'metrics' implicitly has an 'any' type.
-export const metricsToCsv = (metrics /*: $ReadOnlyArray<Metric> */) /*: string */ => {
+export const metricsToCsv = (metrics: ReadonlyArray<Metric>): string => {
   // @ts-expect-error - TS7034 - Variable 'result' implicitly has type 'any' in some locations where its type cannot be determined.
   let result;
 
   const keys = Object.keys(metrics[0]);
   result = `${keys.join(',')}\n`;
 
-  // @ts-expect-error - TS7006 - Parameter 'm' implicitly has an 'any' type.
   metrics.forEach((m) => {
     // @ts-expect-error - TS7005 - Variable 'result' implicitly has an 'any' type.
     result += `${keys.map((k) => m[k]).join(',')}\n`;
@@ -30,18 +26,12 @@ export const metricsToCsv = (metrics /*: $ReadOnlyArray<Metric> */) /*: string *
   return result;
 };
 
-export const getFpsFromEvents = (
-  // @ts-expect-error - TS7006 - Parameter 'events' implicitly has an 'any' type.
-  events /*: $ReadOnlyArray<Event> | [] */,
-) /*: $ReadOnlyArray<Event> */ => {
+export const getFpsFromEvents = (events: ReadonlyArray<Event> | []): ReadonlyArray<Event> => {
   const fpsTimings = [];
 
   const drawFrameEvents = events
-    // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
     .filter((e) => e.name.includes('DrawFrame'))
-    // @ts-expect-error - TS7006 - Parameter 'a' implicitly has an 'any' type. | TS7006 - Parameter 'b' implicitly has an 'any' type.
     .sort((a, b) => a.ts - b.ts);
-  // @ts-expect-error - TS7006 - Parameter 'e' implicitly has an 'any' type.
   const clockSyncEvents = events.filter((e) => e.name.includes('clock_sync'));
 
   for (let i = 0; i < drawFrameEvents.length - 1; i += 1) {
@@ -56,23 +46,21 @@ export const getFpsFromEvents = (
   return [...fpsTimings, ...clockSyncEvents].sort((a, b) => a.ts - b.ts);
 };
 
-export const getFpsMetricsPerScroll = (
-  // @ts-expect-error - TS7006 - Parameter 'events' implicitly has an 'any' type.
-  events /*: $ReadOnlyArray<Event> */,
-) /*: $ReadOnlyArray<Metric> */ => {
+export const getFpsMetricsPerScroll = (events: ReadonlyArray<Event>): ReadonlyArray<Metric> => {
   const fpsMetricsPerScroll = [];
-  let fpsPerScroll = [];
+  let fpsPerScroll: number[] = [];
 
   for (let i = 0; i <= events.length; i += 1) {
-    if (events[i]?.name.includes('clock_sync') || i === events.length) {
+    const event = events[i];
+    if (event?.name.includes('clock_sync') || i === events.length) {
       fpsMetricsPerScroll.push({
         avg: fpsPerScroll.reduce((sum, x) => sum + x) / fpsPerScroll.length,
         max: fpsPerScroll.reduce((hi, x) => (x > hi ? x : hi)),
         min: fpsPerScroll.reduce((lo, x) => (x < lo ? x : lo)),
       });
       fpsPerScroll = [];
-    } else if (events[i]?.fps) {
-      fpsPerScroll.push(events[i]?.fps);
+    } else if (event?.fps) {
+      fpsPerScroll.push(event.fps);
     }
   }
 

--- a/playwright/masonry/utils/waitForRenderedItems.ts
+++ b/playwright/masonry/utils/waitForRenderedItems.ts
@@ -8,24 +8,14 @@ import selectors from './selectors';
 // GTE = greater than or equal to
 // LT = less than
 // LTE = less than or equal to
-/*::
-type waitForRenderedItemsArgs = {|
-  scrollHeight?: number,
-  targetItems?: number,
-  targetItemsGT?: number,
-  targetItemsGTE?: number,
-  targetItemsLT?: number,
-  targetItemsLTE?: number,
-|};
-*/
 
 export default async function waitForRenderedItems(
   // @ts-expect-error - TS7006 - Parameter 'page' implicitly has an 'any' type.
-  page /*: Object */,
+  page,
   // @ts-expect-error - TS7006 - Parameter 'args' implicitly has an 'any' type.
-  args /*: waitForRenderedItemsArgs */,
-  timeout /*: number */ = 5000,
-) /*: Promise<any> */ {
+  args,
+  timeout = 5000,
+) {
   return (
     page
       .waitForFunction(


### PR DESCRIPTION
## What changed?

This is a fix-up for https://github.com/pinterest/gestalt/pull/3580. The PR converts [Flow comment types](https://flow.org/en/docs/types/comments/) in Playwright tests to TypeScript types.

With the additional type coverage, this PR also removes some unused error suppressions and adds a few type-level fixes (e.g. adding optional chaining).

## Why?

The Flow comment types are not handled in migration codemod, so we have to manually convert them to TypeScript types.
