### PR TITLE
Video: Add `dataTestId` prop

### DIFF
--- a/packages/gestalt/src/Video.test.tsx
+++ b/packages/gestalt/src/Video.test.tsx
@@ -132,3 +132,16 @@ test('Video with startTime', () => {
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Video with dataTestId', () => {
+  const tree = create(
+    <Video
+      aspectRatio={1}
+      dataTestId="gestalt-video"
+      onPlay={() => {}}
+      onPlayError={() => {}}
+      src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+    />,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -42,6 +42,10 @@ type Props = {
    */
   controls?: boolean;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Disable remote playback. See [MDN Web Docs: disableRemotePlayback](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/disableRemotePlayback) for more info.
    */
   disableRemotePlayback?: boolean;
@@ -637,6 +641,7 @@ export default class Video extends PureComponent<Props, State> {
       captions,
       children,
       crossOrigin,
+      dataTestId,
       disableRemotePlayback,
       loop,
       objectFit,
@@ -675,6 +680,7 @@ export default class Video extends PureComponent<Props, State> {
           {...({ crossOrigin: crossOriginPolicy } as {
             crossOrigin?: CrossOrigin;
           })}
+          data-test-id={dataTestId}
           disableRemotePlayback={disableRemotePlayback}
           loop={loop}
           muted={volume === 0}

--- a/packages/gestalt/src/__snapshots__/Video.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Video.test.tsx.snap
@@ -339,6 +339,45 @@ exports[`Video with crossOrigin 1`] = `
 </div>
 `;
 
+exports[`Video with dataTestId 1`] = `
+<div
+  className="player blackBg"
+  style={
+    Object {
+      "height": 0,
+      "paddingBottom": "100%",
+    }
+  }
+>
+  <video
+    className="video"
+    data-test-id="gestalt-video"
+    disableRemotePlayback={false}
+    muted={true}
+    onCanPlay={[Function]}
+    onDurationChange={[Function]}
+    onEnded={[Function]}
+    onError={[Function]}
+    onLoadStart={[Function]}
+    onPause={[Function]}
+    onPlay={[Function]}
+    onPlaying={[Function]}
+    onProgress={[Function]}
+    onSeeked={[Function]}
+    onSeeking={[Function]}
+    onStalled={[Function]}
+    onTimeUpdate={[Function]}
+    onWaiting={[Function]}
+    preload="auto"
+    src="https://media.w3.org/2010/05/sintel/trailer_hd.mp4"
+  >
+    <track
+      kind="captions"
+    />
+  </video>
+</div>
+`;
+
 exports[`Video with media attributes 1`] = `
 <div
   className="player blackBg"


### PR DESCRIPTION
### Summary

#### What changed?

- Add an optional `dataTestId` prop to Video

#### Why?
- Better compatibility with react testing library by allowing us to use `screen.queryByTestId` rather than `container.querySelector('video')`

### Checklist

- [x] Added unit tests
- [x] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
