### PR TITLE
Flex: Added forwardRef to Flex, Flex.Item

### DIFF
--- a/packages/gestalt/src/Flex.tsx
+++ b/packages/gestalt/src/Flex.tsx
@@ -1,4 +1,4 @@
-import { Children, forwardRef, ForwardRefExoticComponent, ReactNode } from 'react';
+import { Children, ReactNode } from 'react';
 import { buildStyles } from './boxTransforms';
 import styles from './Flex.css';
 import FlexItem from './FlexItem';
@@ -89,10 +89,6 @@ type Props = {
    */
   overflow?: 'visible' | 'hidden' | 'scroll' | 'scrollX' | 'scrollY' | 'auto';
   /**
-   * Ref that is forwarded to the underlying div element.
-   */
-  ref?: HTMLDivElement;
-  /**
    * Use numbers for pixels: `width={100}` and strings for percentages: `width="100%"`.
    */
   width?: Dimension;
@@ -131,63 +127,50 @@ const allowedProps = [
  * ![Flex light mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Flex.spec.ts-snapshots/Flex-chromium-darwin.png)
  *
  */
-const FlexWithForwardRef = forwardRef<HTMLDivElement, Props>(
-  (
-    {
-      children: childrenProp,
-      dataTestId,
-      direction = 'row',
-      gap = 0,
+export default function Flex({
+  children: childrenProp,
+  dataTestId,
+  direction = 'row',
+  gap = 0,
+  justifyContent,
+  ...rest
+}: Props) {
+  const children = gap
+    ? // @ts-expect-error - TS2533 - Object is possibly 'null' or 'undefined'.
+      Children.map(childrenProp, (child, index) => {
+        if (child === null || child === undefined) {
+          return null;
+        }
+        return wrapWithComponent({
+          element: child,
+          Component: FlexItem,
+          props: {
+            // @ts-expect-error - TS2322 - Type '{ key: number; }' is not assignable to type 'Props'.
+            key: index,
+          },
+        });
+      }).filter(Boolean)
+    : childrenProp;
+
+  const gapStyles = `${styles[`rowGap${typeof gap === 'number' ? gap : gap.row}`]} ${
+    styles[`columnGap${typeof gap === 'number' ? gap : gap.column}`]
+  }`;
+
+  const { passthroughProps, propsStyles } = buildStyles<Props>({
+    baseStyles: `${styles.Flex} ${gapStyles}`,
+    props: {
+      ...rest,
+      children,
+      direction,
       justifyContent,
-      ...rest
-    }: Props,
-    ref,
-  ) => {
-    const children = gap
-      ? // @ts-expect-error - TS2533 - Object is possibly 'null' or 'undefined'.
-        Children.map(childrenProp, (child, index) => {
-          if (child === null || child === undefined) {
-            return null;
-          }
-          return wrapWithComponent({
-            element: child,
-            Component: FlexItem,
-            props: {
-              key: index,
-            },
-          });
-        }).filter(Boolean)
-      : childrenProp;
+    },
+    allowlistProps: allowedProps,
+  });
 
-    const gapStyles = `${styles[`rowGap${typeof gap === 'number' ? gap : gap.row}`]} ${
-      styles[`columnGap${typeof gap === 'number' ? gap : gap.column}`]
-    }`;
-
-    const { passthroughProps, propsStyles } = buildStyles<Props>({
-      baseStyles: `${styles.Flex} ${gapStyles}`,
-      props: {
-        ...rest,
-        children,
-        direction,
-        justifyContent,
-      },
-      allowlistProps: allowedProps,
-    });
-
-    // @ts-expect-error - TS2322 - Type '{ "data-test-id": string | undefined; className: string | null | undefined; style: InlineStyle | null | undefined; alignContent?: "center" | "start" | "end" | "stretch" | "between" | "around" | "evenly" | undefined; ... 18 more ...; wrap?: boolean | undefined; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-    return <div ref={ref} {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
-  },
-);
-
-// Define the type for FlexWithForwardRef to include the subcomponent, otherwise typescript does not recognize Flex.Item
-interface FlexWithSubComponents
-  extends ForwardRefExoticComponent<Props & React.RefAttributes<HTMLDivElement>> {
-  Item: typeof FlexItem;
+  // @ts-expect-error - TS2322 - Type '{ "data-test-id": string | undefined; className: string | null | undefined; style: InlineStyle | null | undefined; alignContent?: "center" | "start" | "end" | "stretch" | "between" | "around" | "evenly" | undefined; ... 18 more ...; wrap?: boolean | undefined; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
+  return <div {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
 }
 
-// Attach the subcomponent to the main component
-(FlexWithForwardRef as FlexWithSubComponents).Item = FlexItem;
+Flex.Item = FlexItem;
 
-FlexWithForwardRef.displayName = 'Flex';
-
-export default FlexWithForwardRef as FlexWithSubComponents;
+Flex.displayName = 'Flex';

--- a/packages/gestalt/src/FlexItem.tsx
+++ b/packages/gestalt/src/FlexItem.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { buildStyles } from './boxTransforms';
 import styles from './Flex.css';
 
@@ -34,10 +34,6 @@ export type Props = {
    * Use numbers for pixels: `minWidth={100}` and strings for percentages: `minWidth="100%"`. Can be used to fix overflowing children; see [the example](https://gestalt.pinterest.systems/web/flex#FlexItem-minWidth) to learn more.
    */
   minWidth?: Dimension;
-  /**
-   *  Ref that is forwarded to the underlying div element.
-   */
-  ref?: HTMLDivElement;
 };
 
 const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'maxWidth', 'minWidth'];
@@ -45,10 +41,7 @@ const allowedProps = ['alignSelf', 'children', 'flex', 'flexBasis', 'maxWidth', 
 /**
  * Use [Flex.Item](https://gestalt.pinterest.systems/web/flex) within a Flex container for more precise control over the child element. Flex children that are not explicitly wrapped in Flex.Item will be wrapped in the the component automatically to apply `gap` spacing.
  */
-const FlexItemWithForwardRef = forwardRef<HTMLDivElement, Props>(function FlexItem(
-  { dataTestId, ...rest }: Props,
-  ref,
-) {
+export default function FlexItem({ dataTestId, ...rest }: Props) {
   const { passthroughProps, propsStyles } = buildStyles<Props>({
     baseStyles: styles.FlexItem,
     props: rest,
@@ -56,9 +49,7 @@ const FlexItemWithForwardRef = forwardRef<HTMLDivElement, Props>(function FlexIt
   });
 
   // @ts-expect-error - TS2322 - Type '{ "data-test-id": string | undefined; className: string | null | undefined; style: InlineStyle | null | undefined; alignSelf?: "center" | "start" | "end" | "baseline" | "stretch" | "auto" | undefined; ... 5 more ...; minWidth?: Dimension | undefined; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-  return <div ref={ref} {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
-});
+  return <div {...passthroughProps} {...propsStyles} data-test-id={dataTestId} />;
+}
 
-export default FlexItemWithForwardRef;
-
-FlexItemWithForwardRef.displayName = 'Flex.Item';
+FlexItem.displayName = 'Flex.Item';


### PR DESCRIPTION
Reverts pinterest/gestalt#3626

### Summary

#### What changed?

This PR introduces a significant change to the Flex and Flex.Item components by adding forwardRef to both. As a result, ref is now available as a prop for these components.

#### Why?

To enhance the usability and flexibility of the Flex and Flex.Item components. By adding forwardRef, developers can now have direct access to the underlying DOM nodes, which is essential for various advanced use cases like managing focus and optimizing performance.
### Links

- [Jira](https://jira.pinadmin.com/browse/CPW-6881)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
