### PR TITLE
AvatarGroup: enable actions in smaller sizes

### DIFF
--- a/docs/pages/web/avatargroup.tsx
+++ b/docs/pages/web/avatargroup.tsx
@@ -1,4 +1,5 @@
-import { AvatarGroup } from 'gestalt';
+import { useState } from 'react';
+import { AvatarGroup, Box, SelectList } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
 import CombinationNew from '../../docs-components/CombinationNew';
 import docGen, { DocGen } from '../../docs-components/docgen';
@@ -20,6 +21,8 @@ import roleLink from '../../examples/avatarGroup/roleLink';
 import sizing from '../../examples/avatarGroup/sizing';
 
 export default function AvatarGroupPage({ generatedDocGen }: { generatedDocGen: DocGen }) {
+  const [avatarsize, setAvatarsize] = useState<'md' | 'xs' | 'sm'>('md');
+
   return (
     <Page title={generatedDocGen?.displayName}>
       <PageHeader description={generatedDocGen?.description} name={generatedDocGen?.displayName}>
@@ -173,9 +176,30 @@ If AvatarGroup is used as a control button to show/hide Popover-component, we re
           />
         </MainSection.Subsection>
         <MainSection.Subsection
-          description="AvatarGroup displays up to three user avatars. More users, if present, will be displayed as a numerical count for the `md` and `fit` sizes."
+          description="AvatarGroup displays up to three user avatars. More users, if present, will be displayed as a numerical count."
           title="Collaborators display"
         >
+          <Box display="flex">
+            <SelectList
+              id="sizeExamples"
+              label="Size"
+              onChange={({ value }) => {
+                if (value === 'md' || value === 'xs' || value === 'sm') {
+                  setAvatarsize(value);
+                }
+              }}
+              size="md"
+              value={avatarsize}
+            >
+              {[
+                { label: 'xs', value: 'xs' },
+                { label: 'sm', value: 'sm' },
+                { label: 'md', value: 'md' },
+              ].map(({ label, value }) => (
+                <SelectList.Option key={label} label={label} value={value} />
+              ))}
+            </SelectList>
+          </Box>
           <CombinationNew
             // @ts-expect-error - TS2322 - Type '{ children: ({ addCollaborators, collaborators }: { [key: string]: any; }) => Element; addCollaborators: boolean[]; collaborators: any[][]; hideTitle: true; }' is not assignable to type 'IntrinsicAttributes & Props'.
             addCollaborators={[false, true]}
@@ -262,13 +286,13 @@ If AvatarGroup is used as a control button to show/hide Popover-component, we re
                   collaborators={collaborators}
                   onClick={() => {}}
                   role="button"
-                  size="md"
+                  size={avatarsize}
                 />
               ) : (
                 <AvatarGroup
                   accessibilityLabel={accessibilityLabel}
                   collaborators={collaborators}
-                  size="md"
+                  size={avatarsize}
                 />
               );
             }}

--- a/packages/gestalt/src/AvatarGroup.tsx
+++ b/packages/gestalt/src/AvatarGroup.tsx
@@ -98,23 +98,15 @@ const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGr
 ) {
   const [hovered, setHovered] = useState(false);
 
-  const isMdSize = size === 'md';
-
-  const isFitSize = size === 'fit';
-
-  const isMdOrFitSize = isMdSize || isFitSize;
-
   const isDisplayOnly = !role;
 
-  const isAboveMaxCollaborators = collaborators.length > MAX_COLLABORATOR_AVATARS;
+  const showCollaboratorsCount = collaborators.length > MAX_COLLABORATOR_AVATARS;
 
-  const showCollaboratorsCount = isMdOrFitSize && isAboveMaxCollaborators;
-
-  const showAddCollaboratorsButton = (isMdOrFitSize && !isDisplayOnly && addCollaborators) ?? false;
+  const showAddCollaboratorsButton = (!isDisplayOnly && addCollaborators) ?? false;
 
   const displayedCollaborators = collaborators.slice(
     0,
-    isAboveMaxCollaborators && isMdOrFitSize ? 2 : MAX_COLLABORATOR_AVATARS,
+    showCollaboratorsCount ? 2 : MAX_COLLABORATOR_AVATARS,
   );
 
   const pileCount =
@@ -161,17 +153,16 @@ const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGr
     <Box
       aria-label={isDisplayOnly ? accessibilityLabel : undefined}
       dangerouslySetInlineStyle={{ __style: { isolation: 'isolate' } }}
-      position={isFitSize ? 'relative' : 'static'}
+      position={size === 'fit' ? 'relative' : 'static'}
     >
-      {isFitSize ? collaboratorStack : <Flex>{collaboratorStack}</Flex>}
+      {size === 'fit' ? collaboratorStack : <Flex>{collaboratorStack}</Flex>}
     </Box>
   );
 
   if (role === 'link' && href) {
     return (
       <TapAreaLink
-        // @ts-expect-error - TS2322 - Type 'ForwardedRef<UnionRefs>' is not assignable to type 'LegacyRef<HTMLAnchorElement> | undefined'.
-        ref={ref}
+        ref={ref as React.LegacyRef<HTMLAnchorElement> | undefined}
         accessibilityLabel={accessibilityLabel}
         fullWidth={false}
         href={href}
@@ -191,8 +182,7 @@ const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGr
   if (role === 'button' && onClick) {
     return (
       <TapArea
-        // @ts-expect-error - TS2322 - Type 'ForwardedRef<UnionRefs>' is not assignable to type 'LegacyRef<HTMLDivElement> | undefined'.
-        ref={ref}
+        ref={ref as React.LegacyRef<HTMLDivElement> | undefined}
         accessibilityControls={accessibilityControls}
         accessibilityExpanded={accessibilityExpanded}
         accessibilityHaspopup={accessibilityHaspopup}


### PR DESCRIPTION
AvatarGroup: enable actions in smaller sizes

BEFORE counter and addCollaborators were only available to md.
AFTER counter and addCollaborators are available to xs, sm, & md.

![Brave Browser - AvatarGroup - Gestalt 2024-07-01 at 10 44 50 AM](https://github.com/pinterest/gestalt/assets/10593890/8250f97c-3c21-4d26-8ace-c74d410a1fc7)
