### PR TITLE
Internal: Upgrade TypeScript to 5.5

### DIFF
--- a/docs/docs-components/GeneratedPropTable.tsx
+++ b/docs/docs-components/GeneratedPropTable.tsx
@@ -7,6 +7,7 @@ function getResponsive(description?: string): {
   responsive?: boolean;
 } {
   const input = description ?? '';
+  // @ts-expect-error - TS1503
   const match = input.match(/(?<main>Responsive: (?<responsive>.*))/);
   const groups = match?.groups ?? {};
 
@@ -22,6 +23,7 @@ function getTypeOverrideValue(description?: string): {
   typeOverride?: string;
 } {
   const input = description ?? '';
+  // @ts-expect-error - TS1503
   const match = input.match(/(?<main>Type: (?<typeOverride>.*))/);
   const groups = match?.groups ?? {};
 
@@ -37,6 +39,7 @@ function getDefaultValue(description?: string): {
   defaultValue?: string;
 } {
   const input = description ?? '';
+  // @ts-expect-error - TS1503
   const match = input.match(/(?<main>Default: (?<defaultValue>.*))/);
   const groups = match?.groups ?? {};
 

--- a/docs/docs-components/TokenTable.tsx
+++ b/docs/docs-components/TokenTable.tsx
@@ -1,6 +1,5 @@
 import { Fragment } from 'react';
 import { Badge, Box, ColorSchemeProvider, Flex, Table, Text } from 'gestalt';
-// @ts-expect-error - TS7016 - Could not find a declaration file for module 'gestalt-design-tokens/dist/js/tokens_dark'. '/packages/gestalt-design-tokens/dist/js/tokens_dark.js' implicitly has an 'any' type.
 import tokensDark from 'gestalt-design-tokens/dist/js/classic/tokens_dark';
 import { TokenExample } from './TokenExample';
 
@@ -33,7 +32,6 @@ function getReferenceTokenMap() {
     }
   >();
 
-  // @ts-expect-error - TS7006 - Parameter 'token' implicitly has an 'any' type.
   tokensDark.forEach((token) => {
     darkTokenMap.set(token.name, {
       value: token.value,

--- a/docs/pages/foundations/design_tokens/component_tokens.tsx
+++ b/docs/pages/foundations/design_tokens/component_tokens.tsx
@@ -1,4 +1,3 @@
-// @ts-expect-error - TS7016 - Could not find a declaration file for module 'gestalt-design-tokens/dist/js/tokens'. '/packages/gestalt-design-tokens/dist/js/tokens.js' implicitly has an 'any' type.
 import tokens from 'gestalt-design-tokens/dist/js/classic/tokens';
 import MainSection from '../../../docs-components/MainSection';
 import Page from '../../../docs-components/Page';

--- a/docs/pages/foundations/design_tokens/overview.tsx
+++ b/docs/pages/foundations/design_tokens/overview.tsx
@@ -1,6 +1,4 @@
-// @ts-expect-error - TS7016 - Could not find a declaration file for module 'gestalt-design-tokens/dist/js/data-viz-tokens'. '/packages/gestalt-design-tokens/dist/js/data-viz-tokens.js' implicitly has an 'any' type.
 import dataVizTokens from 'gestalt-design-tokens/dist/js/classic/data-viz-tokens';
-// @ts-expect-error - TS7016 - Could not find a declaration file for module 'gestalt-design-tokens/dist/js/tokens'. '/packages/gestalt-design-tokens/dist/js/tokens.js' implicitly has an 'any' type.
 import tokens from 'gestalt-design-tokens/dist/js/classic/tokens';
 import MainSection from '../../../docs-components/MainSection';
 import Page from '../../../docs-components/Page';
@@ -143,7 +141,6 @@ export type Token = {
   category: string;
 };
 
-// @ts-expect-error - TS7006 - Parameter 'a' implicitly has an 'any' type. | TS7006 - Parameter 'b' implicitly has an 'any' type.
 const dataVizColorTokens: ReadonlyArray<Token> = dataVizTokens.sort((a, b) =>
   a.name.localeCompare(b.name, undefined, {
     numeric: true,

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
     "sucrase": "^3.35.0",
-    "typescript": "^5.0.2",
+    "typescript": "5.5.2",
     "typescript-plugin-css-modules": "^5.1.0",
     "xml2js": "^0.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "svgIcons:validate": "./scripts/validateIconSvgSpecs.js",
     "test": "./scripts/test.sh",
     "tokens:test": "(cd packages/gestalt-design-tokens && yarn test)",
-    "tsc": "tsc --build --force"
+    "tsc": "tsc --build --force",
+    "ts:removeUnusedTsExpectErrors": "./scripts/ts/tsRemoveUnusedTsExpectErrors.sh"
   },
   "jest": {
     "projects": [

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultLegend.tsx
@@ -58,7 +58,6 @@ export default function useDefaultLegend({
           };
         }) => (
           <Flex key={payloadData.dataKey} gap={{ row: 2, column: 0 }}>
-            {/* @ts-expect-error - TS2786 - 'LegendIcon' cannot be used as a JSX component. */}
             <LegendIcon payloadData={{ ...payloadData, isLegend: true }} />
             <Text size="200">{labelMap?.[payloadData.dataKey] || payloadData.dataKey}</Text>
           </Flex>
@@ -68,7 +67,6 @@ export default function useDefaultLegend({
       const referenceAreas =
         referenceAreaSummary?.map(({ label }: ReferenceAreaSummaryItem) => (
           <Flex key={label} gap={{ row: 2, column: 0 }}>
-            {/* @ts-expect-error - TS2786 - 'LegendIcon' cannot be used as a JSX component. */}
             <LegendIcon payloadData={{ referenceArea: 'default', isLegend: true }} />
             <Text size="200">{label}</Text>
           </Flex>

--- a/packages/gestalt-charts/src/ChartGraph/useDefaultTooltip.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/useDefaultTooltip.tsx
@@ -68,7 +68,6 @@ export default function useDefaultTooltip({
                     strokeWidth?: number;
                   }) => (
                     <Flex key={payloadData.name} alignItems="center" gap={2}>
-                      {/* @ts-expect-error - TS2786 - 'LegendIcon' cannot be used as a JSX component. */}
                       <LegendIcon payloadData={payloadData} />
                       <Flex.Item flex="grow">
                         <Text size="100">

--- a/packages/gestalt/src/Datapoint/InternalDatapoint.tsx
+++ b/packages/gestalt/src/Datapoint/InternalDatapoint.tsx
@@ -98,7 +98,6 @@ export default function InternalDatapoint({
   return (
     <Flex direction="column" gap={{ column: 1, row: 0 }}>
       <Flex alignItems="center" gap={{ row: 1, column: 0 }} minHeight={24}>
-        {/* @ts-expect-error - TS2786 - 'MaybeMinWidth' cannot be used as a JSX component. */}
         <MaybeMinWidth
           maxWidth={maxTitleWidth}
           minWidth={minTitleWidth}

--- a/packages/gestalt/src/Popover.tsx
+++ b/packages/gestalt/src/Popover.tsx
@@ -128,7 +128,6 @@ export default function Popover({
 
   if (!isInExperiment) {
     return (
-      // @ts-expect-error - TS2786 - 'LegacyInternalPopover' cannot be used as a JSX component.
       <LegacyInternalPopover
         __dangerouslySetMaxHeight={__dangerouslySetMaxHeight}
         accessibilityDismissButtonLabel={accessibilityDismissButtonLabel}

--- a/packages/gestalt/src/TextField/InternalTextFieldIconButton.tsx
+++ b/packages/gestalt/src/TextField/InternalTextFieldIconButton.tsx
@@ -61,7 +61,6 @@ export default function InternalTextFieldIconButton({
         marginEnd={2}
         rounding="circle"
       >
-        {/* @ts-expect-error - TS2786 - 'MaybeTooltip' cannot be used as a JSX component. */}
         <MaybeTooltip tooltipText={tooltipText}>
           <TapArea
             accessibilityChecked={accessibilityChecked}

--- a/scripts/ts/removeUnusedTsExpectErrorComments.ts
+++ b/scripts/ts/removeUnusedTsExpectErrorComments.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+
+const TS_EXPECT_ERROR_REMOVED = '__TS_EXPECT_ERROR_REMOVED__'; // special string to mark the line as removed
+
+type FilePathToLineNumbers = {
+  [filePath: string]: ReadonlyArray<number>;
+};
+
+function getUnusedTsExpectErrorComments(tscRunOutputFilePath: string): FilePathToLineNumbers {
+  const filePathToLineNumbers: FilePathToLineNumbers = {};
+  fs.readFileSync(tscRunOutputFilePath, { encoding: 'utf8' })
+    .split('\n')
+    .filter((line) => line.includes(": error TS2578: Unused '@ts-expect-error' directive."))
+    .map((line) => (line.split(':')[0] || '').match(/^(.*)\((\d+),/))
+    .forEach((matches) => {
+      if (matches) {
+        const [_, filePath, lineNum] = matches;
+        filePathToLineNumbers[filePath] = [
+          ...(filePathToLineNumbers[filePath] || []),
+          parseInt(lineNum, 10),
+        ];
+      }
+    });
+  return filePathToLineNumbers;
+}
+
+async function removeTsExpectErrorCommentsForFile(
+  filePath: string,
+  lineNums: ReadonlyArray<number>,
+): Promise<void> {
+  const content = await fs.promises.readFile(filePath, 'utf8');
+  await fs.promises.writeFile(
+    filePath,
+    content
+      .split(/\n/)
+      .map((line, index) => {
+        if (!lineNums.includes(index + 1)) {
+          return line;
+        }
+        // Almost all @ts-expect-error comments are in their own lines, but that isn't always
+        // the case. In some rare cases, a @ts-expect-error comment can be at the end of a line
+        // that is above the line with the error, and we want to make sure that we do not remove
+        // the code before the @ts-expect-error comment.
+        const inlineTsExpectErrorCommentMatch = line.match(/^(.*)\s\/\/\s@ts-expect-error/);
+        if (inlineTsExpectErrorCommentMatch && inlineTsExpectErrorCommentMatch[1].trim() !== '') {
+          return inlineTsExpectErrorCommentMatch[1];
+        }
+        return TS_EXPECT_ERROR_REMOVED;
+      })
+      .filter((line) => line !== TS_EXPECT_ERROR_REMOVED)
+      .join('\n'),
+  );
+}
+
+async function removeUnusedTsExpectErrorComments(tscRunOutputFilePath: string) {
+  await Promise.all(
+    Object.entries(getUnusedTsExpectErrorComments(tscRunOutputFilePath)).map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ([filePath, lineNums]: [any, any]) => removeTsExpectErrorCommentsForFile(filePath, lineNums),
+    ),
+  );
+}
+
+const tscRunOutputFilePath = process.argv[2];
+
+if (!tscRunOutputFilePath) {
+  throw new Error('Please provide the path to the tsc run output file');
+}
+
+removeUnusedTsExpectErrorComments(tscRunOutputFilePath);

--- a/scripts/ts/removeUnusedTsExpectErrorComments.ts
+++ b/scripts/ts/removeUnusedTsExpectErrorComments.ts
@@ -14,7 +14,7 @@ function getUnusedTsExpectErrorComments(tscRunOutputFilePath: string): FilePathT
     .map((line) => (line.split(':')[0] || '').match(/^(.*)\((\d+),/))
     .forEach((matches) => {
       if (matches) {
-        const [_, filePath, lineNum] = matches;
+        const [, filePath, lineNum] = matches;
         filePathToLineNumbers[filePath] = [
           ...(filePathToLineNumbers[filePath] || []),
           parseInt(lineNum, 10),
@@ -55,7 +55,6 @@ async function removeTsExpectErrorCommentsForFile(
 async function removeUnusedTsExpectErrorComments(tscRunOutputFilePath: string) {
   await Promise.all(
     Object.entries(getUnusedTsExpectErrorComments(tscRunOutputFilePath)).map(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ([filePath, lineNums]: [any, any]) => removeTsExpectErrorCommentsForFile(filePath, lineNums),
     ),
   );

--- a/scripts/ts/tsRemoveUnusedTsExpectErrors.sh
+++ b/scripts/ts/tsRemoveUnusedTsExpectErrors.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+TMP_FILE=/tmp/gestalt-tsc-results.txt
+yarn tsc > $TMP_FILE
+yarn babel-node scripts/ts/removeUnusedTsExpectErrorComments.ts $TMP_FILE
+rm $TMP_FILE

--- a/yarn.lock
+++ b/yarn.lock
@@ -19964,6 +19964,11 @@ typescript-plugin-css-modules@^5.1.0:
     stylus "^0.62.0"
     tsconfig-paths "^4.2.0"
 
+typescript@5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
+  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+
 typescript@^3.9.10:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
@@ -19973,11 +19978,6 @@ typescript@^4.1.5, typescript@^4.4.3:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.3.tgz#fe976f0c826a88d0a382007681cbb2da44afdedf"
-  integrity sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==
 
 ua-parser-js@^1.0.33:
   version "1.0.33"


### PR DESCRIPTION
## What changed?

Upgrade to TypeScript 5.5. See https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

Also add the command `yarn ts:removeUnusedTsExpectErrors` to remove unused `@ts-expect-error`.

## Why?

- Stay current
- v5.5 is the biggest TypeScript release, which includes an awesome feature: Inferred Type Predicates

What is Inferred Type Predicates? Basically, it adds type narrowing in array filtering.

So instead of writing the overly complex form
```ts
// reduce instead of filter to appease type checker
myArray.reduce<Array<Item>>(
  (arr, item) =>
    arr.concat(shouldInclude(item) ? [item] : []),
  [],
)
```

You can just write:

```ts
myArray.filter((item) => shouldInclude(item))
```
