### PR TITLE
Checkbox, Modal, ModalAlert, TagData: Adding Data-test-id for those components

### DIFF
--- a/packages/gestalt/src/Checkbox.test.tsx
+++ b/packages/gestalt/src/Checkbox.test.tsx
@@ -77,3 +77,10 @@ test('Checkbox with an image', () => {
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('Checkbox with a data-test-id', () => {
+  const tree = create(
+    <Checkbox dataTestId="checkbox-datatestid" id="id" label="Name" onChange={() => {}} size="sm" />,
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/packages/gestalt/src/Checkbox.tsx
+++ b/packages/gestalt/src/Checkbox.tsx
@@ -7,6 +7,10 @@ type Props = {
    */
   checked?: boolean;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Indicates whether or not Checkbox is disabled. Disabled Checkboxes do not respond to mouse events and cannot be reached by the keyboard. See the [state variant](https://gestalt.pinterest.systems/web/checkbox#State) to learn more.
    */
   disabled?: boolean;
@@ -71,6 +75,7 @@ type Props = {
 const CheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Checkbox(
   {
     checked = false,
+    dataTestId,
     disabled = false,
     errorMessage,
     helperText,
@@ -90,6 +95,7 @@ const CheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Chec
     <InternalCheckbox
       ref={ref}
       checked={checked}
+      dataTestId={dataTestId}
       disabled={disabled}
       errorMessage={errorMessage}
       helperText={helperText}

--- a/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
+++ b/packages/gestalt/src/Checkbox/InternalCheckbox.tsx
@@ -20,6 +20,7 @@ import useFocusVisible from '../useFocusVisible';
 
 type Props = {
   checked?: boolean;
+  dataTestId?: string;
   disabled?: boolean;
   errorMessage?: string;
   helperText?: string;
@@ -47,6 +48,7 @@ const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
   {
     checked = false,
     disabled = false,
+    dataTestId,
     errorMessage,
     helperText,
     id,
@@ -131,7 +133,7 @@ const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
   return (
     <Box>
       <Box alignItems="start" display="flex" justifyContent="start" marginEnd={-1} marginStart={-1}>
-        <Box paddingX={1} position="relative">
+        <Box data-test-id={dataTestId} paddingX={1} position="relative" >
           <input
             // checking for "focused" is not required by screenreaders but it prevents a11y integration tests to complain about missing label, as aria-describedby seems to shadow label in tests though it's a W3 accepeted pattern https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html
             ref={innerRef}

--- a/packages/gestalt/src/Modal.jsdom.test.tsx
+++ b/packages/gestalt/src/Modal.jsdom.test.tsx
@@ -86,6 +86,7 @@ describe('Modal', () => {
       <DeviceTypeProvider deviceType="mobile">
         <Modal
           accessibilityModalLabel="Test modal"
+          dataTestId="Data test id for modal"
           footer={
             <Flex gap={2} justifyContent="end">
               <Button color="gray" text="Cancel" />
@@ -107,6 +108,7 @@ describe('Modal', () => {
     expect(screen.getByText('Modal content')).toBeVisible();
     expect(screen.getByText('Cancel')).toBeVisible();
     expect(screen.getByText('Next')).toBeVisible();
+    expect(screen.getByTestId('Data test id for modal')).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(3);
     expect(screen.getByLabelText('Bottom sheet')).toBeVisible();
     expect(screen.getByLabelText('Dismiss bottom sheet')).toBeVisible();

--- a/packages/gestalt/src/Modal.jsdom.test.tsx
+++ b/packages/gestalt/src/Modal.jsdom.test.tsx
@@ -31,6 +31,7 @@ describe('Modal', () => {
     render(
       <Modal
         accessibilityModalLabel="Test modal"
+        dataTestId="Data test id for modal"
         footer={
           <Flex gap={2} justifyContent="end">
             <Button color="gray" text="Cancel" />
@@ -51,6 +52,7 @@ describe('Modal', () => {
     expect(screen.getByText('Modal content')).toBeVisible();
     expect(screen.getByText('Cancel')).toBeVisible();
     expect(screen.getByText('Next')).toBeVisible();
+    expect(screen.getByTestId('Data test id for modal')).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(2);
     expect(screen.getByLabelText('Test modal')).toBeVisible();
   });

--- a/packages/gestalt/src/Modal.tsx
+++ b/packages/gestalt/src/Modal.tsx
@@ -37,6 +37,10 @@ type Props = {
    */
   closeOnOutsideClick?: boolean;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Supply the element(s) that will be used as Modal's custom footer. See the [Best Practices](https://gestalt.pinterest.systems/web/modal#Best-practices) for more info.
    */
   footer?: ReactNode;
@@ -111,6 +115,7 @@ export default function Modal({
   align = 'center',
   children,
   closeOnOutsideClick = true,
+  dataTestId,
   onDismiss,
   footer,
   padding = 'default',
@@ -197,7 +202,7 @@ export default function Modal({
               style={{ width }}
               tabIndex={-1}
             >
-              <Box direction="column" display="flex" flex="grow" position="relative" width="100%">
+              <Box data-test-id={dataTestId} direction="column" display="flex" flex="grow" position="relative" width="100%">
                 {Boolean(heading) && (
                   <Box
                     borderStyle={showTopShadow ? 'raisedTopShadow' : undefined}

--- a/packages/gestalt/src/Modal.tsx
+++ b/packages/gestalt/src/Modal.tsx
@@ -179,6 +179,7 @@ export default function Modal({
     return (
       <FullPage
         align={align}
+        dataTestId={dataTestId}
         footer={footer}
         heading={heading}
         onDismiss={onDismiss}

--- a/packages/gestalt/src/ModalAlert.jsdom.test.tsx
+++ b/packages/gestalt/src/ModalAlert.jsdom.test.tsx
@@ -86,4 +86,33 @@ describe('ModalAlert', () => {
 
     expect(baseElement).toMatchSnapshot();
   });
+
+  test('Desktop ModalAlert has data-test-id prop', () => {
+    const { baseElement } = render(
+      <ModalAlert
+        accessibilityModalLabel="Test ModalAlert"
+        dataTestId="modal-alert-data-test-id"
+        heading="Delete Pin?"
+        onDismiss={() => {}}
+        primaryAction={{
+          accessibilityLabel: 'Acknowledge expired card',
+          dataTestId: 'modal-alert-primary-action-data-test-id',
+          label: 'Got it',
+          onClick: () => {},
+          role: 'button',
+        }}
+        secondaryAction={{
+            accessibilityLabel: 'Cancel action',
+            dataTestId: 'modal-alert-secondary-action-data-test-id',
+            label: 'Cancel',
+            onClick: () => {},
+            role: 'button',
+          }}
+      >
+        Modal content
+      </ModalAlert>,
+    );
+
+    expect(baseElement).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/ModalAlert.tsx
+++ b/packages/gestalt/src/ModalAlert.tsx
@@ -43,6 +43,10 @@ type Props = {
    */
   children: ReactNode;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * The text used for ModalAlert's heading.
    */
   heading: string;
@@ -81,6 +85,7 @@ export default function ModalAlert({
   accessibilityModalLabel,
   type = 'default',
   children,
+  dataTestId,
   onDismiss,
   heading,
   primaryAction,
@@ -108,6 +113,7 @@ export default function ModalAlert({
         accessibilityModalLabel={accessibilityModalLabel}
         align="start"
         closeOnOutsideClick={type === 'default'}
+        dataTestId={dataTestId}
         footer={
           <Flex gap={2} justifyContent="end">
             {secondaryAction && <ModalAlertAction type="secondary" {...secondaryAction} />}

--- a/packages/gestalt/src/SheetMobile/FullPage.tsx
+++ b/packages/gestalt/src/SheetMobile/FullPage.tsx
@@ -30,6 +30,7 @@ type Props = {
     onClick: OnClickType;
   };
   children?: ReactNode;
+  dataTestId?: string;
   footer?: ReactNode;
   forwardIconButton?: {
     accessibilityLabel: string;
@@ -57,6 +58,7 @@ export default function FullPage({
   align,
   backIconButton,
   children,
+  dataTestId,
   onDismiss,
   footer,
   forwardIconButton,
@@ -133,6 +135,7 @@ export default function FullPage({
             <div
               aria-label={accessibilityLabel ?? defaultAccessibilityLabel}
               className={classnames(sheetMobileStyles.fullPageWrapper, focusStyles.hideOutline)}
+              data-test-id={dataTestId}
               id={id}
               role={role}
               style={{ width: '100%' }}

--- a/packages/gestalt/src/TagData.test.tsx
+++ b/packages/gestalt/src/TagData.test.tsx
@@ -130,4 +130,15 @@ describe('TagData', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('reders tagdata with data test id', () => {
+    const component = create(
+      <TagData
+        dataTestId="tagdata-test-id"
+        text="Text For TagData"
+      />,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/gestalt/src/TagData.tsx
+++ b/packages/gestalt/src/TagData.tsx
@@ -68,6 +68,10 @@ export type Props = {
    */
   color?: DataVisualizationColors;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Indicates if TagData should be disabled. Disabled TagDatas are inactive and cannot be interacted with. See the [disabled variant](https://gestalt.pinterest.systems/web/tagdata#disabled) to learn more.
    */
   disabled?: boolean;
@@ -121,6 +125,7 @@ export default function TagData({
   accessibilityRemoveIconLabel,
   baseColor = 'primary',
   color = '05',
+  dataTestId,
   disabled = false,
   id,
   onTap,
@@ -194,7 +199,7 @@ export default function TagData({
   });
 
   return (
-    <Box display="inlineBlock" maxWidth={300} position="relative" rounding={2}>
+    <Box data-test-id={dataTestId} display="inlineBlock" maxWidth={300} position="relative" rounding={2}>
       <MaybeTooltip disabled={disabled} tooltip={tooltip}>
         <TapArea
           disabled={disabled}

--- a/packages/gestalt/src/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Checkbox.test.tsx.snap
@@ -390,6 +390,65 @@ exports[`Checkbox small 1`] = `
 </div>
 `;
 
+exports[`Checkbox with a data-test-id 1`] = `
+<div
+  className="box"
+>
+  <div
+    className="box marginEndN1 marginStartN1 xsDisplayFlex xsItemsStart"
+  >
+    <div
+      className="box paddingX1 relative"
+      data-test-id="checkbox-datatestid"
+    >
+      <input
+        aria-invalid="false"
+        checked={false}
+        className="input sizeSm inputEnabled"
+        disabled={false}
+        id="id"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        type="checkbox"
+      />
+      <div
+        className="enabled border borderRadiusSm sizeSm check"
+      />
+    </div>
+    <div
+      className="box xsDisplayBlock"
+      style={
+        Object {
+          "marginTop": "-1px",
+        }
+      }
+    >
+      <label
+        className="label"
+        htmlFor="id"
+      >
+        <div
+          className="box paddingX1"
+        >
+          <div
+            className="Text fontSize200 default alignStart breakWord fontWeightNormal"
+          >
+            Name
+          </div>
+        </div>
+      </label>
+      <div
+        className="box paddingX1"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Checkbox with an image 1`] = `
 <div
   className="box"

--- a/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.tsx.snap
@@ -1,5 +1,159 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ModalAlert Desktop ModalAlert has data-test-id prop 1`] = `
+<body
+  style="overflow: hidden;"
+>
+  <div>
+    <div
+      name="trap-focus"
+    >
+      <div
+        aria-label="Test ModalAlert"
+        class="container"
+        role="alertdialog"
+      >
+        <div
+          class="backdrop zoomOut"
+        />
+        <div
+          class="wrapper hideOutline"
+          style="width: 540px;"
+          tabindex="-1"
+        >
+          <div
+            class="box flexGrow relative xsDirectionColumn xsDisplayFlex"
+            data-test-id="modal-alert-data-test-id"
+            style="width: 100%;"
+          >
+            <div
+              class="box fit relative"
+              style="z-index: 1;"
+            >
+              <div
+                class="box paddingX6 paddingY6"
+              >
+                <div
+                  class="Flex rowGap4 columnGap4 flexGrow xsDirectionRow xsItemsCenter"
+                >
+                  <div
+                    class="FlexItem flexGrow"
+                  >
+                    <h1
+                      class="Heading fontSize400 default alignStart breakWord"
+                    >
+                      Delete Pin?
+                    </h1>
+                  </div>
+                  <div
+                    class="FlexItem"
+                  >
+                    <div
+                      class="box marginStart2"
+                    >
+                      <button
+                        aria-label="Dismiss modal"
+                        class="parentButton"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <div
+                          class="button tapTransition enabled"
+                        >
+                          <div
+                            class="pog white"
+                            style="height: 32px; width: 32px;"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              aria-label=""
+                              class="default icon iconBlock"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width="16"
+                            >
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="box flexGrow overflowAuto paddingX6 paddingY6 relative"
+              style="height: 100%;"
+            >
+              Modal content
+            </div>
+            <div
+              class="box fit relative"
+              style="z-index: 1;"
+            >
+              <div
+                class="box paddingX6 paddingY6"
+              >
+                <div
+                  class="Flex rowGap2 columnGap2 justifyEnd xsDirectionRow"
+                >
+                  <div
+                    class="FlexItem"
+                  >
+                    <button
+                      aria-label="Cancel action"
+                      class="button hideOutline block accessibilityOutline parentButton"
+                      data-test-id="modal-alert-secondary-action-data-test-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="button hideOutline block accessibilityOutline tapTransition lg gray enabled childrenDiv"
+                      >
+                        <div
+                          class="Text fontSize300 default alignCenter fontWeightSemiBold"
+                        >
+                          Cancel
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                  <div
+                    class="FlexItem"
+                  >
+                    <button
+                      aria-label="Acknowledge expired card"
+                      class="button hideOutline block accessibilityOutline parentButton"
+                      data-test-id="modal-alert-primary-action-data-test-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <div
+                        class="button hideOutline block accessibilityOutline tapTransition lg red enabled childrenDiv"
+                      >
+                        <div
+                          class="Text fontSize300 inverse alignCenter fontWeightSemiBold"
+                        >
+                          Got it
+                        </div>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`ModalAlert Desktop ModalAlert renders (default) 1`] = `
 <body
   style="overflow: hidden;"

--- a/packages/gestalt/src/__snapshots__/TagData.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/TagData.test.tsx.snap
@@ -75,6 +75,64 @@ exports[`TagData TagData has a tooltip 1`] = `
 </div>
 `;
 
+exports[`TagData reders tagdata with data test id 1`] = `
+<div
+  className="box relative rounding2 xsDisplayInlineBlock"
+  data-test-id="tagdata-test-id"
+  style={
+    Object {
+      "maxWidth": 300,
+    }
+  }
+>
+  <div
+    aria-disabled={false}
+    className="hideOutline tapTransition rounding2 accessibilityOutline fullHeight fullWidth pointer"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <div
+      className="solid transparentBorder tagMedium primary tagWrapperRounded"
+      style={Object {}}
+    >
+      <div
+        className="box marginEnd0 paddingX2 xsDisplayFlex xsItemsCenter"
+        style={
+          Object {
+            "height": "100%",
+          }
+        }
+      >
+        <span
+          className="Text fontSize200 default alignStart breakAll fontWeightNormal lineClamp"
+          style={
+            Object {
+              "WebkitLineClamp": 1,
+            }
+          }
+          title="Text For TagData"
+        >
+          Text For TagData
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TagData renders all colors as expected 1`] = `
 <div
   className="Flex rowGap2 columnGap2 xsDirectionRow"


### PR DESCRIPTION
### Summary

#### What changed?

Some of the components do not have the data-test-id property, which makes it difficult to reference them in an integration test. For this reason, some of them have been updated and had it added

#### Why?

In integration tests, there are multiple ways to locate an element, such as using the ID, classes, or content. However, these approaches can change without prior notice and may also depend on the language in which the application is being executed.
Therefore, one of the best practices is to have a property that remains constant, something that does not affect the execution or performance and remains consistent at all times.

Thus, the data-test-id property is crucial for testing purposes, and it is now very helpful to have it in all components if feasible.

### Checklist

- [x] Added unit tests
- [x] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
