### PR TITLE
Badge: add interactive icon to all types

### DIFF
--- a/docs/examples/badge/variantsType.tsx
+++ b/docs/examples/badge/variantsType.tsx
@@ -29,7 +29,7 @@ export default function Example() {
                   <Badge
                     text="New"
                     tooltip={{
-                      text: 'This is a new feature',
+                      text: 'Collages is a new feature',
                       idealDirection: 'up',
                     }}
                     type="info"
@@ -44,9 +44,22 @@ export default function Example() {
               <Text>Success</Text>
             </Table.Cell>
             <Table.Cell>
-              <Text size="300">
-                Ads & Campaigns <Badge text="Completed" type="success" />
-              </Text>
+              <Flex direction="column" gap={2}>
+                <Text size="300">
+                  Ads & Campaigns <Badge text="Completed" type="success" />
+                </Text>
+                <Text size="300">
+                  Ads & Campaigns{' '}
+                  <Badge
+                    text="Completed"
+                    tooltip={{
+                      text: 'Your onboarding is almost completed',
+                      idealDirection: 'up',
+                    }}
+                    type="success"
+                  />
+                </Text>
+              </Flex>
             </Table.Cell>
           </Table.Row>
 
@@ -55,9 +68,22 @@ export default function Example() {
               <Text>Warning</Text>
             </Table.Cell>
             <Table.Cell>
-              <Text size="300">
-                Ads & Campaigns <Badge text="Needs attention" type="warning" />
-              </Text>
+              <Flex direction="column" gap={2}>
+                <Text size="300">
+                  Ads & Campaigns <Badge text="Needs attention" type="warning" />
+                </Text>
+                <Text size="300">
+                  Ads & Campaigns{' '}
+                  <Badge
+                    text="Needs attention"
+                    tooltip={{
+                      text: 'Your account needs attention',
+                      idealDirection: 'up',
+                    }}
+                    type="warning"
+                  />
+                </Text>
+              </Flex>
             </Table.Cell>
           </Table.Row>
 
@@ -66,9 +92,22 @@ export default function Example() {
               <Text>Error</Text>
             </Table.Cell>
             <Table.Cell>
-              <Text size="300">
-                Ads & Campaigns <Badge text="Failed" type="error" />
-              </Text>
+              <Flex direction="column" gap={2}>
+                <Text size="300">
+                  Ads & Campaigns <Badge text="Failed" type="error" />
+                </Text>
+                <Text size="300">
+                  Ads & Campaigns{' '}
+                  <Badge
+                    text="Failed"
+                    tooltip={{
+                      text: 'Your uploading failed',
+                      idealDirection: 'up',
+                    }}
+                    type="error"
+                  />
+                </Text>
+              </Flex>
             </Table.Cell>
           </Table.Row>
 
@@ -77,9 +116,22 @@ export default function Example() {
               <Text>Neutral</Text>
             </Table.Cell>
             <Table.Cell>
-              <Text size="300">
-                Ads & Campaigns <Badge text="Not started" type="neutral" />
-              </Text>
+              <Flex direction="column" gap={2}>
+                <Text size="300">
+                  Ads & Campaigns <Badge text="Not started" type="neutral" />
+                </Text>{' '}
+                <Text size="300">
+                  Ads & Campaigns{' '}
+                  <Badge
+                    text="Not started"
+                    tooltip={{
+                      text: 'Your campaign has not started',
+                      idealDirection: 'up',
+                    }}
+                    type="neutral"
+                  />
+                </Text>{' '}
+              </Flex>
             </Table.Cell>
           </Table.Row>
 
@@ -88,9 +140,22 @@ export default function Example() {
               <Text>Recommendation</Text>
             </Table.Cell>
             <Table.Cell>
-              <Text size="300">
-                Ads & Campaigns <Badge text="Recommended for you" type="recommendation" />
-              </Text>
+              <Flex direction="column" gap={2}>
+                <Text size="300">
+                  Ads & Campaigns <Badge text="Recommended for you" type="recommendation" />
+                </Text>{' '}
+                <Text size="300">
+                  Ads & Campaigns{' '}
+                  <Badge
+                    text="Recommended for you"
+                    tooltip={{
+                      text: 'This business product is recommended for you',
+                      idealDirection: 'up',
+                    }}
+                    type="recommendation"
+                  />
+                </Text>
+              </Flex>
             </Table.Cell>
           </Table.Row>
         </Table.Body>

--- a/docs/pages/web/badge.tsx
+++ b/docs/pages/web/badge.tsx
@@ -125,7 +125,7 @@ export default function DocsPage({ generatedDocGen }: { generatedDocGen: DocGen 
                 code={variantsType}
                 layout="column"
                 name="Variants - Type"
-                previewHeight={400}
+                previewHeight={600}
               />
             }
           />

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -50,7 +50,7 @@
   background-color: var(--color-background-badge-recommendation);
 }
 
-.neutral ,
+.neutral,
 .interactive-neutral {
   background-color: var(--color-background-badge-neutral);
 }

--- a/packages/gestalt/src/Badge.css
+++ b/packages/gestalt/src/Badge.css
@@ -21,41 +21,48 @@
 /* Color */
 
 .info,
-.interactiveInfo {
+.interactive-info {
   background-color: var(--color-background-badge-info-default);
 }
 
-.interactiveInfo:hover,
-.interactiveInfo:focus {
+.interactive-info:hover,
+.interactive-info:focus {
   background-color: var(--color-background-badge-info-hover);
 }
 
-.error {
+.error,
+.interactive-error {
   background-color: var(--color-background-badge-error);
 }
 
-.warning {
+.warning,
+.interactive-warning {
   background-color: var(--color-background-badge-warning);
 }
 
-.success {
+.success,
+.interactive-success {
   background-color: var(--color-background-badge-success);
 }
 
-.recommendation {
+.recommendation,
+.interactive-recommendation {
   background-color: var(--color-background-badge-recommendation);
 }
 
-.neutral {
+.neutral ,
+.interactive-neutral {
   background-color: var(--color-background-badge-neutral);
 }
 
-.darkWash {
+.darkWash,
+.interactive-darkWash {
   background-color: var(--color-background-badge-darkwash);
   color: var(--color-text-light);
 }
 
-.lightWash {
+.lightWash,
+.interactive-lightWash {
   background-color: var(--color-background-badge-lightwash);
   color: var(--color-text-dark);
 }

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -1,3 +1,4 @@
+import { ComponentProps } from 'react';
 import cx from 'classnames';
 import styles from './Badge.css';
 import Box from './Box';
@@ -25,6 +26,16 @@ export type TypeOptions =
   | 'darkWash'
   | 'lightWash';
 
+type InteractiveTypeOptions =
+  | 'interactive-info'
+  | 'interactive-error'
+  | 'interactive-warning'
+  | 'interactive-success'
+  | 'interactive-neutral'
+  | 'interactive-recommendation'
+  | 'interactive-darkWash'
+  | 'interactive-lightWash';
+
 type Props = {
   /**
    * Badge position relative to its parent element. See the [positioning](https://gestalt.pinterest.systems/web/badge#Positioning) variant to learn more.
@@ -51,16 +62,25 @@ type Props = {
  * ![Badge dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Badge-dark.spec.ts-snapshots/Badge-dark-chromium-darwin.png)
  *
  */
-
 export default function Badge({ position = 'middle', text, type = 'info', tooltip }: Props) {
-  const isInfoType = type === 'info';
+  const shouldUseTooltip = tooltip?.text;
 
-  const shouldUseTooltip = isInfoType && tooltip?.text;
+  const ICON_MAP = Object.freeze({
+    'info': 'info-circle',
+    'error': 'workflow-status-problem',
+    'warning': 'workflow-status-warning',
+    'success': 'check-circle',
+    'neutral': 'lock',
+    'recommendation': 'performance-plus',
+    'darkWash': 'info-circle',
+    'lightWash': 'info-circle',
+  });
 
-  let styleType: TypeOptions | 'interactiveInfo' = type;
+
+  let styleType: TypeOptions | InteractiveTypeOptions = type;
 
   if (shouldUseTooltip) {
-    styleType = 'interactiveInfo';
+    styleType = `interactive-${type}`;
   }
 
   const csBadge = cx(styles.Badge, styles[position], styles[styleType]);
@@ -70,7 +90,7 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
       <Flex alignItems="center" gap={1}>
         {shouldUseTooltip ? (
           <Box aria-hidden>
-            <Icon accessibilityLabel="" color="inverse" icon="info-circle" inline size="14" />
+            <Icon accessibilityLabel="" color="inverse" icon={ICON_MAP[type] as ComponentProps<typeof Icon>['icon'] } inline size="14" />
           </Box>
         ) : null}
         <Box dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }} display="inlineBlock">
@@ -80,7 +100,7 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
     </div>
   );
 
-  return isInfoType && tooltip?.text ? (
+  return shouldUseTooltip ? (
     <Tooltip
       accessibilityLabel={tooltip.accessibilityLabel}
       idealDirection={tooltip.idealDirection}

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -76,7 +76,6 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
     'lightWash': 'info-circle',
   });
 
-
   let styleType: TypeOptions | InteractiveTypeOptions = type;
 
   if (shouldUseTooltip) {
@@ -90,7 +89,13 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
       <Flex alignItems="center" gap={1}>
         {shouldUseTooltip ? (
           <Box aria-hidden>
-            <Icon accessibilityLabel="" color="inverse" icon={ICON_MAP[type] as ComponentProps<typeof Icon>['icon'] } inline size="14" />
+            <Icon
+              accessibilityLabel=""
+              color="inverse"
+              icon={ICON_MAP[type] as ComponentProps<typeof Icon>['icon']}
+              inline
+              size="14"
+            />
           </Box>
         ) : null}
         <Box dangerouslySetInlineStyle={{ __style: { marginTop: '2px' } }} display="inlineBlock">

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -46,7 +46,7 @@ type Props = {
    */
   text: string;
   /**
-   *  Experimental prop, do not use. Adds a [Tooltip](/web/tooltip) on hover/focus of the Badge. To convey the interaction, it also displays an information Icon. See the [type](https://gestalt.pinterest.systems/web/badge#Type) variant to learn more.
+   *  Adds a [Tooltip](https://gestalt.pinterest.systems/web/tooltip) on hover/focus of the Badge. To convey the interaction, it also displays an Icon. See the [type](https://gestalt.pinterest.systems/web/badge#Type) variant to learn more.
    */
   tooltip?: TooltipProps;
   /**


### PR DESCRIPTION
Badge: add interactive icon to all types

BEFORE

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/b062bada-023a-4382-8a6c-bef68bf826ea)


AFTER
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/857aa233-8dc4-448d-a4a8-c5f92d89a7f5)
