### PR TITLE
Image: Address onLoad not being called for SSR images

### DIFF
--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -149,8 +149,8 @@ export default class Image extends PureComponent<Props> {
       // Since we don't have the SyntheticEvent here,
       // we must create one with the same shape.
       // See https://reactjs.org/docs/events.html
-      const loadEvent = new Event('load')
-      Object.defineProperty(loadEvent, 'target', { writable: false, value: node })
+      const loadEvent = new Event('load');
+      Object.defineProperty(loadEvent, 'target', { writable: false, value: node });
       this.handleLoad({
         ...loadEvent,
         nativeEvent: loadEvent,
@@ -163,7 +163,7 @@ export default class Image extends PureComponent<Props> {
         stopPropagation: () => {},
       });
     }
-  }
+  };
 
   render() {
     const {


### PR DESCRIPTION
# Summary
`<Image />` accepts an `onLoad` callback which ends up being attached to the native `img` element's `load` event handler and is triggered once the image resource has finished loading. 

The problem with this approach is that the `onLoad` handler does not get triggered if the image resource has already finished loading _before_ the `<Image />` component is rendered. The most common scenario of this happening is server-side rendering since the image request will be kicked off via the server-rendered HTML and, very likely, be completed by the time client hydration happens.

# Change
This PR introduces a fix for this by attached a ref callback to the native `img` callback which will do the following:
- check that `_fixCompletedOnLoad` is true, the [img complete attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/complete) is true, and the `onLoad` callback has not yet been triggered
- if the above is true, we will call `onLoad` will a fake load Event. Because the load event has already happened, we need to construct our own.

## Why is this in an experiment
I discovered this issue when debugging an impression drop with my Masonry V2 experiment. I found that, because my experiment resulted in the initial server rendered Pins not being unmounted/re-mounted, the image onLoad callbacks were never being triggered and consequently, we were not logging impressions.

I'm planning to test this change across both control and enabled groups of the Masonry V2 experiment to validate this and in parallel, will chat with metrics quality about rolling this out since it _could_ have impression impact. 
