### PR TITLE
Internal: fix some TS suppressions due to ReactNode

### DIFF
--- a/docs/docs-components/App.tsx
+++ b/docs/docs-components/App.tsx
@@ -70,7 +70,6 @@ export default function App({ children, files }: Props) {
   return (
     <AppContextProvider>
       <DocsExperimentProvider>
-        {/* @ts-expect-error - TS2786 - 'AppContextConsumer' cannot be used as a JSX component. */}
         <AppContextConsumer>
           {({ colorScheme }) => (
             <ColorSchemeProvider colorScheme={colorScheme}>

--- a/docs/docs-components/ColorPalette.tsx
+++ b/docs/docs-components/ColorPalette.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Box, Text } from 'gestalt';
 import ColorTile from './ColorTile';
 
@@ -9,38 +8,36 @@ type Props = {
 };
 
 function ColorPalette({ name, tokenId, tokenData }: Props) {
-  if (tokenData) {
-    const tiles = tokenData.map((token) => {
-      const regex = /\d+(?=\D*$)/;
-      const grade = (token.match(regex) || [])[0];
-      const isTransparent = tokenId === 'transparent';
-      const textColor = Number(grade) <= 400 || isTransparent ? 'dark' : 'light';
+  const tiles = tokenData.map((token) => {
+    const regex = /\d+(?=\D*$)/;
+    const grade = (token.match(regex) || [])[0];
+    const isTransparent = tokenId === 'transparent';
+    const textColor = Number(grade) <= 400 || isTransparent ? 'dark' : 'light';
 
-      if (isTransparent || (grade !== '450' && !Number.isNaN(Number(grade)))) {
-        return (
-          <ColorTile
-            key={token}
-            description={grade || 'transparent'}
-            number={Number(grade) || 0}
-            textColor={textColor}
-            token={token}
-          />
-        );
-      }
+    if (isTransparent || (grade !== '450' && !Number.isNaN(Number(grade)))) {
+      return (
+        <ColorTile
+          key={token}
+          description={grade || 'transparent'}
+          number={Number(grade) || 0}
+          textColor={textColor}
+          token={token}
+        />
+      );
+    }
 
-      return null;
-    });
+    return null;
+  });
 
-    return (
-      <Fragment>
-        <Box marginBottom={8} marginTop={8}>
-          <Text weight="bold">
-            {name} ({tokenId})
-          </Text>
-        </Box>
-        {tiles}
-      </Fragment>
-    );
-  }
+  return (
+    <Box>
+      <Box marginBottom={8} marginTop={8}>
+        <Text weight="bold">
+          {name} ({tokenId})
+        </Text>
+      </Box>
+      {tiles}
+    </Box>
+  );
 }
 export default ColorPalette;

--- a/docs/docs-components/ErrorBoundary.tsx
+++ b/docs/docs-components/ErrorBoundary.tsx
@@ -31,7 +31,7 @@ class ErrorBoundary extends React.Component<
     console.log({ error, errorInfo });
   }
 
-  render(): ReactNode {
+  render() {
     // Check if the error is thrown
     if (this.state.hasError) {
       // You can render any custom fallback UI

--- a/docs/docs-components/StatusData.tsx
+++ b/docs/docs-components/StatusData.tsx
@@ -28,8 +28,7 @@ export default function StatusData({ status, text, href }: Props) {
           accessibilityLabel={`This component is ${label}`}
           title={href ? '' : label}
           // @ts-expect-error - TS2322 - Type 'string' is not assignable to type '"ok" | "inProgress" | "unstarted" | "canceled" | "queued" | "halted" | "problem" | "warning"'.
-          type={STATUS_EQUIVALENCY_MAP[status] !== 'notAvailable' && STATUS_EQUIVALENCY_MAP[status]
-}
+          type={STATUS_EQUIVALENCY_MAP[status] !== 'notAvailable' && STATUS_EQUIVALENCY_MAP[status]}
         />
       )}
       {href ? (

--- a/docs/docs-components/StatusData.tsx
+++ b/docs/docs-components/StatusData.tsx
@@ -28,7 +28,7 @@ export default function StatusData({ status, text, href }: Props) {
           accessibilityLabel={`This component is ${label}`}
           title={href ? '' : label}
           // @ts-expect-error - TS2322 - Type 'string' is not assignable to type '"ok" | "inProgress" | "unstarted" | "canceled" | "queued" | "halted" | "problem" | "warning"'.
-          type={STATUS_EQUIVALENCY_MAP[status] as StatusType
+          type={STATUS_EQUIVALENCY_MAP[status] !== 'notAvailable' && STATUS_EQUIVALENCY_MAP[status]
 }
         />
       )}

--- a/docs/docs-components/StatusData.tsx
+++ b/docs/docs-components/StatusData.tsx
@@ -28,7 +28,8 @@ export default function StatusData({ status, text, href }: Props) {
           accessibilityLabel={`This component is ${label}`}
           title={href ? '' : label}
           // @ts-expect-error - TS2322 - Type 'string' is not assignable to type '"ok" | "inProgress" | "unstarted" | "canceled" | "queued" | "halted" | "problem" | "warning"'.
-          type={STATUS_EQUIVALENCY_MAP[status]}
+          type={STATUS_EQUIVALENCY_MAP[status] as StatusType
+}
         />
       )}
       {href ? (

--- a/docs/docs-components/createHydra.ts
+++ b/docs/docs-components/createHydra.ts
@@ -28,11 +28,11 @@ Related articles:
 https://americanexpress.io/hydra/
 https://kentcdodds.com/blog/how-to-use-react-context-effectively */
 
-import { Context, createContext, ReactNode, useContext } from 'react';
+import { Context, createContext, ReactElement, useContext } from 'react';
 
 export type Hydra<ContextType> = {
   Provider: Context<ContextType | undefined>['Provider'];
-  Consumer: (props: { children: (arg1: ContextType) => ReactNode }) => ReactNode;
+  Consumer: (props: { children: (arg1: ContextType) => ReactElement }) => ReactElement;
   useHook: () => ContextType;
 };
 
@@ -70,7 +70,7 @@ export default function createHydra<ContextType>(
   const { Provider } = context;
 
   // Consumer: Render Prop
-  const Consumer = ({ children }: { children: (arg1: ContextType) => ReactNode }) => {
+  const Consumer = ({ children }: { children: (arg1: ContextType) => ReactElement }) => {
     const contextValue = useContext(context);
 
     if (contextValue === undefined) {

--- a/docs/docs-components/data/componentStatusMessaging.ts
+++ b/docs/docs-components/data/componentStatusMessaging.ts
@@ -6,6 +6,7 @@ export const STATUS_EQUIVALENCY_MAP = Object.freeze({
   'deprecated': 'canceled',
 });
 
+
 export const STATUS_DESCRIPTION = Object.freeze({
   ready: { title: 'Ready', description: "Available for use. Has been reviewed and QA'd." },
   partial: {

--- a/docs/docs-components/data/componentStatusMessaging.ts
+++ b/docs/docs-components/data/componentStatusMessaging.ts
@@ -6,7 +6,6 @@ export const STATUS_EQUIVALENCY_MAP = Object.freeze({
   'deprecated': 'canceled',
 });
 
-
 export const STATUS_DESCRIPTION = Object.freeze({
   ready: { title: 'Ready', description: "Available for use. Has been reviewed and QA'd." },
   partial: {

--- a/docs/pages/foundations/color/palette.tsx
+++ b/docs/pages/foundations/color/palette.tsx
@@ -268,7 +268,6 @@ export default function ColorPage() {
             wrap
           >
             {getColors().map(({ id, name, tokenData }) => (
-              // @ts-expect-error - TS2786 - 'ColorPalette' cannot be used as a JSX component.
               <ColorPalette key={name} name={name} tokenData={tokenData} tokenId={id} />
             ))}
           </Flex>
@@ -276,14 +275,12 @@ export default function ColorPage() {
         <MainSection.Subsection description="Pinterest name (common name)" title="Neutrals">
           <Flex direction="column">
             {getNeutrals().map(({ id, name, tokenData }) => (
-              // @ts-expect-error - TS2786 - 'ColorPalette' cannot be used as a JSX component.
               <ColorPalette key={name} name={name} tokenData={tokenData} tokenId={id} />
             ))}
           </Flex>
         </MainSection.Subsection>
         <MainSection.Subsection description="(common name)" title="Transparent">
           <Flex direction="column">
-            {/* @ts-expect-error - TS2786 - 'ColorPalette' cannot be used as a JSX component. */}
             <ColorPalette
               name="transparent"
               tokenData={[TOKEN_COLOR_TRANSPARENT]}

--- a/docs/pages/foundations/data_visualization/color/usage.tsx
+++ b/docs/pages/foundations/data_visualization/color/usage.tsx
@@ -78,21 +78,25 @@ type ColorCardProps = {
 };
 
 function PaletteGenerator({ count }: ColorCardProps) {
-  return [...Array(count)].map((step, idx) => {
-    const tokenStep = idx + 1;
+  return (
+    <Box>
+      {[...Array(count)].map((step, idx) => {
+        const tokenStep = idx + 1;
 
-    return (
-      <Box key={`color-${tokenStep}`} marginBottom={1}>
-        <ColorTile
-          description={`Data Visualization 0${tokenStep}`}
-          // @ts-expect-error - TS7053 - Element implicitly has an 'any' type because expression of type '`0${number}`' can't be used to index type '{ readonly '01': "light"; readonly '02': "dark"; readonly '03': "light"; readonly '04': "dark"; readonly '05': "dark"; readonly '06': "default"; readonly '07': "dark"; readonly '08': "light"; readonly '09': "dark"; readonly '10': "light"; readonly '11': "inverse"; readonly '12': "inverse"; }'.
-          textColor={COLOR_TEXT_PAIRINGS[`0${tokenStep}`]}
-          // @ts-expect-error - TS7053 - Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ readonly '1': "var(--color-data-visualization-01)"; readonly '2': "var(--color-data-visualization-02)"; readonly '3': "var(--color-data-visualization-03)"; readonly '4': "var(--color-data-visualization-04)"; ... 7 more ...; readonly '12': "var(--color-data-visualization-12)"; }'.
-          token={MAP[tokenStep]}
-        />
-      </Box>
-    );
-  });
+        return (
+          <Box key={`color-${tokenStep}`} marginBottom={1}>
+            <ColorTile
+              description={`Data Visualization 0${tokenStep}`}
+              // @ts-expect-error - TS7053 - Element implicitly has an 'any' type because expression of type '`0${number}`' can't be used to index type '{ readonly '01': "light"; readonly '02': "dark"; readonly '03': "light"; readonly '04': "dark"; readonly '05': "dark"; readonly '06': "default"; readonly '07': "dark"; readonly '08': "light"; readonly '09': "dark"; readonly '10': "light"; readonly '11': "inverse"; readonly '12': "inverse"; }'.
+              textColor={COLOR_TEXT_PAIRINGS[`0${tokenStep}`]}
+              // @ts-expect-error - TS7053 - Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ readonly '1': "var(--color-data-visualization-01)"; readonly '2': "var(--color-data-visualization-02)"; readonly '3': "var(--color-data-visualization-03)"; readonly '4': "var(--color-data-visualization-04)"; ... 7 more ...; readonly '12': "var(--color-data-visualization-12)"; }'.
+              token={MAP[tokenStep]}
+            />
+          </Box>
+        );
+      })}
+    </Box>
+  );
 }
 
 type PairSetProps = {
@@ -229,7 +233,6 @@ export default function ColorPage() {
                 column: 1,
               }}
             >
-              {/* @ts-expect-error - TS2786 - 'PaletteGenerator' cannot be used as a JSX component. */}
               <PaletteGenerator count={2} />
             </Flex>
             <Box marginBottom={10}>
@@ -252,7 +255,6 @@ export default function ColorPage() {
                 column: 1,
               }}
             >
-              {/* @ts-expect-error - TS2786 - 'PaletteGenerator' cannot be used as a JSX component. */}
               <PaletteGenerator count={3} />
             </Flex>
             <Box marginBottom={10}>
@@ -276,7 +278,6 @@ export default function ColorPage() {
                 column: 1,
               }}
             >
-              {/* @ts-expect-error - TS2786 - 'PaletteGenerator' cannot be used as a JSX component. */}
               <PaletteGenerator count={4} />
             </Flex>
             <Box marginBottom={10}>
@@ -300,7 +301,6 @@ export default function ColorPage() {
                 column: 1,
               }}
             >
-              {/* @ts-expect-error - TS2786 - 'PaletteGenerator' cannot be used as a JSX component. */}
               <PaletteGenerator count={6} />
             </Flex>
             <Box marginBottom={10}>
@@ -323,7 +323,6 @@ export default function ColorPage() {
                 column: 1,
               }}
             >
-              {/* @ts-expect-error - TS2786 - 'PaletteGenerator' cannot be used as a JSX component. */}
               <PaletteGenerator count={8} />
             </Flex>
             <Box marginBottom={10}>

--- a/docs/pages/integration-test/masonry.tsx
+++ b/docs/pages/integration-test/masonry.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react';
+import { ReactElement, useEffect, useState } from 'react';
 import LazyHydrate from 'react-lazy-hydration';
 import { useRouter } from 'next/router';
 import { ColorSchemeProvider, Masonry, MasonryV2 } from 'gestalt';
@@ -33,9 +33,8 @@ function booleanize(value: string): boolean {
 }
 
 // LazyHydrate doesn't like to be used without any props, so we have to add it conditionally
-function MaybeLazyHydrate({ children, ssrOnly }: { children: ReactNode; ssrOnly: boolean }) {
+function MaybeLazyHydrate({ children, ssrOnly }: { children: ReactElement; ssrOnly: boolean }) {
   if (ssrOnly) {
-    // @ts-expect-error - TS2322 - Type 'ReactNode' is not assignable to type 'ReactNode & ReactElement<any, string | JSXElementConstructor<any>>'.
     return <LazyHydrate ssrOnly>{children}</LazyHydrate>;
   }
   return children;
@@ -107,7 +106,6 @@ export default function TestPage({
 
   return (
     <ColorSchemeProvider colorScheme="light">
-      {/* @ts-expect-error - TS2786 - 'MaybeLazyHydrate' cannot be used as a JSX component. */}
       <MaybeLazyHydrate ssrOnly={ssrOnly}>
         {/* @ts-expect-error - TS2769 - No overload matches this call. */}
         <MasonryContainer

--- a/packages/gestalt-charts/src/ChartGraph/renderGraphPoint.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/renderGraphPoint.tsx
@@ -53,7 +53,7 @@ const renderGraphPoint: (options: {
   color: DataVisualizationColors;
   active: boolean;
 }) => (props: { cx: number; cy: number }) => ReactNode = (options) => {
-  function RenderPoint({ cx, cy }: { cx: number; cy: number }): ReactNode {
+  function RenderPoint({ cx, cy }: { cx: number; cy: number }) {
     return <GraphPoint key={options.color + cy + cx} color={options.color} cx={cx} cy={cy} />;
   }
 

--- a/packages/gestalt-datepicker/src/DatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement, ReactNode, useEffect, useImperativeHandle, useRef } from 'react';
+import { forwardRef, ReactElement, useEffect, useImperativeHandle, useRef } from 'react';
 import { Locale } from 'date-fns/locale';
 import { useGlobalEventsHandler } from 'gestalt';
 import InternalDatePicker from './DatePicker/InternalDatePicker';
@@ -99,7 +99,7 @@ export type Props = {
  * ![DatePicker closed light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/DatePicker-closed.spec.mjs-snapshots/DatePicker-closed-chromium-darwin.png)
  * ![DatePicker closed dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/DatePicker-closed-dark.spec.mjs-snapshots/DatePicker-closed-dark-chromium-darwin.png)
  */
-// @ts-expect-error - TS2345 - Argument of type '({ disabled, errorMessage, excludeDates, helperText, id, idealDirection, includeDates, label, localeData, maxDate, minDate, name, nextRef, onChange, placeholder, rangeEndDate, rangeSelector, rangeStartDate, selectLists, value, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function DatePicker(
   {
     disabled,
@@ -124,7 +124,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
     value,
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerInputRef = useRef<null | HTMLInputElement>(null);
   // @ts-expect-error - TS2322 - Type 'HTMLInputElement | null' is not assignable to type 'HTMLInputElement'.
   useImperativeHandle(ref, () => innerInputRef.current);

--- a/packages/gestalt/src/AvatarGroup.tsx
+++ b/packages/gestalt/src/AvatarGroup.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Fragment, ReactNode, useState } from 'react';
+import { forwardRef, Fragment, useState } from 'react';
 import AddCollaboratorsButton from './AvatarGroup/AddCollaboratorsButton';
 import CollaboratorAvatar from './AvatarGroup/CollaboratorAvatar';
 import CollaboratorsCount from './AvatarGroup/CollaboratorsCount';
@@ -81,7 +81,6 @@ type Props = {
  * ![AvatarGroup light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup.spec.mjs-snapshots/AvatarGroup-chromium-darwin.png)
  * ![AvatarGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/AvatarGroup-dark.spec.mjs-snapshots/AvatarGroup-dark-chromium-darwin.png)
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityControls, accessibilityExpanded, accessibilityHaspopup, addCollaborators, collaborators, href, onClick, role, size, }: Props, ref: ForwardedRef<UnionRefs>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<UnionRefs, Props>'.
 const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGroup(
   {
     accessibilityLabel,
@@ -96,7 +95,7 @@ const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGr
     size = 'fit',
   }: Props,
   ref,
-): ReactNode {
+) {
   const [hovered, setHovered] = useState(false);
 
   const isMdSize = size === 'md';

--- a/packages/gestalt/src/Button.tsx
+++ b/packages/gestalt/src/Button.tsx
@@ -148,7 +148,7 @@ function InternalButtonContent({
  * ![Button dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Button-dark.spec.mjs-snapshots/Button-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, color, dataTestId, disabled, fullWidth, iconEnd, onClick, tabIndex, selected, size, text, type, name, accessibilityControls, accessibilityExpanded, accessibilityHaspopup, }: Props, ref: ForwardedRef<HTMLButtonElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLButtonElement, Props>'.
+
 const ButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function Button(
   {
     accessibilityLabel,
@@ -169,7 +169,7 @@ const ButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function Butto
     accessibilityHaspopup,
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLButtonElement>(null);
 
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/ButtonLink.tsx
+++ b/packages/gestalt/src/ButtonLink.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import getAriaLabel from './accessibility/getAriaLabel';
 import NewTabAccessibilityLabel from './accessibility/NewTabAccessibilityLabel';
 import { useColorScheme } from './contexts/ColorSchemeProvider';
@@ -100,7 +100,7 @@ type ButtonProps = {
  * ![ButtonLink light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ButtonLink.spec.mjs-snapshots/ButtonLink-chromium-darwin.png)
  * ![ButtonLink dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ButtonLink-dark.spec.mjs-snapshots/ButtonLink-dark-chromium-darwin.png)
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, color, dataTestId, disabled, fullWidth, iconEnd, onClick, tabIndex, size, text, href, rel, target, }: ButtonProps, ref: ForwardedRef<HTMLAnchorElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLAnchorElement, ButtonProps>'.
+
 const ButtonLinkWithForwardRef = forwardRef<HTMLAnchorElement, ButtonProps>(function ButtonLink(
   {
     accessibilityLabel,
@@ -118,7 +118,7 @@ const ButtonLinkWithForwardRef = forwardRef<HTMLAnchorElement, ButtonProps>(func
     target = null,
   }: ButtonProps,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLAnchorElement>(null);
 
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/Checkbox.tsx
+++ b/packages/gestalt/src/Checkbox.tsx
@@ -67,7 +67,7 @@ type Props = {
  * ![Checkbox dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Checkbox-dark.spec.mjs-snapshots/Checkbox-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ checked, disabled, errorMessage, helperText, id, image, indeterminate, label, labelDisplay, name, onChange, onClick, size, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const CheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Checkbox(
   {
     checked = false,
@@ -85,7 +85,7 @@ const CheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Chec
     size = 'md',
   }: Props,
   ref,
-): ReactNode {
+) {
   return (
     <InternalCheckbox
       ref={ref}

--- a/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
+++ b/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
@@ -43,7 +43,6 @@ type Props = {
   };
 };
 
-
 const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Checkbox(
   {
     checked = false,

--- a/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
+++ b/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
@@ -43,7 +43,7 @@ type Props = {
   };
 };
 
-// @ts-expect-error - TS2345 - Argument of type '({ checked, disabled, errorMessage, helperText, id, image, indeterminate, label, labelDisplay, name, onChange, onClick, readOnly, size, style, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Checkbox(
   {
     checked = false,
@@ -63,7 +63,7 @@ const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
     style,
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLInputElement>(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <Checkbox ref={inputRef} /> to call inputRef.current.focus()

--- a/packages/gestalt/src/Collage/Collection.tsx
+++ b/packages/gestalt/src/Collage/Collection.tsx
@@ -99,7 +99,7 @@ export default function Collection(props: Props) {
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
           {/* @ts-expect-error - TS2786 - 'Item' cannot be used as a JSX component. */}
-          {renderItem ? renderItem({ idx }) : Item as ReactNode && <Item idx={idx} />}
+          {renderItem ? renderItem({ idx }) : (Item as ReactNode) && <Item idx={idx} />}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/Collage/Collection.tsx
+++ b/packages/gestalt/src/Collage/Collection.tsx
@@ -99,7 +99,7 @@ export default function Collection(props: Props) {
       {items.map(({ idx, ...style }) => (
         <div key={idx} className={layoutStyles.absolute} style={style}>
           {/* @ts-expect-error - TS2786 - 'Item' cannot be used as a JSX component. */}
-          {renderItem ? renderItem({ idx }) : Item && <Item idx={idx} />}
+          {renderItem ? renderItem({ idx }) : Item as ReactNode && <Item idx={idx} />}
         </div>
       ))}
     </div>

--- a/packages/gestalt/src/ComboBox.tsx
+++ b/packages/gestalt/src/ComboBox.tsx
@@ -147,7 +147,7 @@ type Props = {
  * ![Combobox open dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/ComboBox-open-dark.spec.mjs-snapshots/ComboBox-open-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityClearButtonLabel, disabled, errorMessage, helperText, id, inputValue: controlledInputValue, label, labelDisplay, noResultText, onBlur, onChange, onClear, onFocus, onKeyDown, onSelect, options, placeholder, size, selectedOption, tags, zIndex, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const ComboBoxWithForwardRef = forwardRef<HTMLInputElement, Props>(function ComboBox(
   {
     accessibilityClearButtonLabel,
@@ -173,7 +173,7 @@ const ComboBoxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Comb
     zIndex,
   }: Props,
   ref,
-): ReactNode {
+) {
   const {
     accessibilityClearButtonLabel: accessibilityClearButtonLabelDefault,
     noResultText: noResultTextDefault,
@@ -491,7 +491,6 @@ const ComboBoxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Comb
       </Box>
       {showOptionsList && innerRef.current ? (
         <Layer zIndex={zIndex}>
-          {/* @ts-expect-error - TS2786 - 'InternalPopover' cannot be used as a JSX component. */}
           <InternalPopover
             anchor={innerRef.current}
             color="white"

--- a/packages/gestalt/src/ComboBox/Item.tsx
+++ b/packages/gestalt/src/ComboBox/Item.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
 import classnames from 'classnames';
 import bordersStyles from '../Borders.css';
 import boxWhitespaceStyles from '../boxWhitespace.css';
@@ -29,7 +29,6 @@ type Props = {
 };
 
 const ComboBoxItemWithForwardRef = forwardRef<HTMLElement | null | undefined, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ isHovered, id, index, isSelected, label, onSelect, setHoveredItemIndex, subtext, value, }: Props, ref: ForwardedRef<HTMLElement | null | undefined>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLElement | null | undefined, Props>'.
   function OptionItem(
     {
       isHovered,
@@ -43,7 +42,7 @@ const ComboBoxItemWithForwardRef = forwardRef<HTMLElement | null | undefined, Pr
       value,
     }: Props,
     ref,
-  ): ReactNode {
+  ) {
     const handleEventPreventDefault = (event: React.ChangeEvent<HTMLDivElement>) =>
       event.preventDefault();
 

--- a/packages/gestalt/src/Dropdown/OptionItem.tsx
+++ b/packages/gestalt/src/Dropdown/OptionItem.tsx
@@ -57,7 +57,6 @@ type Props = {
 };
 
 const OptionItemWithForwardRef = forwardRef<HTMLElement | null | undefined, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ badge, children, dataTestId, disabled, onSelect, hoveredItemIndex, href, id, index, isExternal, onClick, option, selected, setHoveredItemIndex, textWeight, }: Props, ref: ForwardedRef<HTMLElement | null | undefined>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLElement | null | undefined, Props>'.
   function OptionItem(
     {
       badge,
@@ -77,7 +76,7 @@ const OptionItemWithForwardRef = forwardRef<HTMLElement | null | undefined, Prop
       textWeight = 'normal',
     }: Props,
     ref,
-  ): ReactNode {
+  ) {
     const deviceType = useDeviceType();
     const isMobile = deviceType === 'mobile';
 

--- a/packages/gestalt/src/HelpButton.tsx
+++ b/packages/gestalt/src/HelpButton.tsx
@@ -171,7 +171,6 @@ export default function HelpButton({
     );
 
   const popoverElement = (
-    // @ts-expect-error - TS2786 - 'InternalPopover' cannot be used as a JSX component.
     <InternalPopover
       accessibilityLabel={accessibilityPopoverLabel}
       anchor={tapAreaRef.current}

--- a/packages/gestalt/src/IconButton.tsx
+++ b/packages/gestalt/src/IconButton.tsx
@@ -112,7 +112,7 @@ type Props = {
  *
  */
 
- const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function IconButton(
+const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function IconButton(
   {
     accessibilityLabel,
     accessibilityControls,

--- a/packages/gestalt/src/IconButton.tsx
+++ b/packages/gestalt/src/IconButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import classnames from 'classnames';
 import styles from './IconButton.css';
 import icons from './icons/index';
@@ -111,8 +111,8 @@ type Props = {
  * ![IconButton dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/IconButton-dark.spec.mjs-snapshots/IconButton-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityControls, accessibilityExpanded, accessibilityHaspopup, accessibilityPopupRole, name, selected, type, bgColor, dangerouslySetSvgPath, dataTestId, disabled, icon, iconColor, onClick, padding, tabIndex, tooltip, size, }: Props, ref: ForwardedRef<HTMLButtonElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLButtonElement, Props>'.
-const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function IconButton(
+
+ const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function IconButton(
   {
     accessibilityLabel,
     accessibilityControls,
@@ -135,7 +135,7 @@ const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function I
     size = 'lg',
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLButtonElement>(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <IconButton ref={inputRef} /> to call inputRef.current.focus()

--- a/packages/gestalt/src/IconButtonFloating.tsx
+++ b/packages/gestalt/src/IconButtonFloating.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
 import Box from './Box';
 import IconButton from './IconButton';
 import icons from './icons/index';
@@ -69,7 +69,6 @@ type Props = {
  *
  */
 const IconButtonFloatingWithForwardRef = forwardRef<HTMLButtonElement, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ accessibilityControls, accessibilityExpanded, accessibilityPopupRole, accessibilityLabel, dangerouslySetSvgPath, disabled, icon, onClick, selected, tooltip, }: Props, ref: ForwardedRef<HTMLButtonElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLButtonElement, Props>'.
   function IconButtonFloating(
     {
       accessibilityControls,
@@ -84,7 +83,7 @@ const IconButtonFloatingWithForwardRef = forwardRef<HTMLButtonElement, Props>(
       tooltip,
     }: Props,
     ref,
-  ): ReactNode {
+  ) {
     return (
       <Box borderStyle="shadow" color="default" rounding="circle">
         <IconButton

--- a/packages/gestalt/src/IconButtonLink.tsx
+++ b/packages/gestalt/src/IconButtonLink.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useImperativeHandle, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useRef } from 'react';
 import getAriaLabel from './accessibility/getAriaLabel';
 import NewTabAccessibilityLabel from './accessibility/NewTabAccessibilityLabel';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
@@ -93,7 +93,7 @@ type Props = {
  * ![IconButton dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/IconButton-dark.spec.mjs-snapshots/IconButton-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ href, rel, target, accessibilityLabel, bgColor, dangerouslySetSvgPath, dataTestId, disabled, icon, iconColor, onClick, padding, tabIndex, tooltip, size, }: Props, ref: ForwardedRef<HTMLAnchorElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLAnchorElement, Props>'.
+
 const IconButtonLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function IconButtonLink(
   {
     href,
@@ -113,7 +113,7 @@ const IconButtonLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(functi
     size = 'lg',
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLAnchorElement>(null);
 
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -134,7 +134,7 @@ export default class Image extends PureComponent<Props> {
     }
   }
 
-  render(): ReactNode {
+  render() {
     const {
       alt,
       color,

--- a/packages/gestalt/src/LegacyContents.tsx
+++ b/packages/gestalt/src/LegacyContents.tsx
@@ -250,7 +250,7 @@ class LegacyContents extends Component<Props, State> {
     };
   }
 
-  render(): ReactNode {
+  render() {
     const {
       accessibilityLabel,
       bgColor,

--- a/packages/gestalt/src/LegacyController.tsx
+++ b/packages/gestalt/src/LegacyController.tsx
@@ -122,7 +122,7 @@ class LegacyController extends Component<Props, State> {
     this.setState({ relativeOffset, triggerBoundingRect });
   };
 
-  render(): ReactNode {
+  render() {
     const {
       accessibilityLabel,
       anchor,

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -485,7 +485,7 @@ export default class Masonry<
     return virtualize ? (isVisible && itemComponent) || null : itemComponent;
   };
 
-  render(): ReactNode {
+  render() {
     const {
       align = 'center',
       columnWidth,

--- a/packages/gestalt/src/Masonry/ScrollContainer.ts
+++ b/packages/gestalt/src/Masonry/ScrollContainer.ts
@@ -66,7 +66,7 @@ export default class ScrollContainer extends Component<Props> {
     this.scrollContainer.addEventListener('scroll', this.handleScroll);
   }
 
-  render(): ReactNode {
+  render() {
     // Ensure that we only ever have a single child element
     return Children.only(this.props.children);
   }

--- a/packages/gestalt/src/NumberField.tsx
+++ b/packages/gestalt/src/NumberField.tsx
@@ -134,7 +134,7 @@ type Props = {
  * ![NumberField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/NumberField-dark.spec.mjs-snapshots/NumberField-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ autoComplete, dataTestId, disabled, mobileEnterKeyHint, errorMessage, helperText, id, label, labelDisplay, max, min, name, onBlur, onChange, onFocus, onKeyDown, placeholder, size, step, value, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const NumberFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function NumberField(
   {
     autoComplete,
@@ -159,7 +159,7 @@ const NumberFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function N
     value,
   }: Props,
   ref,
-): ReactNode {
+) {
   return (
     <InternalTextField
       ref={ref}

--- a/packages/gestalt/src/OverlayPanel/ConfirmationPopover.tsx
+++ b/packages/gestalt/src/OverlayPanel/ConfirmationPopover.tsx
@@ -78,7 +78,6 @@ export default function ConfirmationPopover({
   }, []);
 
   return (
-    // @ts-expect-error - TS2786 - 'InternalPopover' cannot be used as a JSX component.
     <InternalPopover
       accessibilityLabel="Popover"
       anchor={anchor}

--- a/packages/gestalt/src/Popover.tsx
+++ b/packages/gestalt/src/Popover.tsx
@@ -156,7 +156,6 @@ export default function Popover({
   }
 
   return (
-    // @ts-expect-error - TS2786 - 'InternalPopover' cannot be used as a JSX component.
     <InternalPopover
       accessibilityDismissButtonLabel={accessibilityDismissButtonLabel}
       accessibilityLabel={accessibilityLabel}

--- a/packages/gestalt/src/Popover/InternalPopover.tsx
+++ b/packages/gestalt/src/Popover/InternalPopover.tsx
@@ -54,7 +54,7 @@ export default function InternalPopover({
   onPositioned,
   disableFocusTrap = false,
   overflow,
-}: Props): null | ReactNode {
+}: Props) {
   const { accessibilityDismissButtonLabel: accessibilityDismissButtonLabelDefault } =
     useDefaultLabelContext('Popover');
 

--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -163,7 +163,6 @@ export default function PopoverEducational({
 
   return (
     <Box position={zIndex ? 'relative' : undefined} zIndex={zIndex}>
-      {/* @ts-expect-error - TS2786 - 'InternalPopover' cannot be used as a JSX component. */}
       <InternalPopover
         accessibilityLabel={accessibilityLabel}
         anchor={anchor}

--- a/packages/gestalt/src/RadioButton.tsx
+++ b/packages/gestalt/src/RadioButton.tsx
@@ -58,7 +58,7 @@ type Props = {
 /**
  * **NOTE** The standalone RadioButton is soon to be deprecated, use [RadioGroup](https://gestalt.pinterest.systems/web/radiogroup) and RadioGroup.RadioButton instead.**NOTE**
  */
-// @ts-expect-error - TS2345 - Argument of type '({ checked, disabled, id, image, label, name, onChange, subtext, value, size, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const RadioButtonWithForwardRef = forwardRef<HTMLInputElement, Props>(function RadioButton(
   {
     checked = false,
@@ -73,7 +73,7 @@ const RadioButtonWithForwardRef = forwardRef<HTMLInputElement, Props>(function R
     size = 'md',
   }: Props,
   ref,
-): ReactNode {
+) {
   const [focused, setFocused] = useState(false);
   const [hovered, setHover] = useState(false);
 

--- a/packages/gestalt/src/RadioGroupButton.tsx
+++ b/packages/gestalt/src/RadioGroupButton.tsx
@@ -83,7 +83,7 @@ type Props = {
  * ![RadioGroup dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/RadioGroup-dark.spec.mjs-snapshots/RadioGroup-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ checked, disabled, id, image, label, name, onChange, helperText, value, badge, size, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const RadioGroupButtonWithForwardRef = forwardRef<HTMLInputElement, Props>(function RadioButton(
   {
     checked = false,
@@ -99,7 +99,7 @@ const RadioGroupButtonWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
     size = 'md',
   }: Props,
   ref,
-): ReactNode {
+) {
   const [focused, setFocused] = useState(false);
   const [hovered, setHover] = useState(false);
 

--- a/packages/gestalt/src/ScrollBoundaryContainer/InternalScrollBoundaryContainerWithForwardRef.tsx
+++ b/packages/gestalt/src/ScrollBoundaryContainer/InternalScrollBoundaryContainerWithForwardRef.tsx
@@ -17,7 +17,6 @@ type InternalProps = {
 // ScrollBoundaryContainerWithForwardRef is the ScrollBoundaryContainer to be used internally, within components (e. Modal, OverlayPanel).
 // It has an extended API with private props (onScroll, padding, and ref) to maintain border shadows in the component main content container.
 const ScrollBoundaryContainerWithForwardRef = forwardRef<HTMLElement, InternalProps>(
-  // @ts-expect-error - TS2345 - Argument of type '({ children, onScroll, includesFooter, padding, height, overflow, }: InternalProps, ref: ForwardedRef<HTMLElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLElement, InternalProps>'.
   function ScrollBoundaryContainer(
     {
       children,
@@ -28,7 +27,7 @@ const ScrollBoundaryContainerWithForwardRef = forwardRef<HTMLElement, InternalPr
       overflow = 'auto',
     }: InternalProps,
     ref,
-  ): ReactNode {
+  ) {
     const { addRef } = useScrollBoundaryContainer();
     const anchorRef = useRef<HTMLElement | null>(null);
     // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/SearchField.tsx
+++ b/packages/gestalt/src/SearchField.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import classnames from 'classnames';
 import Box from './Box';
 import Icon from './Icon';
@@ -80,7 +80,7 @@ type Props = {
  * ![SearchField dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/SearchField-dark.spec.mjs-snapshots/SearchField-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityClearButtonLabel, autoComplete, id, label, onBlur, onChange, onFocus, onKeyDown, placeholder, size, value, errorMessage, }: Props, ref: ForwardedRef<HTMLInputElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
+
 const SearchFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function SearchField(
   {
     accessibilityLabel,
@@ -98,7 +98,7 @@ const SearchFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function S
     errorMessage,
   }: Props,
   ref,
-): ReactNode {
+) {
   const [hovered, setHovered] = useState<boolean>(false);
   const [focused, setFocused] = useState<boolean>(false);
 

--- a/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.tsx
+++ b/packages/gestalt/src/SideNavigation/PrimaryActionIconButton.tsx
@@ -78,7 +78,6 @@ function ItemIconButton({
     : new FixedZIndex(1);
   const dropdownZIndex = new CompositeZIndex([tooltipZIndex]);
   return (
-    // @ts-expect-error - TS2786 - 'MaybeTooltip' cannot be used as a JSX component.
     <MaybeTooltip
       disabled={open}
       tooltip={{

--- a/packages/gestalt/src/SideNavigationNestedItem.tsx
+++ b/packages/gestalt/src/SideNavigationNestedItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef } from 'react';
 import SideNavigationTopItem from './SideNavigationTopItem';
 
 type Props = {
@@ -38,11 +38,10 @@ type Props = {
  * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
  */
 const SideNavigationNestedItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ active, counter, href, label, onClick }: Props, ref: ForwardedRef<HTMLLIElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLLIElement, Props>'.
   function SideNavigationNestedItem(
     { active, counter, href, label, onClick }: Props,
     ref,
-  ): ReactNode {
+  ) {
     return (
       <SideNavigationTopItem
         ref={ref}

--- a/packages/gestalt/src/SideNavigationNestedItem.tsx
+++ b/packages/gestalt/src/SideNavigationNestedItem.tsx
@@ -38,10 +38,7 @@ type Props = {
  * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
  */
 const SideNavigationNestedItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
-  function SideNavigationNestedItem(
-    { active, counter, href, label, onClick }: Props,
-    ref,
-  ) {
+  function SideNavigationNestedItem({ active, counter, href, label, onClick }: Props, ref) {
     return (
       <SideNavigationTopItem
         ref={ref}

--- a/packages/gestalt/src/SideNavigationTopItem.tsx
+++ b/packages/gestalt/src/SideNavigationTopItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement, ReactNode, useEffect, useId, useState } from 'react';
+import { forwardRef, ReactElement, useEffect, useId, useState } from 'react';
 import classnames from 'classnames';
 import { TOKEN_SPACE_400, TOKEN_SPACE_1200 } from 'gestalt-design-tokens';
 import Badge from './Badge';
@@ -92,7 +92,6 @@ export type Props = {
  * Use [SideNavigation.TopItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.TopItem) to redirect the user to a different page or section. SideNavigation.TopItem must be used at the top level of SideNavigation. It supports badges, icons, counters, and notifications.
  */
 const SideNavigationTopItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ active, href, badge, counter, icon, label, primaryAction, notificationAccessibilityLabel, onClick, }: Props, ref: ForwardedRef<HTMLLIElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLLIElement, Props>'.
   function SideNavigationTopItem(
     {
       active,
@@ -106,7 +105,7 @@ const SideNavigationTopItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
       onClick,
     }: Props,
     ref,
-  ): ReactNode {
+  ) {
     const { nestedLevel } = useNesting();
 
     const {

--- a/packages/gestalt/src/TagData.tsx
+++ b/packages/gestalt/src/TagData.tsx
@@ -195,7 +195,6 @@ export default function TagData({
 
   return (
     <Box display="inlineBlock" maxWidth={300} position="relative" rounding={2}>
-      {/* @ts-expect-error - TS2786 - 'MaybeTooltip' cannot be used as a JSX component. */}
       <MaybeTooltip disabled={disabled} tooltip={tooltip}>
         <TapArea
           disabled={disabled}

--- a/packages/gestalt/src/TapArea.tsx
+++ b/packages/gestalt/src/TapArea.tsx
@@ -152,7 +152,7 @@ type Props = {
  *
  * ![TapArea](https://raw.githubusercontent.com/pinterest/gestalt/master/docs/graphics/building-blocks/TapArea.svg)
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityControls, accessibilityExpanded, accessibilityHaspopup, accessibilityChecked, children, dataTestId, disabled, fullHeight, fullWidth, mouseCursor, onBlur, onKeyDown, onFocus, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onTap, tabIndex, role, rounding, tapStyle, }: Props, re...' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLDivElement, Props>'.
+
 const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea(
   {
     accessibilityLabel,
@@ -180,7 +180,7 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
     tapStyle = 'none',
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLDivElement>(null);
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component
   // that renders <TapArea ref={inputRef} /> to call inputRef.current.focus()

--- a/packages/gestalt/src/TapAreaLink.tsx
+++ b/packages/gestalt/src/TapAreaLink.tsx
@@ -124,7 +124,7 @@ type Props = {
  *
  * ![TapAreaLink](https://raw.githubusercontent.com/pinterest/gestalt/master/docs/graphics/building-blocks/TapArea.svg)
  */
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityCurrent, children, dataTestId, disabled, fullHeight, fullWidth, href, mouseCursor, onBlur, onKeyDown, onFocus, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onTap, tabIndex, rel, rounding, tapStyle, target, }: Props, ref: ForwardedRef<HTMLAnchorElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLAnchorElement, Props>'.
+
 const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function TapAreaLink(
   {
     accessibilityLabel,
@@ -151,7 +151,7 @@ const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function 
     target = null,
   }: Props,
   ref,
-): ReactNode {
+) {
   const innerRef = useRef<null | HTMLAnchorElement>(null);
 
   // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/TextArea.tsx
+++ b/packages/gestalt/src/TextArea.tsx
@@ -104,7 +104,7 @@ type Props = {
  * ![TextArea dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/TextArea-dark.spec.mjs-snapshots/TextArea-dark-chromium-darwin.png)
  *
  */
-// @ts-expect-error - TS2345 - Argument of type '({ dataTestId, disabled, errorMessage, hasError, helperText, id, label, labelDisplay, maxLength, name, onBlur, onChange, onFocus, onKeyDown, placeholder, readOnly, rows, tags, value, }: Props, ref: ForwardedRef<HTMLTextAreaElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLTextAreaElement, Props>'.
+
 const TextAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function TextArea(
   {
     dataTestId,
@@ -128,7 +128,7 @@ const TextAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function T
     value,
   }: Props,
   ref,
-): ReactNode {
+) {
   const [focused, setFocused] = useState(false);
   const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
 

--- a/packages/gestalt/src/TextField/InternalTextField.tsx
+++ b/packages/gestalt/src/TextField/InternalTextField.tsx
@@ -120,7 +120,6 @@ type Props = {
 
 const applyDensityStyle = (size: SizeType) => styles[`${size}`];
 
-// @ts-expect-error - TS2345 - Argument of type '({ accessibilityControls, accessibilityActiveDescendant, autoComplete, dataTestId, disabled, errorMessage, hasError, helperText, id, iconButton, label, labelDisplay, max, maxLength, mobileEnterKeyHint, mobileInputMode, min, name, onBlur, onChange, onClick, onFocus, onKeyDown, placeholder, readOnly, size, step, tags,...' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLInputElement, Props>'.
 const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function TextField(
   {
     accessibilityControls,
@@ -155,7 +154,7 @@ const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(func
     value,
   }: Props,
   ref,
-): ReactNode {
+) {
   // ==== REFS ====
   const innerRef = useRef<null | HTMLInputElement | HTMLDivElement>(null);
   // When using both forwardRef and innerRefs, useimperativehandle() allows to externally set focus via the ref prop: textfieldRef.current.focus()

--- a/packages/gestalt/src/TileData.tsx
+++ b/packages/gestalt/src/TileData.tsx
@@ -146,7 +146,6 @@ export default function TileData({
   });
 
   return (
-    // @ts-expect-error - TS2786 - 'MaybeTooltip' cannot be used as a JSX component.
     <MaybeTooltip disabled={disabled} tooltip={tooltip}>
       <Box>
         <TapArea

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -629,7 +629,7 @@ export default class Video extends PureComponent<Props, State> {
     onWaiting?.({ event });
   };
 
-  render(): ReactNode {
+  render() {
     const {
       aspectRatio,
       autoplay,

--- a/packages/gestalt/src/Video/Playhead.tsx
+++ b/packages/gestalt/src/Video/Playhead.tsx
@@ -1,4 +1,4 @@
-import { PureComponent, ReactNode } from 'react';
+import { PureComponent } from 'react';
 import Box from '../Box';
 import styles from '../Video.css';
 
@@ -158,7 +158,7 @@ export default class VideoPlayhead extends PureComponent<Props, State> {
     onPlayheadUp(event);
   };
 
-  render(): ReactNode {
+  render() {
     const { accessibilityProgressBarLabel, currentTime, duration } = this.props;
     const width = `${Math.floor((currentTime * 10000) / duration) / 100}%`;
 

--- a/packages/gestalt/src/behaviors/StopScrollBehavior.ts
+++ b/packages/gestalt/src/behaviors/StopScrollBehavior.ts
@@ -26,7 +26,7 @@ export default class NoScrollBehavior extends Component<Props> {
     }
   }
 
-  render(): ReactNode {
+  render() {
     return this.props.children;
   }
 }

--- a/packages/gestalt/src/sharedSubcomponents/InternalDismissButton.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/InternalDismissButton.tsx
@@ -7,7 +7,6 @@ InternalDismissIconButton aims to replace "dismiss" IconButtons in components th
 import {
   ComponentProps,
   forwardRef,
-  ReactNode,
   useImperativeHandle,
   useRef,
   useState,
@@ -30,7 +29,6 @@ type Props = {
 };
 
 const InternalDismissIconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(
-  // @ts-expect-error - TS2345 - Argument of type '({ accessibilityLabel, accessibilityControls, iconColor, onClick, size, }: Props, ref: ForwardedRef<HTMLButtonElement>) => ReactNode' is not assignable to parameter of type 'ForwardRefRenderFunction<HTMLButtonElement, Props>'.
   function IconButton(
     {
       accessibilityLabel,
@@ -40,7 +38,7 @@ const InternalDismissIconButtonWithForwardRef = forwardRef<HTMLButtonElement, Pr
       size = 'lg',
     }: Props,
     ref,
-  ): ReactNode {
+  ) {
     const innerRef = useRef<HTMLButtonElement | null>(null);
 
     // When using both forwardRef and innerRef, React.useimperativehandle() allows a parent component

--- a/packages/gestalt/src/sharedSubcomponents/InternalDismissButton.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/InternalDismissButton.tsx
@@ -4,13 +4,7 @@ InternalDismissIconButton aims to replace "dismiss" IconButtons in components th
 
 */
 
-import {
-  ComponentProps,
-  forwardRef,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react';
+import { ComponentProps, forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import classnames from 'classnames';
 import styles from '../IconButton.css';
 import Pog from '../Pog';

--- a/packages/gestalt/src/sharedSubcomponents/MaybeTooltip.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/MaybeTooltip.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import InternalTooltip from '../Tooltip/InternalTooltip';
 import { Indexable } from '../zIndex';
 
@@ -15,7 +15,7 @@ export default function MaybeTooltip({
   disabled,
   tooltip,
 }: {
-  children: ReactNode;
+  children: ReactElement;
   disabled?: boolean;
   tooltip?: TooltipProps;
 }) {


### PR DESCRIPTION
Internal: fix some TS suppressions due to ReactNode

ReactNode can be everything: a  string, undefined, ReactElement... and .tsx files should only return ReactElements
