### PR TITLE
SideNavigation: Add `primaryAction` prop to all nested subcomponents

### DIFF
--- a/docs/examples/sidenavigation/primaryAction.tsx
+++ b/docs/examples/sidenavigation/primaryAction.tsx
@@ -5,16 +5,25 @@ export default function Example() {
   const [mobile, setMobile] = useState(false);
 
   return (
-    <Box color="lightWash" height="100%" padding={4}>
+    <Box color="lightWash" height="100%" padding={4} position="relative">
       <Flex gap={12}>
         <Button color="red" onClick={() => setMobile(true)} text="View mobile" />
         <DeviceTypeProvider deviceType={mobile ? 'mobile' : 'desktop'}>
-          <Box bottom id="sidenavigation" left position={mobile ? 'absolute' : undefined} right top>
+          <Box
+            bottom
+            id="sidenavigation"
+            left={mobile}
+            position={mobile ? 'absolute' : undefined}
+            right={mobile}
+            top={mobile}
+            width={mobile ? undefined : 360}
+          >
             <SideNavigation
               accessibilityLabel="Notification example"
               dismissButton={{ onDismiss: () => setMobile((value) => !value) }}
             >
               <SideNavigation.TopItem
+                counter={{ number: '10', accessibilityLabel: '10 updates' }}
                 href="#"
                 label="Campaign z-168i"
                 onClick={({ event }) => {
@@ -72,12 +81,98 @@ export default function Example() {
                   href="#"
                   label="West Coast"
                   onClick={({ event }) => event.preventDefault()}
+                  primaryAction={{
+                    onClick: ({ event }) => {
+                      event.preventDefault();
+                    },
+                    tooltip: { text: 'More options' },
+                    dropdownItems: [
+                      <Dropdown.Item
+                        key="edit"
+                        onSelect={() => {}}
+                        option={{ value: 'Edit', label: 'Edit' }}
+                      />,
+                      <Dropdown.Item
+                        key="trash"
+                        onSelect={() => {}}
+                        option={{ value: 'Delete', label: 'Delete' }}
+                      />,
+                    ],
+                  }}
                 />
                 <SideNavigation.NestedItem
                   href="#"
                   label="East Coast"
                   onClick={({ event }) => event.preventDefault()}
+                  primaryAction={{
+                    onClick: ({ event }) => {
+                      event.preventDefault();
+                    },
+                    tooltip: { text: 'More options' },
+                    dropdownItems: [
+                      <Dropdown.Item
+                        key="edit"
+                        onSelect={() => {}}
+                        option={{ value: 'Edit', label: 'Edit' }}
+                      />,
+                      <Dropdown.Item
+                        key="trash"
+                        onSelect={() => {}}
+                        option={{ value: 'Delete', label: 'Delete' }}
+                      />,
+                    ],
+                  }}
                 />
+                <SideNavigation.NestedGroup
+                  label="Alternative campaigns"
+                  primaryAction={{
+                    onClick: ({ event }) => {
+                      event.preventDefault();
+                    },
+                    tooltip: { text: 'More options' },
+                    dropdownItems: [
+                      <Dropdown.Item
+                        key="edit"
+                        onSelect={() => {}}
+                        option={{ value: 'Edit', label: 'Edit' }}
+                      />,
+                      <Dropdown.Item
+                        key="trash"
+                        onSelect={() => {}}
+                        option={{ value: 'Delete', label: 'Delete' }}
+                      />,
+                    ],
+                  }}
+                >
+                  <SideNavigation.NestedItem
+                    href="#"
+                    label="West Coast"
+                    onClick={({ event }) => event.preventDefault()}
+                    primaryAction={{
+                      onClick: ({ event }) => {
+                        event.preventDefault();
+                      },
+                      tooltip: { text: 'More options' },
+                      dropdownItems: [
+                        <Dropdown.Item
+                          key="edit"
+                          onSelect={() => {}}
+                          option={{ value: 'Edit', label: 'Edit' }}
+                        />,
+                        <Dropdown.Item
+                          key="trash"
+                          onSelect={() => {}}
+                          option={{ value: 'Delete', label: 'Delete' }}
+                        />,
+                      ],
+                    }}
+                  />
+                  <SideNavigation.NestedItem
+                    href="#"
+                    label="East Coast"
+                    onClick={({ event }) => event.preventDefault()}
+                  />
+                </SideNavigation.NestedGroup>
               </SideNavigation.Group>
               <SideNavigation.TopItem
                 counter={{ number: '87', accessibilityLabel: '87 archived campaings' }}

--- a/packages/gestalt/src/SideNavigationNestedGroup.tsx
+++ b/packages/gestalt/src/SideNavigationNestedGroup.tsx
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import SideNavigationGroup from './SideNavigationGroup';
+import { Indexable } from './zIndex';
 
 type Props = {
   /**
@@ -29,6 +30,21 @@ type Props = {
    * Callback fired when the expand button component is clicked and the component is controlled. This functionality is not supported in mobile.
    */
   onExpand?: (arg1: { expanded: boolean }) => void;
+  /**
+   * The primary action for each item. See the [primary action variant](https://gestalt.pinterest.systems/web/sidenavigation#Primary-action) to learn more.
+   */
+  primaryAction?: {
+    icon?: 'ellipsis' | 'edit' | 'trash-can';
+    onClick?: (arg1: {
+      event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>;
+    }) => void;
+    tooltip: {
+      accessibilityLabel?: string;
+      text: string;
+      zIndex?: Indexable;
+    };
+    dropdownItems?: ReadonlyArray<ReactElement>;
+  };
 };
 
 /**
@@ -40,6 +56,7 @@ export default function SideNavigationNestedGroup({
   display = 'expandable',
   expanded,
   label,
+  primaryAction,
   onExpand,
 }: Props) {
   return (
@@ -49,6 +66,7 @@ export default function SideNavigationNestedGroup({
       expanded={expanded}
       label={label}
       onExpand={onExpand}
+      primaryAction={primaryAction}
     >
       {children}
     </SideNavigationGroup>

--- a/packages/gestalt/src/SideNavigationNestedItem.tsx
+++ b/packages/gestalt/src/SideNavigationNestedItem.tsx
@@ -1,5 +1,6 @@
-import { forwardRef } from 'react';
+import { forwardRef, ReactElement } from 'react';
 import SideNavigationTopItem from './SideNavigationTopItem';
+import { Indexable } from './zIndex';
 
 type Props = {
   /**
@@ -29,6 +30,21 @@ type Props = {
     dangerouslyDisableOnNavigation: () => void;
   }) => void;
   /**
+   * The primary action for each item. See the [primary action variant](https://gestalt.pinterest.systems/web/sidenavigation#Primary-action) to learn more.
+   */
+  primaryAction?: {
+    icon?: 'ellipsis' | 'edit' | 'trash-can';
+    onClick?: (arg1: {
+      event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>;
+    }) => void;
+    tooltip: {
+      accessibilityLabel?: string;
+      text: string;
+      zIndex?: Indexable;
+    };
+    dropdownItems?: ReadonlyArray<ReactElement>;
+  };
+  /**
    * Ref that is forwarded to the underlying `li` element.
    */
   ref?: HTMLLIElement; // eslint-disable-line react/no-unused-prop-types
@@ -38,7 +54,10 @@ type Props = {
  * Use [SideNavigation.NestedItem](https://gestalt.pinterest.systems/web/sidenavigation#SideNavigation.NestedItem) to redirect the user to a different page or section. SideNavigation.NestedItem must be used in second and third nested levels.
  */
 const SideNavigationNestedItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
-  function SideNavigationNestedItem({ active, counter, href, label, onClick }: Props, ref) {
+  function SideNavigationNestedItem(
+    { active, counter, href, label, onClick, primaryAction }: Props,
+    ref,
+  ) {
     return (
       <SideNavigationTopItem
         ref={ref}
@@ -47,6 +66,7 @@ const SideNavigationNestedItemWithForwardRef = forwardRef<HTMLLIElement, Props>(
         href={href}
         label={label}
         onClick={onClick}
+        primaryAction={primaryAction}
       />
     );
   },


### PR DESCRIPTION
### Summary

Now all the subcomponents of SideNavigation can have `primaryAction`.

![ezgif-3-9e29e22f3f](https://github.com/pinterest/gestalt/assets/29589560/cdc55943-3bfe-4184-b459-d53e2c6f3a29)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-8031)
- [Figma](https://www.figma.com/design/vjhfBsOtHw0wVg67vqwz1v/branch/V3zxGsrUf68qHDFNmD7rKw/Gestalt-for-Web?m=auto&node-id=35045-2125&t=aAacqGW7EWFWfDga-1)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
