### PR TITLE
Masonry: Responsive grid modules

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.tsx
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.tsx
@@ -410,14 +410,14 @@ export default class MasonryContainer extends Component<Props<Record<any, any>>,
             ref={this.gridRef}
             _getColumnSpanConfig={(item) => {
               const columnSpan = item.columnSpan as number | undefined;
-              return columnSpan ?? 1
+              return columnSpan ?? 1;
             }}
             _logTwoColWhitespace={
               logWhitespace
                 ? // eslint-disable-next-line no-console
                   (whitespace) => console.log('Whitespace above 2-col module:', whitespace)
                 : undefined
-            } 
+            }
             columnWidth={columnWidth}
             gutterWidth={0}
             items={items}

--- a/docs/integration-test-helpers/masonry/MasonryContainer.tsx
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.tsx
@@ -334,7 +334,6 @@ export default class MasonryContainer extends Component<Props<Record<any, any>>,
       noScroll,
       offsetTop,
       positionStore,
-      twoColItems,
       virtualBoundsBottom,
       virtualBoundsTop,
       virtualize,
@@ -409,16 +408,16 @@ export default class MasonryContainer extends Component<Props<Record<any, any>>,
         {mountGrid && (
           <MasonryComponent
             ref={this.gridRef}
+            _getColumnSpanConfig={(item) => {
+              const columnSpan = item.columnSpan as number | undefined;
+              return columnSpan ?? 1
+            }}
             _logTwoColWhitespace={
               logWhitespace
                 ? // eslint-disable-next-line no-console
                   (whitespace) => console.log('Whitespace above 2-col module:', whitespace)
                 : undefined
-            }
-            _getColumnSpanConfig={(item) => {
-              const columnSpan = item.columnSpan as number | undefined;
-              return columnSpan ?? 1
-            }} 
+            } 
             columnWidth={columnWidth}
             gutterWidth={0}
             items={items}

--- a/docs/integration-test-helpers/masonry/MasonryContainer.tsx
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.tsx
@@ -416,7 +416,10 @@ export default class MasonryContainer extends Component<Props<Record<any, any>>,
                   (whitespace) => console.log('Whitespace above 2-col module:', whitespace)
                 : undefined
             }
-            _twoColItems={twoColItems}
+            _getColumnSpanConfig={(item) => {
+              const columnSpan = item.columnSpan as number | undefined;
+              return columnSpan ?? 1
+            }} 
             columnWidth={columnWidth}
             gutterWidth={0}
             items={items}

--- a/docs/integration-test-helpers/masonry/MasonryContainer.tsx
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.tsx
@@ -18,7 +18,6 @@ import getRandomNumberGenerator from './items-utils/getRandomNumberGenerator';
 
 const TWO_COL_MINDEX = 50;
 
-// @ts-expect-error - TS2749 - 'Masonry' refers to a value, but is being used as a type here. Did you mean 'typeof Masonry'?
 type MasonryProps<T> = Masonry<T>['props'];
 
 type Props<T> = {

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -6,7 +6,7 @@ import { Cache } from './Masonry/Cache';
 import defaultLayout from './Masonry/defaultLayout';
 import fullWidthLayout from './Masonry/fullWidthLayout';
 import MeasurementStore from './Masonry/MeasurementStore';
-import { ColumnSpanConfig,MULTI_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/multiColumnLayout';
+import { ColumnSpanConfig, MULTI_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/multiColumnLayout';
 import ScrollContainer from './Masonry/ScrollContainer';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
 import { Align, Layout, Position } from './Masonry/types';
@@ -558,7 +558,11 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                   }
                 }}
                 className="static"
-                data-column-span={typeof columnSpanConfig === 'number' ? columnSpanConfig : btoa(JSON.stringify(columnSpanConfig))}
+                data-column-span={
+                  typeof columnSpanConfig === 'number'
+                    ? columnSpanConfig
+                    : btoa(JSON.stringify(columnSpanConfig))
+                }
                 data-grid-item
                 role="listitem"
                 style={{
@@ -568,10 +572,14 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                   WebkitTransform: 'translateX(0px) translateY(0px)',
                   // @ts-expect-error - TS2322 - Type 'number | null | undefined' is not assignable to type 'Width<string | number> | undefined'.
                   width:
-                    layout === 'flexible' || layout === 'serverRenderedFlexible' || typeof columnSpanConfig === 'object'
+                    layout === 'flexible' ||
+                    layout === 'serverRenderedFlexible' ||
+                    typeof columnSpanConfig === 'object'
                       ? undefined // we can't set a width for server rendered flexible items
                       : layoutNumberToCssDimension(
-                          typeof columnSpanConfig === 'number' && columnWidth != null && gutter != null
+                          typeof columnSpanConfig === 'number' &&
+                            columnWidth != null &&
+                            gutter != null
                             ? columnWidth * columnSpanConfig + gutter * (columnSpanConfig - 1)
                             : columnWidth,
                         ),
@@ -593,9 +601,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
       const hasMultiColumnItems =
         _getColumnSpanConfig &&
-        itemsWithoutPositions.some(
-          (item) => _getColumnSpanConfig(item) !== 1
-        );
+        itemsWithoutPositions.some((item) => _getColumnSpanConfig(item) !== 1);
 
       // If there are 2-col items, we need to measure more items to ensure we have enough possible layouts to find a suitable one
       // we need the batch size (number of one column items for the graph) + 1 (two column item)

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -6,7 +6,7 @@ import { Cache } from './Masonry/Cache';
 import defaultLayout from './Masonry/defaultLayout';
 import fullWidthLayout from './Masonry/fullWidthLayout';
 import MeasurementStore from './Masonry/MeasurementStore';
-import { MULTI_COL_ITEMS_MEASURE_BATCH_SIZE, ColumnSpanConfig } from './Masonry/multiColumnLayout';
+import { ColumnSpanConfig,MULTI_COL_ITEMS_MEASURE_BATCH_SIZE } from './Masonry/multiColumnLayout';
 import ScrollContainer from './Masonry/ScrollContainer';
 import { getElementHeight, getRelativeScrollTop, getScrollPos } from './Masonry/scrollUtils';
 import { Align, Layout, Position } from './Masonry/types';

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -117,7 +117,7 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _getColumnSpan?: (item: T) => ColumnSpanConfig;
+  _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
 };
 
 type State<T> = {
@@ -486,7 +486,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       renderItem,
       scrollContainer,
       _logTwoColWhitespace,
-      _getColumnSpan,
+      _getColumnSpanConfig,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
     const { positionStore } = this;
@@ -502,7 +502,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         idealColumnWidth: columnWidth,
         width,
         logWhitespace: _logTwoColWhitespace,
-        _getColumnSpan,
+        _getColumnSpanConfig,
       });
     } else if (layout === 'uniformRow') {
       getPositions = uniformRowLayout({
@@ -524,7 +524,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         rawItemCount: items.length,
         width,
         logWhitespace: _logTwoColWhitespace,
-        _getColumnSpan,
+        _getColumnSpanConfig,
       });
     }
 
@@ -540,7 +540,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
           style={{ height: 0, width: '100%' }}
         >
           {items.filter(Boolean).map((item, i) => {
-            const maybeColumnSpan = _getColumnSpan?.(item) ?? 1;
+            const maybeColumnSpan = _getColumnSpanConfig?.(item) ?? 1;
             return (
               <div // keep this in sync with renderMasonryComponent
                 // eslint-disable-next-line react/no-array-index-key
@@ -589,9 +589,9 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       const itemsToRender = items.filter((item) => item && measurementStore.has(item));
       const itemsWithoutPositions = items.filter((item) => item && !positionStore.has(item));
       const hasMultiColumnItems =
-        _getColumnSpan &&
+        _getColumnSpanConfig &&
         itemsWithoutPositions.some(
-          (item) => _getColumnSpan(item) !== 1
+          (item) => _getColumnSpanConfig(item) !== 1
         );
 
       // If there are 2-col items, we need to measure more items to ensure we have enough possible layouts to find a suitable one

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -114,8 +114,11 @@ type Props<T> = {
   _logTwoColWhitespace?: (arg1: number) => void;
   /**
    * Experimental prop to define how many columns a module should span. This is also used to enable multi-column support
+   * _getColumnSpanConfig is a function that takes an individual grid item as an input and returns a ColumnSpanConfig. ColumnSpanConfig can be one of two things:
+   * - A number, which indicates a static number of columns the item should span
+   * - An object, which allows for configuration of the item's column span across the following grid sizes: sm (2 columns), md (3-4 columns), lg (5-8 columns), xl (9+ columns)
    *
-   * This is an experimental prop and may be removed in the future.
+   * This is an experimental prop and may be removed or changed in the future.
    */
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
 };
@@ -540,7 +543,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
           style={{ height: 0, width: '100%' }}
         >
           {items.filter(Boolean).map((item, i) => {
-            const maybeColumnSpan = _getColumnSpanConfig?.(item) ?? 1;
+            const columnSpanConfig = _getColumnSpanConfig?.(item) ?? 1;
             return (
               <div // keep this in sync with renderMasonryComponent
                 // eslint-disable-next-line react/no-array-index-key
@@ -555,7 +558,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                   }
                 }}
                 className="static"
-                data-column-span={typeof maybeColumnSpan === 'number' ? maybeColumnSpan : btoa(JSON.stringify(maybeColumnSpan))}
+                data-column-span={typeof columnSpanConfig === 'number' ? columnSpanConfig : btoa(JSON.stringify(columnSpanConfig))}
                 data-grid-item
                 role="listitem"
                 style={{
@@ -565,11 +568,11 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                   WebkitTransform: 'translateX(0px) translateY(0px)',
                   // @ts-expect-error - TS2322 - Type 'number | null | undefined' is not assignable to type 'Width<string | number> | undefined'.
                   width:
-                    layout === 'flexible' || layout === 'serverRenderedFlexible' || typeof maybeColumnSpan === 'object'
+                    layout === 'flexible' || layout === 'serverRenderedFlexible' || typeof columnSpanConfig === 'object'
                       ? undefined // we can't set a width for server rendered flexible items
                       : layoutNumberToCssDimension(
-                          typeof maybeColumnSpan === 'number' && columnWidth != null && gutter != null
-                            ? columnWidth * maybeColumnSpan + gutter * (maybeColumnSpan - 1)
+                          typeof columnSpanConfig === 'number' && columnWidth != null && gutter != null
+                            ? columnWidth * columnSpanConfig + gutter * (columnSpanConfig - 1)
                             : columnWidth,
                         ),
                 }}

--- a/packages/gestalt/src/Masonry/defaultLayout.test.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.ts
@@ -6,9 +6,12 @@ type Item = {
   name: string;
   height: number;
   color?: string;
+  columnSpan?: number;
 };
 
-describe.each([false, true])('default layout tests', (_twoColItems) => {
+const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
+
+describe.each([undefined, getColumnSpanConfig])('default layout tests', (_getColumnSpanConfig) => {
   test('left-aligns grid within the viewport', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
@@ -30,7 +33,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       minCols: 2,
       rawItemCount: items.length,
       width: 8000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
     expect(layout(items)).toEqual([
       { top: 0, height: 100, left: 0, width: 236 },
@@ -61,7 +64,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       minCols: 2,
       rawItemCount: items.length,
       width: 8000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
 
     expect(layout(items)).toEqual([
@@ -93,7 +96,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       minCols: 2,
       rawItemCount: items.length,
       width: 8000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
 
     expect(layout(items)).toEqual([
@@ -125,7 +128,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       minCols: 2,
       rawItemCount: items.length,
       width: 8000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
 
     expect(layout(items)).toEqual([
@@ -156,7 +159,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       layout: 'basic',
       rawItemCount: items.length,
       width: 501,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
 
     expect(layout(items)).toEqual([
@@ -187,7 +190,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
       layout: 'basic',
       rawItemCount: items.length,
       width: 200,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
 
     expect(layout(items)).toEqual([
@@ -221,7 +224,7 @@ describe.each([false, true])('default layout tests', (_twoColItems) => {
         layout: align === 'center' ? 'basicCentered' : 'basic',
         rawItemCount: items.length,
         width: 1000,
-        _twoColItems,
+        _getColumnSpanConfig,
       })(items);
 
     const justifyStart = makeLayout('start');

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -1,7 +1,7 @@
 import { Align, Layout } from 'gestalt/src//Masonry/types';
 import { Cache } from './Cache';
 import mindex from './mindex';
-import multiColumnLayout from './multiColumnLayout';
+import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { Position } from './types';
 
 const offscreen = (width: number, height: number = Infinity) => ({
@@ -42,11 +42,7 @@ const calculateCenterOffset = ({
 };
 
 const defaultLayout =
-  <
-    T extends {
-      readonly [key: string]: unknown;
-    },
-  >({
+  <T>({
     align,
     columnWidth = 236,
     gutter = 14,
@@ -55,7 +51,7 @@ const defaultLayout =
     rawItemCount,
     width,
     measurementCache,
-    _twoColItems = false,
+    _getColumnSpan,
     ...otherProps
   }: {
     columnWidth?: number;
@@ -67,7 +63,7 @@ const defaultLayout =
     width?: number | null | undefined;
     positionCache: Cache<T, Position>;
     measurementCache: Cache<T, number>;
-    _twoColItems?: boolean;
+    _getColumnSpan?: (item: T) => ColumnSpanConfig;
     whitespaceThreshold?: number;
     logWhitespace?: (arg1: number) => void;
   }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) =>
@@ -91,7 +87,7 @@ const defaultLayout =
       width,
     });
 
-    return _twoColItems
+    return _getColumnSpan
       ? multiColumnLayout({
           items,
           columnWidth,
@@ -99,6 +95,7 @@ const defaultLayout =
           centerOffset,
           gutter,
           measurementCache,
+          _getColumnSpan,
           ...otherProps,
         })
       : items.reduce<Array<any>>((acc, item) => {

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -51,7 +51,7 @@ const defaultLayout =
     rawItemCount,
     width,
     measurementCache,
-    _getColumnSpan,
+    _getColumnSpanConfig,
     ...otherProps
   }: {
     columnWidth?: number;
@@ -63,7 +63,7 @@ const defaultLayout =
     width?: number | null | undefined;
     positionCache: Cache<T, Position>;
     measurementCache: Cache<T, number>;
-    _getColumnSpan?: (item: T) => ColumnSpanConfig;
+    _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
     whitespaceThreshold?: number;
     logWhitespace?: (arg1: number) => void;
   }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) =>
@@ -87,7 +87,7 @@ const defaultLayout =
       width,
     });
 
-    return _getColumnSpan
+    return _getColumnSpanConfig
       ? multiColumnLayout({
           items,
           columnWidth,
@@ -95,7 +95,7 @@ const defaultLayout =
           centerOffset,
           gutter,
           measurementCache,
-          _getColumnSpan,
+          _getColumnSpanConfig,
           ...otherProps,
         })
       : items.reduce<Array<any>>((acc, item) => {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -11,67 +11,70 @@ type Item = {
 
 const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
 
-describe.each([undefined, getColumnSpanConfig])('full width layout tests', (_getColumnSpanConfig) => {
-  test('sets correct width and center offset when positioning', () => {
-    const measurementStore = new MeasurementStore<Record<any, any>, number>();
-    const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items: ReadonlyArray<Item> = [
-      { 'name': 'Pin 0', 'height': 100 },
-      { 'name': 'Pin 1', 'height': 120 },
-      { 'name': 'Pin 2', 'height': 80 },
-      { 'name': 'Pin 3', 'height': 100 },
-    ];
-    items.forEach((item: any) => {
-      measurementStore.set(item, item.height);
+describe.each([undefined, getColumnSpanConfig])(
+  'full width layout tests',
+  (_getColumnSpanConfig) => {
+    test('sets correct width and center offset when positioning', () => {
+      const measurementStore = new MeasurementStore<Record<any, any>, number>();
+      const positionCache = new MeasurementStore<Record<any, any>, Position>();
+      const items: ReadonlyArray<Item> = [
+        { 'name': 'Pin 0', 'height': 100 },
+        { 'name': 'Pin 1', 'height': 120 },
+        { 'name': 'Pin 2', 'height': 80 },
+        { 'name': 'Pin 3', 'height': 100 },
+      ];
+      items.forEach((item: any) => {
+        measurementStore.set(item, item.height);
+      });
+
+      const layout = fullWidthLayout({
+        measurementCache: measurementStore,
+        positionCache,
+        gutter: 10,
+        idealColumnWidth: 240,
+        minCols: 2,
+        width: 1000,
+        _getColumnSpanConfig,
+      });
+      expect(layout(items)).toEqual([
+        { top: 0, height: 100, left: 5, width: 240 },
+        { top: 0, height: 120, left: 255, width: 240 },
+        { top: 0, height: 80, left: 505, width: 240 },
+        { top: 0, height: 100, left: 755, width: 240 },
+      ]);
     });
 
-    const layout = fullWidthLayout({
-      measurementCache: measurementStore,
-      positionCache,
-      gutter: 10,
-      idealColumnWidth: 240,
-      minCols: 2,
-      width: 1000,
-      _getColumnSpanConfig,
-    });
-    expect(layout(items)).toEqual([
-      { top: 0, height: 100, left: 5, width: 240 },
-      { top: 0, height: 120, left: 255, width: 240 },
-      { top: 0, height: 80, left: 505, width: 240 },
-      { top: 0, height: 100, left: 755, width: 240 },
-    ]);
-  });
+    test('sets correct height gutter', () => {
+      const measurementStore = new MeasurementStore<Record<any, any>, number>();
+      const positionCache = new MeasurementStore<Record<any, any>, Position>();
+      const items: ReadonlyArray<Item> = [
+        { 'name': 'Pin 0', 'height': 100 },
+        { 'name': 'Pin 1', 'height': 120 },
+        { 'name': 'Pin 2', 'height': 80 },
+        { 'name': 'Pin 3', 'height': 100 },
+        { 'name': 'Pin 4', 'height': 100 },
+        { 'name': 'Pin 5', 'height': 120 },
+        { 'name': 'Pin 6', 'height': 80 },
+        { 'name': 'Pin 7', 'height': 100 },
+      ];
+      items.forEach((item: any) => {
+        measurementStore.set(item, item.height);
+      });
 
-  test('sets correct height gutter', () => {
-    const measurementStore = new MeasurementStore<Record<any, any>, number>();
-    const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items: ReadonlyArray<Item> = [
-      { 'name': 'Pin 0', 'height': 100 },
-      { 'name': 'Pin 1', 'height': 120 },
-      { 'name': 'Pin 2', 'height': 80 },
-      { 'name': 'Pin 3', 'height': 100 },
-      { 'name': 'Pin 4', 'height': 100 },
-      { 'name': 'Pin 5', 'height': 120 },
-      { 'name': 'Pin 6', 'height': 80 },
-      { 'name': 'Pin 7', 'height': 100 },
-    ];
-    items.forEach((item: any) => {
-      measurementStore.set(item, item.height);
+      const layout = fullWidthLayout({
+        measurementCache: measurementStore,
+        positionCache,
+        gutter: 10,
+        idealColumnWidth: 240,
+        minCols: 2,
+        width: 1000,
+        _getColumnSpanConfig,
+      });
+      expect(
+        layout(items)
+          .slice(4)
+          .map((position) => position.top),
+      ).toEqual([90, 110, 110, 130]);
     });
-
-    const layout = fullWidthLayout({
-      measurementCache: measurementStore,
-      positionCache,
-      gutter: 10,
-      idealColumnWidth: 240,
-      minCols: 2,
-      width: 1000,
-      _getColumnSpanConfig,
-    });
-    expect(
-      layout(items)
-        .slice(4)
-        .map((position) => position.top),
-    ).toEqual([90, 110, 110, 130]);
-  });
-});
+  },
+);

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -6,9 +6,12 @@ type Item = {
   name: string;
   height: number;
   color?: string;
+  columnSpan?: number;
 };
 
-describe.each([false, true])('full width layout tests', (_twoColItems) => {
+const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
+
+describe.each([undefined, getColumnSpanConfig])('full width layout tests', (_getColumnSpanConfig) => {
   test('sets correct width and center offset when positioning', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
@@ -29,7 +32,7 @@ describe.each([false, true])('full width layout tests', (_twoColItems) => {
       idealColumnWidth: 240,
       minCols: 2,
       width: 1000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
     expect(layout(items)).toEqual([
       { top: 0, height: 100, left: 5, width: 240 },
@@ -63,7 +66,7 @@ describe.each([false, true])('full width layout tests', (_twoColItems) => {
       idealColumnWidth: 240,
       minCols: 2,
       width: 1000,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
     expect(
       layout(items)

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -9,7 +9,7 @@ const fullWidthLayout = <T>({
   gutter = 0,
   minCols = 2,
   measurementCache,
-  _getColumnSpan,
+  _getColumnSpanConfig,
   ...otherProps
 }: {
   idealColumnWidth?: number;
@@ -18,7 +18,7 @@ const fullWidthLayout = <T>({
   width?: number | null | undefined;
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
-  _getColumnSpan?: (item: T) => ColumnSpanConfig;
+  _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
   logWhitespace?: (arg1: number) => void;
 }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) => {
@@ -43,7 +43,7 @@ const fullWidthLayout = <T>({
 
   return (items: ReadonlyArray<T>) => {
     const heights = new Array<number>(columnCount).fill(0);
-    return _getColumnSpan
+    return _getColumnSpanConfig
       ? multiColumnLayout({
           items,
           columnWidth,
@@ -51,7 +51,7 @@ const fullWidthLayout = <T>({
           centerOffset,
           gutter,
           measurementCache,
-          _getColumnSpan,
+          _getColumnSpanConfig,
           ...otherProps,
         })
       : items.reduce<Array<any>>((acc, item) => {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -1,19 +1,15 @@
 import { Cache } from './Cache';
 import mindex from './mindex';
-import multiColumnLayout from './multiColumnLayout';
+import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { Position } from './types';
 
-const fullWidthLayout = <
-  T extends {
-    readonly [key: string]: unknown;
-  },
->({
+const fullWidthLayout = <T>({
   width,
   idealColumnWidth = 240,
   gutter = 0,
   minCols = 2,
   measurementCache,
-  _twoColItems = false,
+  _getColumnSpan,
   ...otherProps
 }: {
   idealColumnWidth?: number;
@@ -22,7 +18,7 @@ const fullWidthLayout = <
   width?: number | null | undefined;
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
-  _twoColItems?: boolean;
+  _getColumnSpan?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
   logWhitespace?: (arg1: number) => void;
 }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) => {
@@ -47,7 +43,7 @@ const fullWidthLayout = <
 
   return (items: ReadonlyArray<T>) => {
     const heights = new Array<number>(columnCount).fill(0);
-    return _twoColItems
+    return _getColumnSpan
       ? multiColumnLayout({
           items,
           columnWidth,
@@ -55,6 +51,7 @@ const fullWidthLayout = <
           centerOffset,
           gutter,
           measurementCache,
+          _getColumnSpan,
           ...otherProps,
         })
       : items.reduce<Array<any>>((acc, item) => {

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -4,11 +4,7 @@ import fullWidthLayout from './fullWidthLayout';
 import { Align, Layout, Position } from './types';
 import uniformRowLayout from './uniformRowLayout';
 
-export default function getLayoutAlgorithm<
-  T extends {
-    readonly [key: string]: unknown;
-  },
->({
+export default function getLayoutAlgorithm<T>({
   align,
   columnWidth,
   gutter,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -1,6 +1,7 @@
 import { Cache } from './Cache';
 import defaultLayout from './defaultLayout';
 import fullWidthLayout from './fullWidthLayout';
+import { ColumnSpanConfig } from './multiColumnLayout';
 import { Align, Layout, Position } from './types';
 import uniformRowLayout from './uniformRowLayout';
 
@@ -14,7 +15,7 @@ export default function getLayoutAlgorithm<T>({
   minCols,
   positionStore,
   width,
-  _twoColItems,
+  _getColumnSpanConfig,
   _logTwoColWhitespace,
 }: {
   align: Align;
@@ -26,7 +27,7 @@ export default function getLayoutAlgorithm<T>({
   minCols: number;
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
-  _twoColItems?: boolean;
+  _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   _logTwoColWhitespace?: (arg1: number) => void;
 }): (forItems: ReadonlyArray<T>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
@@ -38,7 +39,7 @@ export default function getLayoutAlgorithm<T>({
       idealColumnWidth: columnWidth,
       width,
       logWhitespace: _logTwoColWhitespace,
-      _twoColItems,
+      _getColumnSpanConfig,
     });
   }
   if (layout === 'uniformRow') {
@@ -61,6 +62,6 @@ export default function getLayoutAlgorithm<T>({
     minCols,
     rawItemCount: items.length,
     width,
-    _twoColItems,
+    _getColumnSpanConfig,
   });
 }

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -1,4 +1,3 @@
-import { item } from '../ComboBox.css';
 import MeasurementStore from './MeasurementStore';
 import multiColumnLayout, { initializeHeightsArray } from './multiColumnLayout';
 import { Position } from './types';
@@ -754,7 +753,6 @@ describe('responsive module layout test cases', () => {
     items.forEach((item: any) => {
       measurementStore.set(item, item.height);
     });
-    const getColumnSpanConfig = (item: Item) => item.name === 'Pin 10' ? 2 : 1;
 
     const layout = (columnCount: number) =>
       multiColumnLayout({
@@ -764,7 +762,7 @@ describe('responsive module layout test cases', () => {
         gutter: 0,
         measurementCache: measurementStore,
         positionCache,
-        _getColumnSpanConfig: getColumnSpanConfig,
+        _getColumnSpanConfig: (item: Item) => item.name === 'Pin 10' ? 2 : 1,
       });
 
     const columnCounts = [2,3,4,5,6,7,8,9,10];
@@ -794,13 +792,7 @@ describe('responsive module layout test cases', () => {
     items.forEach((item: any) => {
       measurementStore.set(item, item.height);
     });
-    const getColumnSpanConfig = (item: Item) => item.name === 'Pin 10' ? {
-      sm: 2,
-      md: 3,
-      lg: 5,
-      xl: 9
-    } : 1;
-
+    
     const layout = (columnCount: number) =>
       multiColumnLayout({
         items,
@@ -809,11 +801,17 @@ describe('responsive module layout test cases', () => {
         gutter: 0,
         measurementCache: measurementStore,
         positionCache,
-        _getColumnSpanConfig: getColumnSpanConfig,
+        _getColumnSpanConfig:  (item: Item) => item.name === 'Pin 10' ? {
+          sm: 2,
+          md: 3,
+          lg: 5,
+          xl: 9
+        } : 1,
       });
 
     const breakpoints = [2,3,4,5,6,7,8,9,10].map((columnCount) => ({
       columnCount,
+      // eslint-disable-next-line no-nested-ternary
       expectedColumnSpan: columnCount < 3 ? 2 : columnCount < 5 ? 3 : columnCount < 9 ? 5 : 9
     }));
 

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -6,7 +6,10 @@ type Item = {
   name: string;
   height: number;
   color?: string;
+  columnSpan?: number;
 };
+
+const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
 
 describe('one column layout test cases', () => {
   test('empty', () => {
@@ -18,6 +21,7 @@ describe('one column layout test cases', () => {
       items,
       measurementCache: measurementStore,
       positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
     });
     expect(positions).toEqual([]);
   });
@@ -39,6 +43,7 @@ describe('one column layout test cases', () => {
       columnCount: 3,
       measurementCache: measurementStore,
       positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
     });
     expect(positions).toEqual([
       { top: 0, height: 100, left: 0, width: 236 },
@@ -65,6 +70,7 @@ describe('one column layout test cases', () => {
       columnCount: 2,
       measurementCache: measurementStore,
       positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
     });
     expect(positions).toEqual([
       { top: 0, height: 100, left: 0, width: 236 },
@@ -103,6 +109,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 99,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     // perform single column layout first since we expect two column items on second page+ currently
@@ -200,6 +207,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 99,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     let mockItems: any;
@@ -300,6 +308,7 @@ describe('multi column layout test cases', () => {
         measurementCache: measurementStore,
         positionCache,
         whitespaceThreshold: 11,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     items.forEach((item: any) => {
@@ -338,6 +347,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 99,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     let mockItems: any;
@@ -408,6 +418,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 92,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     let mockItems: any;
@@ -478,6 +489,7 @@ describe('multi column layout test cases', () => {
         columnCount: 4,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     const multiColumnModuleIndex = 2;
@@ -511,6 +523,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 99,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     const columnSpan = 5;
@@ -579,6 +592,7 @@ describe('multi column layout test cases', () => {
         centerOffset: 92,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
 
     const positions = layout(items);
@@ -642,6 +656,7 @@ describe('multi column layout test cases', () => {
           centerOffset: 30,
           measurementCache: measurementStore,
           positionCache,
+          _getColumnSpanConfig: getColumnSpanConfig,
         });
 
       // perform single column layout first since we expect two column items on second page+ currently
@@ -699,6 +714,7 @@ describe('multi column layout test cases', () => {
           centerOffset: 0,
           measurementCache: measurementStore,
           positionCache,
+          _getColumnSpanConfig: getColumnSpanConfig,
         });
 
       layout(mockItems);
@@ -718,6 +734,7 @@ describe('multi column layout test cases', () => {
 });
 
 describe('initializeHeightsArray', () => {
+  
   test('correctly determines column heights before laying out new items (default layout)', () => {
     const gutter = 16;
     const columnWidth = 236;
@@ -760,6 +777,7 @@ describe('initializeHeightsArray', () => {
         centerOffset: 1,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
     const positions = layout(items);
     expect(positions).toEqual([
@@ -795,6 +813,7 @@ describe('initializeHeightsArray', () => {
       gutter,
       items,
       positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
     });
 
     expect(heights.length).toEqual(9);
@@ -843,6 +862,7 @@ describe('initializeHeightsArray', () => {
         centerOffset: 1,
         measurementCache: measurementStore,
         positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
       });
     const positions = layout(items);
     expect(positions).toEqual([
@@ -878,6 +898,7 @@ describe('initializeHeightsArray', () => {
       gutter,
       items,
       positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
     });
 
     expect(heights.length).toEqual(9);

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -762,10 +762,10 @@ describe('responsive module layout test cases', () => {
         gutter: 0,
         measurementCache: measurementStore,
         positionCache,
-        _getColumnSpanConfig: (item: Item) => item.name === 'Pin 10' ? 2 : 1,
+        _getColumnSpanConfig: (item: Item) => (item.name === 'Pin 10' ? 2 : 1),
       });
 
-    const columnCounts = [2,3,4,5,6,7,8,9,10];
+    const columnCounts = [2, 3, 4, 5, 6, 7, 8, 9, 10];
 
     columnCounts.forEach((columnCount) => {
       layout(columnCount);
@@ -792,7 +792,7 @@ describe('responsive module layout test cases', () => {
     items.forEach((item: any) => {
       measurementStore.set(item, item.height);
     });
-    
+
     const layout = (columnCount: number) =>
       multiColumnLayout({
         items,
@@ -801,18 +801,21 @@ describe('responsive module layout test cases', () => {
         gutter: 0,
         measurementCache: measurementStore,
         positionCache,
-        _getColumnSpanConfig:  (item: Item) => item.name === 'Pin 10' ? {
-          sm: 2,
-          md: 3,
-          lg: 5,
-          xl: 9
-        } : 1,
+        _getColumnSpanConfig: (item: Item) =>
+          item.name === 'Pin 10'
+            ? {
+                sm: 2,
+                md: 3,
+                lg: 5,
+                xl: 9,
+              }
+            : 1,
       });
 
-    const breakpoints = [2,3,4,5,6,7,8,9,10].map((columnCount) => ({
+    const breakpoints = [2, 3, 4, 5, 6, 7, 8, 9, 10].map((columnCount) => ({
       columnCount,
       // eslint-disable-next-line no-nested-ternary
-      expectedColumnSpan: columnCount < 3 ? 2 : columnCount < 5 ? 3 : columnCount < 9 ? 5 : 9
+      expectedColumnSpan: columnCount < 3 ? 2 : columnCount < 5 ? 3 : columnCount < 9 ? 5 : 9,
     }));
 
     breakpoints.forEach(({ columnCount, expectedColumnSpan }) => {
@@ -824,7 +827,6 @@ describe('responsive module layout test cases', () => {
 });
 
 describe('initializeHeightsArray', () => {
-  
   test('correctly determines column heights before laying out new items (default layout)', () => {
     const gutter = 16;
     const columnWidth = 236;

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -1,3 +1,4 @@
+import { item } from '../ComboBox.css';
 import MeasurementStore from './MeasurementStore';
 import multiColumnLayout, { initializeHeightsArray } from './multiColumnLayout';
 import { Position } from './types';
@@ -731,6 +732,97 @@ describe('multi column layout test cases', () => {
       });
     },
   );
+});
+
+describe('responsive module layout test cases', () => {
+  test('sets the correct column width for fixed column span', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 200, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 200, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 200, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 200, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 200, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 200, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 200, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 200, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 200, 'color': '#F45098' },
+      { 'name': 'Pin 10', 'height': 200, 'color': '#30BAF6' },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+    const getColumnSpanConfig = (item: Item) => item.name === 'Pin 10' ? 2 : 1;
+
+    const layout = (columnCount: number) =>
+      multiColumnLayout({
+        items,
+        columnWidth: 240,
+        columnCount,
+        gutter: 0,
+        measurementCache: measurementStore,
+        positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
+      });
+
+    const columnCounts = [2,3,4,5,6,7,8,9,10];
+
+    columnCounts.forEach((columnCount) => {
+      layout(columnCount);
+      expect(positionCache.get(items[10])?.width).toEqual(480);
+      positionCache.reset();
+    });
+  });
+  test('sets the correct column width for responsive column span', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 200, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 200, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 200, 'color': '#EDF21D' },
+      { 'name': 'Pin 4', 'height': 200, 'color': '#CF4509' },
+      { 'name': 'Pin 5', 'height': 200, 'color': '#230BAF' },
+      { 'name': 'Pin 6', 'height': 200, 'color': '#67076F' },
+      { 'name': 'Pin 7', 'height': 200, 'color': '#AB032E' },
+      { 'name': 'Pin 8', 'height': 200, 'color': '#DF21DC' },
+      { 'name': 'Pin 9', 'height': 200, 'color': '#F45098' },
+      { 'name': 'Pin 10', 'height': 200, 'color': '#30BAF6' },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+    const getColumnSpanConfig = (item: Item) => item.name === 'Pin 10' ? {
+      sm: 2,
+      md: 3,
+      lg: 5,
+      xl: 9
+    } : 1;
+
+    const layout = (columnCount: number) =>
+      multiColumnLayout({
+        items,
+        columnWidth: 240,
+        columnCount,
+        gutter: 0,
+        measurementCache: measurementStore,
+        positionCache,
+        _getColumnSpanConfig: getColumnSpanConfig,
+      });
+
+    const breakpoints = [2,3,4,5,6,7,8,9,10].map((columnCount) => ({
+      columnCount,
+      expectedColumnSpan: columnCount < 3 ? 2 : columnCount < 5 ? 3 : columnCount < 9 ? 5 : 9
+    }));
+
+    breakpoints.forEach(({ columnCount, expectedColumnSpan }) => {
+      layout(columnCount);
+      expect(positionCache.get(items[10])?.width).toEqual(240 * expectedColumnSpan);
+      positionCache.reset();
+    });
+  });
 });
 
 describe('initializeHeightsArray', () => {

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -7,6 +7,24 @@ import { NodeData, Position } from './types';
 // This may need to be tweaked to balance the tradeoff of delayed rendering vs having enough possible layouts
 export const MULTI_COL_ITEMS_MEASURE_BATCH_SIZE = 5;
 
+type GridSize = 'sm' | 'md' | 'lg' | 'xl';
+
+export type ColumnSpanConfig = number | { [Size in GridSize]: number }
+
+export function columnCountToGridSize(columnCount: number): GridSize {
+  // write the following logic in a functional manner
+  if (columnCount <= 2) {
+    return 'sm';
+  }
+  if (columnCount <= 4) {
+    return 'md';
+  }
+  if (columnCount <= 8) {
+    return 'lg';
+  }
+  return 'xl';
+}
+
 function isNil(value: unknown): boolean {
   return value === null || value === undefined;
 }
@@ -17,14 +35,6 @@ const offscreen = (width: number, height: number = Infinity) => ({
   width,
   height,
 });
-
-function getItemColumnSpan<
-  T extends {
-    readonly [key: string]: unknown;
-  },
->(item: T): number {
-  return typeof item.columnSpan === 'number' ? item.columnSpan : 1;
-}
 
 function getPositionsOnly<T>(
   positions: ReadonlyArray<{
@@ -104,17 +114,14 @@ function calculateSplitIndex({
   return multiColumnIndex;
 }
 
-export function initializeHeightsArray<
-  T extends {
-    readonly [key: string]: unknown;
-  },
->({
+export function initializeHeightsArray<T>({
   centerOffset,
   columnCount,
   columnWidthAndGutter,
   gutter,
   items,
   positionCache,
+  _getColumnSpan,
 }: {
   centerOffset: number;
   columnCount: number;
@@ -122,13 +129,14 @@ export function initializeHeightsArray<
   gutter: number;
   items: ReadonlyArray<T>;
   positionCache: Cache<T, Position> | null | undefined;
+  _getColumnSpan: (item: T) => ColumnSpanConfig;
 }): ReadonlyArray<number> {
   const heights = new Array<number>(columnCount).fill(0);
   items.forEach((item) => {
     const position = positionCache?.get(item);
     if (position) {
       const col = (position.left - centerOffset) / columnWidthAndGutter;
-      const columnSpan = getItemColumnSpan(item);
+      const columnSpan = calculateActualColumnSpan({ columnCount, item, _getColumnSpan });
       // the height of the column is just the sum of the top and height of the item
       const absoluteHeight = position.top + position.height + gutter;
       for (let i = col; i < col + columnSpan; i += 1) {
@@ -434,11 +442,7 @@ function getGraphPositions<T>({
     : { winningNode: startNodeData, additionalWhitespace: startingLowestAdjacentColumnHeightDelta };
 }
 
-function getPositionsWithMultiColumnItem<
-  T extends {
-    readonly [key: string]: unknown;
-  },
->({
+function getPositionsWithMultiColumnItem<T>({
   multiColumnItem,
   itemsToPosition,
   heights,
@@ -446,6 +450,7 @@ function getPositionsWithMultiColumnItem<
   whitespaceThreshold,
   columnCount,
   logWhitespace,
+  _getColumnSpan,
   ...commonGetPositionArgs
 }: {
   multiColumnItem: T;
@@ -464,6 +469,7 @@ function getPositionsWithMultiColumnItem<
   gutter: number;
   measurementCache: Cache<T, number>;
   positionCache: Cache<T, Position>;
+  _getColumnSpan: (item: T) => ColumnSpanConfig;
 }): {
   positions: ReadonlyArray<{
     item: T;
@@ -476,15 +482,14 @@ function getPositionsWithMultiColumnItem<
   // This is the index inside the items to position array
   const multiColumnIndex = itemsToPosition.indexOf(multiColumnItem);
   const oneColumnItems = itemsToPosition.filter(
-    (item) => !item.columnSpan || item.columnSpan === 1,
+    (item) => calculateActualColumnSpan({ columnCount, item, _getColumnSpan }) === 1,
   );
 
   // The empty columns can be different from columnCount if there are
   // items already positioned from previous batches
   const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
-  // @ts-expect-error - TS2345 - Argument of type 'unknown' is not assignable to parameter of type 'string'.
-  const multiColumnItemColumnSpan = Math.min(parseInt(multiColumnItem.columnSpan, 10), columnCount);
+  const multiColumnItemColumnSpan = Math.min(calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpan }), columnCount);
 
   // Skip the graph logic if the two column item can be displayed on the first row,
   // this means graphBatch is empty and multi column item is positioned on its
@@ -574,11 +579,24 @@ function getPositionsWithMultiColumnItem<
   return { positions: prevPositions.concat(finalPositions), heights: finalHeights };
 }
 
-const multiColumnLayout = <
-  T extends {
-    readonly [key: string]: unknown;
-  },
->({
+function calculateActualColumnSpan<T>({
+  columnCount,
+  item,
+  _getColumnSpan,
+}: {
+  columnCount: number;
+  item: T,
+  _getColumnSpan: (item: T) => ColumnSpanConfig;
+}): number {
+  const columnSpanConfig = _getColumnSpan(item);
+  if (typeof columnSpanConfig === 'number') {
+    return columnSpanConfig;
+  }
+  const gridSize = columnCountToGridSize(columnCount);
+  return columnSpanConfig[gridSize] ?? 1;
+}
+
+const multiColumnLayout = <T>({
   items,
   gutter = 14,
   columnWidth = 236,
@@ -588,6 +606,7 @@ const multiColumnLayout = <
   measurementCache,
   positionCache,
   whitespaceThreshold,
+  _getColumnSpan,
 }: {
   items: ReadonlyArray<T>;
   gutter?: number;
@@ -598,11 +617,13 @@ const multiColumnLayout = <
   measurementCache: Cache<T, number>;
   whitespaceThreshold?: number;
   logWhitespace?: (arg1: number) => void;
+  _getColumnSpan: (item: T) => ColumnSpanConfig;
 }): ReadonlyArray<Position> => {
   if (!items.every((item) => measurementCache.has(item))) {
     return items.map((item) => {
-      if (typeof item.columnSpan === 'number' && item.columnSpan > 1) {
-        const columnSpan = Math.min(item.columnSpan, columnCount);
+      const itemColumnSpan = calculateActualColumnSpan({ columnCount, item, _getColumnSpan });
+      if (itemColumnSpan > 1) {
+        const columnSpan = Math.min(itemColumnSpan, columnCount);
         return offscreen(columnWidth * columnSpan + gutter * (columnSpan - 1));
       }
       return offscreen(columnWidth);
@@ -619,13 +640,14 @@ const multiColumnLayout = <
     gutter,
     items,
     positionCache,
+    _getColumnSpan,
   });
 
   const itemsWithPositions = items.filter((item) => positionCache?.has(item));
   const itemsWithoutPositions = items.filter((item) => !positionCache?.has(item));
 
   const multiColumnItems = itemsWithoutPositions.filter(
-    (item) => typeof item.columnSpan === 'number' && item.columnSpan > 1,
+    (item) => calculateActualColumnSpan({ columnCount, item, _getColumnSpan }) > 1,
   );
 
   const commonGetPositionArgs = {
@@ -674,6 +696,7 @@ const multiColumnLayout = <
           whitespaceThreshold,
           logWhitespace,
           columnCount,
+          _getColumnSpan,
           ...commonGetPositionArgs,
         }),
       { heights: paintedItemHeights, positions: paintedItemPositions },

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -9,7 +9,7 @@ export const MULTI_COL_ITEMS_MEASURE_BATCH_SIZE = 5;
 
 type GridSize = 'sm' | 'md' | 'lg' | 'xl';
 
-export type ColumnSpanConfig = number | { [Size in GridSize]: number }
+export type ColumnSpanConfig = number | { [Size in GridSize]: number };
 
 // maps the number of columns to a grid breakpoint
 // sm: 2 columns
@@ -51,7 +51,7 @@ function getPositionsOnly<T>(
 
 function calculateActualColumnSpan<T>(props: {
   columnCount: number;
-  item: T,
+  item: T;
   _getColumnSpanConfig: (item: T) => ColumnSpanConfig;
 }): number {
   const { columnCount, item, _getColumnSpanConfig } = props;
@@ -507,7 +507,10 @@ function getPositionsWithMultiColumnItem<T>({
   // items already positioned from previous batches
   const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
-  const multiColumnItemColumnSpan = Math.min(calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpanConfig }), columnCount);
+  const multiColumnItemColumnSpan = Math.min(
+    calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpanConfig }),
+    columnCount,
+  );
 
   // Skip the graph logic if the two column item can be displayed on the first row,
   // this means graphBatch is empty and multi column item is positioned on its

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -49,6 +49,20 @@ function getPositionsOnly<T>(
   return positions.map(({ position }) => position);
 }
 
+function calculateActualColumnSpan<T>(props: {
+  columnCount: number;
+  item: T,
+  _getColumnSpanConfig: (item: T) => ColumnSpanConfig;
+}): number {
+  const { columnCount, item, _getColumnSpanConfig } = props;
+  const columnSpanConfig = _getColumnSpanConfig(item);
+  if (typeof columnSpanConfig === 'number') {
+    return columnSpanConfig;
+  }
+  const gridSize = columnCountToGridSize(columnCount);
+  return columnSpanConfig[gridSize] ?? 1;
+}
+
 function getAdjacentColumnHeightDeltas(
   heights: ReadonlyArray<number>,
   columnSpan: number,
@@ -581,23 +595,6 @@ function getPositionsWithMultiColumnItem<T>({
   // FUTURE OPTIMIZATION - do we want a min threshold for an acceptably low score?
   // If so, we could save the multi column item somehow and try again with the next batch of items
   return { positions: prevPositions.concat(finalPositions), heights: finalHeights };
-}
-
-function calculateActualColumnSpan<T>({
-  columnCount,
-  item,
-  _getColumnSpanConfig,
-}: {
-  columnCount: number;
-  item: T,
-  _getColumnSpanConfig: (item: T) => ColumnSpanConfig;
-}): number {
-  const columnSpanConfig = _getColumnSpanConfig(item);
-  if (typeof columnSpanConfig === 'number') {
-    return columnSpanConfig;
-  }
-  const gridSize = columnCountToGridSize(columnCount);
-  return columnSpanConfig[gridSize] ?? 1;
 }
 
 const multiColumnLayout = <T>({

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -11,8 +11,12 @@ type GridSize = 'sm' | 'md' | 'lg' | 'xl';
 
 export type ColumnSpanConfig = number | { [Size in GridSize]: number }
 
+// maps the number of columns to a grid breakpoint
+// sm: 2 columns
+// md: 3-4 columns
+// lg: 5-8 columns
+// xl: 9+ columns
 export function columnCountToGridSize(columnCount: number): GridSize {
-  // write the following logic in a functional manner
   if (columnCount <= 2) {
     return 'sm';
   }

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -352,7 +352,7 @@ function useLayout<T>({
   updateMeasurement: (arg1: T, arg2: number) => void;
 } {
   const hasMultiColumnItems =
-  _getColumnSpanConfig &&
+    _getColumnSpanConfig &&
     items
       .filter((item) => item && !positionStore.has(item))
       .some((item) => _getColumnSpanConfig(item) !== 1);
@@ -510,7 +510,7 @@ function MasonryItem<T>({
   left: number;
   layout: Layout;
   renderItem: Props<T>['renderItem'];
-  serializedColumnSpanConfig: string | number,
+  serializedColumnSpanConfig: string | number;
   top: number;
   updateMeasurement: (arg1: T, arg2: number) => void;
   width: number | null | undefined;
@@ -720,7 +720,9 @@ function Masonry<T>(
                 height: undefined,
                 width:
                   // eslint-disable-next-line no-nested-ternary
-                  layout === 'flexible' || layout === 'serverRenderedFlexible' || typeof columnSpanConfig === 'object'
+                  layout === 'flexible' ||
+                  layout === 'serverRenderedFlexible' ||
+                  typeof columnSpanConfig === 'object'
                     ? undefined // we can't set a width for server rendered flexible items
                     : typeof columnSpanConfig === 'number' && columnWidth != null && gutter != null
                     ? columnWidth * columnSpanConfig + gutter * (columnSpanConfig - 1)
@@ -740,7 +742,10 @@ function Masonry<T>(
                   position.top > viewportBottom
                 );
 
-          const serializedColumnSpanConfig = typeof columnSpanConfig === 'number' ? columnSpanConfig : btoa(JSON.stringify(columnSpanConfig));
+          const serializedColumnSpanConfig =
+            typeof columnSpanConfig === 'number'
+              ? columnSpanConfig
+              : btoa(JSON.stringify(columnSpanConfig));
 
           return isVisible ? (
             <MasonryItemMemo

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -569,7 +569,7 @@ function MasonryItem<T>({
   );
 }
 
-const MasonryItemMemo = memo(MasonryItem);
+const MasonryItemMemo = memo(MasonryItem) as typeof MasonryItem;
 
 function Masonry<T>(
   {
@@ -607,12 +607,12 @@ function Masonry<T>(
     }
   }, []);
 
-  const measurementStore = useMemo(
+  const measurementStore: Cache<T, number> = useMemo(
     () => measurementStoreProp || createMeasurementStore(),
     [measurementStoreProp],
   );
 
-  const positionStore = useMemo(
+  const positionStore: Cache<T, Position> = useMemo(
     () => positionStoreProp || createMeasurementStore(),
     [positionStoreProp],
   );
@@ -672,10 +672,8 @@ function Masonry<T>(
     gutter,
     items,
     layout,
-    // @ts-expect-error - TS2322 - Type 'Cache<T, number> | MeasurementStore<Record<any, any>, unknown>' is not assignable to type 'Cache<Record<any, any>, number>'.
     measurementStore,
     minCols,
-    // @ts-expect-error - TS2322 - Type 'Cache<T, Position> | MeasurementStore<Record<any, any>, unknown>' is not assignable to type 'Cache<Record<any, any>, Position>'.
     positionStore,
     width,
     _logTwoColWhitespace,

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -327,7 +327,6 @@ function useLayout<T>({
   minCols,
   positionStore,
   width,
-  _twoColItems,
   _logTwoColWhitespace,
   _measureAll,
   _useRAF,
@@ -342,7 +341,6 @@ function useLayout<T>({
   minCols: number;
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
-  _twoColItems?: boolean;
   _logTwoColWhitespace?: (arg1: number) => void;
   _measureAll?: boolean;
   _useRAF?: boolean;
@@ -369,7 +367,7 @@ function useLayout<T>({
     positionStore,
     minCols,
     width,
-    _twoColItems,
+    _getColumnSpanConfig,
     _logTwoColWhitespace,
   });
 


### PR DESCRIPTION
# Summary
This PR builds on Masonry's multi-column module support and adds support for _responsive_ grid modules
**Note: ** This is a breaking change since it removes support for Masonry's experimental `_twoColItems` prop in favor of `_getColumnSpanConfig`

# Current State
At a high level, how N-column Masonry currently works:
- Modules can declare their column span via a static columnSpan property, which can span 1 - N columns, where N is the maximum number of columns in the grid
- Modules are positioned to optimize for reducing whitespace in the grid. We do this by generating a directed acyclic graph (DAG) of different layouts and picking the one with the least amount of whitespace. This means that we do not guarantee exact item positioning but can guarantee the general area (e.g. Pin 20 will not show up in the 40th slot)
- If a module’s columnSpan is greater than the number of columns in the grid, the module will scale down to match

The current expectation is that module sizes are static regardless of the grid width. This means that a two column module will remain a two column module regardless if the grid is two columns or ten columns wide.  

# Responsive Modules
With responsive grid modules, the idea is that items in the grid can have different column spans and scale depending on the size of the grid (i.e. a module can span 5 columns on a larger screen and 3 columns on a smaller screen).

To enable this, we are introducing a new experimental API called `_getColumnSpanConfig`, which will replace the current `_twoColItems` prop. 

## _getColumnSpanConfig
```js
getColumnSpanConfig<T>: (item: T) => number | { sm: number, md: number, lg: number, xl: number }
```
`_getColumnSpanConfig` is a function which takes the item data (T) as an input and returns one of two things:
- `number`: Fixed column span (same behavior as today)
- `{ [gridSize]: number }`: An object which defines how many columns a module should span, depending on the size of the grid. The definition of gridSize here will be:
  - sm: 2 columns
  - md: 3 - 4 columns
  - lg: 5 - 8 columns
  - xl: 9+ columns

The gridSize breakpoints are inspired by how our grids currently render against the existing Gestalt [breakpoints](https://gestalt.pinterest.systems/foundations/screen_sizes) (with the exception of xl which doesn’t exist yet). The motivation behind having a predefined set of breakpoints is to provide developers enough flexibility to define how modules should render across different grid sizes but doing so in a way that ties into our existing responsive design standards. 

Additionally, this API allows us to support server rendering of responsive modules. Because we do not have enough information on the server to determine how many columns will be rendered, we need to know all possible column spans and breakpoints in order to generate the correct CSS styles to render.

## Changes Made
In addition to adding support for `_getColumnSpanConfig`, the majority of changes in this PR are replacing the existing usages of `_twoColItems` with `_getColumnSpanConfig`.

## Rollout
While this is technically a breaking change, rollout will be straightforward since we can replace all existing instances of `_twoColItems` with `_getColumnSpanConfig: (item) => item.columnSpan ?? 1`

# Test Plan
Unit test

Tested locally
8 columns
<img width="1994" alt="image" src="https://github.com/pinterest/gestalt/assets/6487551/0ca808e9-e8e4-4277-8c17-ba048fce85d1">

4 columns
<img width="1038" alt="image" src="https://github.com/pinterest/gestalt/assets/6487551/639ead86-eb4f-455f-93e2-69ae981b1013">


