### PR TITLE
Docs: Update design_contributions_overview.md

### DIFF
--- a/docs/markdown/team_support/design_contributions/design_contributions_overview.md
+++ b/docs/markdown/team_support/design_contributions/design_contributions_overview.md
@@ -14,7 +14,7 @@ fullwidth: true
 
 ### One step to contribute
 
-- One step to get started: **[complete the intake form](http://pinch.pinadmin.com/design-contribution-form)**
+- One step to get started: Complete the intake form in **[#gestalt-design](http://pinch.pinadmin.com/gestalt-design)**
 - All you need is a Figma link for your design—your contribution doesn't need to be finalized or componentized. You’ll have a chance to answer “how done is this design” when submitting. For further tips on getting your design closer to completion, go to [Contribution types and criteria](team_support/design_contributions/contribution_types_and_criteria)
 <br/>
 


### PR DESCRIPTION
### Summary
Updated link on the Design Contributions page.

#### What changed?

Fixed a broken Slack link—can't link to Slack workflows via the browser; linked to our design channel instead.

#### Why?

Link was broken

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-8005)
