### PR TITLE
MasonryV2: Iterate + bug fixes

### DIFF
--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -11,7 +11,6 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
-  useTransition,
 } from 'react';
 import debounce from './debounce';
 import styles from './Masonry.css';

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -425,16 +425,14 @@ function useLayout<
         startTransition(() => {
           forceUpdate();
         });
-      } else {
-        if (!rafId.current) {
-          rafId.current = requestAnimationFrame(() => {
-            rafId.current = null;
-            forceUpdate();
-          });
-        }
+      } else if (!rafId.current) {
+        rafId.current = requestAnimationFrame(() => {
+          rafId.current = null;
+          forceUpdate();
+        });
       }
     },
-    [measurementStore],
+    [measurementStore, forceUpdate, _useRAF],
   );
 
   // Math.max() === -Infinity when there are no positions

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -420,6 +420,8 @@ function useLayout<
   const updateMeasurement = useCallback(
     (item: T, itemHeight: number) => {
       measurementStore.set(item, itemHeight);
+      // schedule state update either via startTransition or requestAnimationFrame depending on whether _useRAF is true.
+      // requestAnimationFrame is to test parity with Masonry V1
       if (!_useRAF) {
         startTransition(() => {
           forceUpdate();
@@ -427,7 +429,6 @@ function useLayout<
       } else {
         if (!rafId.current) {
           rafId.current = requestAnimationFrame(() => {
-            console.log('frame');
             rafId.current = null;
             forceUpdate();
           });


### PR DESCRIPTION
# Summary
This PR continues to iterate on the MasonryV2 implementation.

We're currently seeing a few regressions with https://helium.pinadmin.com/web_masonry_v2_auth/ and https://helium.pinadmin.com/web_masonry_v2_unauth/, namely decrease in Pin impressions as well as decrease in landers (specifically on hf). Conversely,  also seeing increases in certain engagement metrics (repins, clicks, etc).

To help debug these issues, we added some logging in Pinboard which shows a few things:
- number of items fetched is flat between the groups
- % items measured is flat between the groups
- % items rendered is lower in enabled vs control

Based on this, it sounds like there is potentially an issue with how MasonryV2 transitions from measuring -> rendering an item.  To test this, I'm making two changes in this PR:

### Change how the current re-render happens.
Currently, we wrap the call to `updateMeasurement` inside a `startTransition`. What this actually does is:
- `startTransition` immediately re-renders 
- call `updateMeasurement` synchronously
- `startTransition` schedules a future re-render

As you can see here, there are actually two renders scheduled as the result of each measurement update (not great). After doing a bit more research, I updated this to use the "global" [startTransition](https://react.dev/reference/react/startTransition) vs the startTransition from [useTransition](https://react.dev/reference/react/useTransition#usetransition). The main difference in behavior here is that only one re-render will be scheduled

### Add a flag to use requestAnimationFrame
One of the major changes in V2 was removing the use of requestAnimationFrame. This PR adds it back as an option so we can test it as a separate group 

The other change in this PR was a bug I found with scrollContainer where we always attached the `scroll` event on window vs the scrollContainerElement