### PR TITLE
PageHeader: standardize tooltip prop

### DIFF
--- a/docs/examples/pageheader/titleExample.tsx
+++ b/docs/examples/pageheader/titleExample.tsx
@@ -6,7 +6,7 @@ export default function PageHeaderTitleExample() {
   return (
     <Fragment>
       <PageHeader
-        badge={{ text: 'New', type: 'info', tooltipText: 'New integration' }}
+        badge={{ text: 'New', type: 'info', tooltip: { text: 'New integration' } }}
         helperIconButton={{
           accessibilityControls: '',
           accessibilityExpanded: false,

--- a/docs/pages/visual-test/PageHeader-thumbnail-badge-iconButton.tsx
+++ b/docs/pages/visual-test/PageHeader-thumbnail-badge-iconButton.tsx
@@ -4,7 +4,7 @@ export default function Snapshot() {
   return (
     <Box width="100vw">
       <PageHeader
-        badge={{ text: 'Beta', tooltipText: 'This feature is on beta phase' }}
+        badge={{ text: 'Beta', tooltip: { text: 'This feature is on beta phase' } }}
         helperIconButton={{
           accessibilityLabel: 'test',
           accessibilityControls: 'test',

--- a/packages/gestalt/src/PageHeader.tsx
+++ b/packages/gestalt/src/PageHeader.tsx
@@ -12,6 +12,7 @@ import {
   PageHeaderThumbnail,
   PageHeaderTitle,
 } from './PageHeader/components';
+import { Indexable } from './zIndex';
 
 export type ActionType = ReactElement;
 
@@ -23,7 +24,12 @@ type Props = {
    */
   badge?: {
     text: string;
-    tooltipText?: string;
+    tooltip?: {
+      accessibilityLabel?: string;
+      idealDirection?: 'up' | 'right' | 'down' | 'left';
+      text: string;
+      zIndex?: Indexable;
+    };
     type?:
       | 'info'
       | 'error'
@@ -147,7 +153,7 @@ export default function PageHeader({
                           {badge ? (
                             <PageHeaderBadge
                               badgeText={badge.text}
-                              badgeTooltipText={badge.tooltipText}
+                              badgeTooltip={badge.tooltip}
                               type={badge.type}
                             />
                           ) : null}

--- a/packages/gestalt/src/PageHeader/components.tsx
+++ b/packages/gestalt/src/PageHeader/components.tsx
@@ -1,4 +1,12 @@
-import { cloneElement, ComponentProps, Fragment, ReactElement, ReactNode, useRef, useState } from 'react';
+import {
+  cloneElement,
+  ComponentProps,
+  Fragment,
+  ReactElement,
+  ReactNode,
+  useRef,
+  useState,
+} from 'react';
 import Badge, { TypeOptions } from '../Badge';
 import Box from '../Box';
 import Dropdown from '../Dropdown';
@@ -59,12 +67,7 @@ export function PageHeaderBadge({
   type?: TypeOptions;
 }) {
   return badgeTooltip ? (
-    <Badge
-      position="middle"
-      text={badgeText}
-      tooltip={badgeTooltip}
-      type={type}
-    />
+    <Badge position="middle" text={badgeText} tooltip={badgeTooltip} type={type} />
   ) : (
     <Badge position="middle" text={badgeText} type={type} />
   );

--- a/packages/gestalt/src/PageHeader/components.tsx
+++ b/packages/gestalt/src/PageHeader/components.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, Fragment, ReactElement, ReactNode, useRef, useState } from 'react';
+import { cloneElement, ComponentProps, Fragment, ReactElement, ReactNode, useRef, useState } from 'react';
 import Badge, { TypeOptions } from '../Badge';
 import Box from '../Box';
 import Dropdown from '../Dropdown';
@@ -51,22 +51,18 @@ export function PageHeaderThumbnail({ thumbnail }: { thumbnail: ReactNode }) {
 
 export function PageHeaderBadge({
   badgeText,
-  badgeTooltipText,
+  badgeTooltip,
   type = 'info',
 }: {
   badgeText: string;
-  badgeTooltipText?: string;
+  badgeTooltip?: ComponentProps<typeof Badge>['tooltip'];
   type?: TypeOptions;
 }) {
-  return badgeTooltipText ? (
+  return badgeTooltip ? (
     <Badge
       position="middle"
       text={badgeText}
-      tooltip={{
-        accessibilityLabel: '',
-        text: badgeTooltipText,
-        idealDirection: 'up',
-      }}
+      tooltip={badgeTooltip}
       type={type}
     />
   ) : (


### PR DESCRIPTION
## BREAKING CHANGE

first

```
yarn codemod modifyProp ~/path/to/your/code
--component=PageHeader
--previousProp=tooltipText
--nextProp=tooltip
```

PageHeader: standardize tooltip prop