### PR TITLE
Masonry: Remove legacy flexible gutter logic

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -118,12 +118,6 @@ type Props<T> = {
    * This is an experimental prop and may be removed in the future.
    */
   _logTwoColWhitespace?: (arg1: number) => void;
-  /**
-   * Temporal prop to sync gutter logic on full width layout refactor.
-   *
-   * This is an experimental prop and will be removed in the future.
-   */
-  _legacyFlexibleGutterLogic?: boolean;
 };
 
 type State<T> = {
@@ -497,7 +491,6 @@ export default class Masonry<
       scrollContainer,
       _twoColItems,
       _logTwoColWhitespace,
-      _legacyFlexibleGutterLogic,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
     const { positionStore } = this;
@@ -514,7 +507,6 @@ export default class Masonry<
         width,
         logWhitespace: _logTwoColWhitespace,
         _twoColItems,
-        _legacyFlexibleGutterLogic,
       });
     } else if (layout === 'uniformRow') {
       getPositions = uniformRowLayout({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -64,9 +64,6 @@ describe.each([false, true])('full width layout tests', (_twoColItems) => {
       minCols: 2,
       width: 1000,
       _twoColItems,
-      // When using _legacyGutterLogic we are not setting the height gutter,
-      // this is the current behavior in pinboard and will be fixed
-      _legacyFlexibleGutterLogic: false,
     });
     expect(
       layout(items)

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -14,7 +14,6 @@ const fullWidthLayout = <
   minCols = 2,
   measurementCache,
   _twoColItems = false,
-  _legacyFlexibleGutterLogic = true,
   ...otherProps
 }: {
   idealColumnWidth?: number;
@@ -24,7 +23,6 @@ const fullWidthLayout = <
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
   _twoColItems?: boolean;
-  _legacyFlexibleGutterLogic?: boolean;
   whitespaceThreshold?: number;
   logWhitespace?: (arg1: number) => void;
 }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) => {
@@ -76,7 +74,7 @@ const fullWidthLayout = <
             const top = heights[col];
             const left = col * columnWidthAndGutter + centerOffset;
 
-            heights[col] += height + (_legacyFlexibleGutterLogic ? 0 : gutter);
+            heights[col] += height + gutter;
             position = {
               top,
               left,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -20,7 +20,6 @@ export default function getLayoutAlgorithm<
   width,
   _twoColItems,
   _logTwoColWhitespace,
-  _legacyFlexibleGutterLogic,
 }: {
   align: Align;
   columnWidth: number;
@@ -33,7 +32,6 @@ export default function getLayoutAlgorithm<
   width: number | null | undefined;
   _twoColItems?: boolean;
   _logTwoColWhitespace?: (arg1: number) => void;
-  _legacyFlexibleGutterLogic?: boolean;
 }): (forItems: ReadonlyArray<T>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
     return fullWidthLayout({
@@ -45,7 +43,6 @@ export default function getLayoutAlgorithm<
       width,
       logWhitespace: _logTwoColWhitespace,
       _twoColItems,
-      _legacyFlexibleGutterLogic,
     });
   }
   if (layout === 'uniformRow') {

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -136,12 +136,6 @@ type Props<T> = {
    * Experimental prop to trigger rendering updates via requestAnimationFrame
    */
   _useRAF?: boolean;
-  /**
-   * Temporal prop to sync gutter logic on full width layout refactor.
-   *
-   * This is an experimental prop and will be removed in the future.
-   */
-  _legacyFlexibleGutterLogic?: boolean;
 };
 
 type MasonryRef = {
@@ -338,7 +332,6 @@ function useLayout<
   _logTwoColWhitespace,
   _measureAll,
   _useRAF,
-  _legacyFlexibleGutterLogic,
 }: {
   align: Align;
   columnWidth: number;
@@ -353,7 +346,6 @@ function useLayout<
   _logTwoColWhitespace?: (arg1: number) => void;
   _measureAll?: boolean;
   _useRAF?: boolean;
-  _legacyFlexibleGutterLogic?: boolean;
 }): {
   height: number;
   hasPendingMeasurements: boolean;
@@ -378,7 +370,6 @@ function useLayout<
     width,
     _twoColItems,
     _logTwoColWhitespace,
-    _legacyFlexibleGutterLogic,
   });
 
   const itemMeasurements = items.filter((item) => measurementStore.has(item));
@@ -606,7 +597,6 @@ function Masonry<
     _logTwoColWhitespace,
     _measureAll,
     _useRAF,
-    _legacyFlexibleGutterLogic,
   }: Props<T>,
   ref:
     | {
@@ -697,7 +687,6 @@ function Masonry<
     _logTwoColWhitespace,
     _measureAll,
     _useRAF,
-    _legacyFlexibleGutterLogic,
   });
 
   useFetchOnScroll({


### PR DESCRIPTION
### Summary

#### What changed?

Removed the `_legacyFlexibleGutterLogic` prop for masonry full width layout.

#### Why?

When we enabled multi column items on the flexible layout we found that there was a bug on the logic to calculate the height position, it was not used to calculate the new col height so the vertical gutter was ignored. To keep the same behavior we added a flag to keep the old logic, the proble is that this only works when not using the multi column modules logic. To be able to unify the logic we need to get rid of the legacy logic.

I did an investigation inside pinboard and the vast mayority of cases don't use a gutter so are not affected, a couple have 2px, 4px and 6px gutters, this was not too impactful.

There are some components that have 16px or higher but was not able to test them, in case we find issues we can talk with the owner teams to fix the gutter inside the component and not in masonry.

### Tests

Tested the before and after the change. 

<img width="521" alt="Screenshot 2024-06-12 at 9 14 20 p m" src="https://github.com/pinterest/gestalt/assets/700818/9ff0c558-ebc1-4f17-986e-f2f2d5507b4b">
<img width="521" alt="Screenshot 2024-06-12 at 9 14 04 p m" src="https://github.com/pinterest/gestalt/assets/700818/c7fc7a24-9098-44ac-bb60-b77df1ddc28c">
<img width="521" alt="Screenshot 2024-06-12 at 7 22 50 p m" src="https://github.com/pinterest/gestalt/assets/700818/76c0236e-ac48-4a7a-8da1-5486e2969b17">
<img width="521" alt="Screenshot 2024-06-12 at 7 22 33 p m" src="https://github.com/pinterest/gestalt/assets/700818/2afd0b52-cbd3-4910-8b88-6fc2c9feeef1">
<img width="521" alt="Screenshot 2024-06-12 at 6 24 52 p m" src="https://github.com/pinterest/gestalt/assets/700818/ca865057-8f7f-4362-99c9-c257ce5b3f30">
<img width="520" alt="Screenshot 2024-06-12 at 6 24 32 p m" src="https://github.com/pinterest/gestalt/assets/700818/8a21fb1c-19e2-4fbb-8abe-4ebe108fba29">
<img width="523" alt="Screenshot 2024-06-11 at 7 31 39 p m" src="https://github.com/pinterest/gestalt/assets/700818/2cef1ee5-a2b4-44a5-a4d8-64cfbd58e3ce">
<img width="526" alt="Screenshot 2024-06-11 at 7 31 22 p m" src="https://github.com/pinterest/gestalt/assets/700818/30da01dd-9eea-4ab8-b1ed-cc264558ebeb">

