### PR TITLE
[WIP] SelectList: Added onBlur/onFocus props + unit tests

### DIFF
--- a/packages/gestalt/src/SelectList.test.tsx
+++ b/packages/gestalt/src/SelectList.test.tsx
@@ -95,7 +95,7 @@ describe('SelectList', () => {
     render(
       <SelectList id="test" onBlur={onBlurMock} onChange={jest.fn()}>
         {options}
-      </SelectList>
+      </SelectList>,
     );
 
     const select = screen.getByRole('combobox');
@@ -112,7 +112,7 @@ describe('SelectList', () => {
     render(
       <SelectList id="test" onChange={jest.fn()} onFocus={onFocusMock}>
         {options}
-      </SelectList>
+      </SelectList>,
     );
 
     const select = screen.getByRole('combobox');

--- a/packages/gestalt/src/SelectList.test.tsx
+++ b/packages/gestalt/src/SelectList.test.tsx
@@ -113,7 +113,7 @@ describe('SelectList', () => {
   it('calls onFocus prop when select gains focus', () => {
     const onFocusMock = jest.fn();
     const component = create(
-      <SelectList id="test" onFocus={onFocusMock} onChange={jest.fn()}>
+      <SelectList id="test"  onChange={jest.fn()} onFocus={onFocusMock}>
         {options}
       </SelectList>,
     );

--- a/packages/gestalt/src/SelectList.test.tsx
+++ b/packages/gestalt/src/SelectList.test.tsx
@@ -88,7 +88,7 @@ describe('SelectList', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('calls onBlur prop when select loses focus', () => {
+  it('calls onBlur prop when select loses focus', async () => {
     const onBlurMock = jest.fn();
     const component = create(
       <SelectList id="test" onBlur={onBlurMock} onChange={jest.fn()}>
@@ -98,7 +98,7 @@ describe('SelectList', () => {
 
     const select = component.root.findByType('select');
 
-    act(() => {
+    await act(async () => {
       select.props.onBlur({
         target: { value: 'value1' },
       });
@@ -110,17 +110,17 @@ describe('SelectList', () => {
     });
   });
 
-  it('calls onFocus prop when select gains focus', () => {
+  it('calls onFocus prop when select gains focus', async () => {
     const onFocusMock = jest.fn();
     const component = create(
-      <SelectList id="test"  onChange={jest.fn()} onFocus={onFocusMock}>
+      <SelectList id="test" onChange={jest.fn()} onFocus={onFocusMock}>
         {options}
       </SelectList>,
     );
 
     const select = component.root.findByType('select');
 
-    act(() => {
+    await act(async () => {
       select.props.onFocus({
         target: { value: 'value1' },
       });

--- a/packages/gestalt/src/SelectList.test.tsx
+++ b/packages/gestalt/src/SelectList.test.tsx
@@ -1,4 +1,6 @@
-import { act, create } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import SelectList from './SelectList';
 
 const options = [
@@ -88,21 +90,16 @@ describe('SelectList', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('calls onBlur prop when select loses focus', async () => {
+  it('calls onBlur prop when select loses focus', () => {
     const onBlurMock = jest.fn();
-    const component = create(
+    render(
       <SelectList id="test" onBlur={onBlurMock} onChange={jest.fn()}>
         {options}
-      </SelectList>,
+      </SelectList>
     );
 
-    const select = component.root.findByType('select');
-
-    await act(async () => {
-      select.props.onBlur({
-        target: { value: 'value1' },
-      });
-    });
+    const select = screen.getByRole('combobox');
+    fireEvent.blur(select, { target: { value: 'value1' } });
 
     expect(onBlurMock).toHaveBeenCalledWith({
       event: expect.any(Object),
@@ -110,21 +107,16 @@ describe('SelectList', () => {
     });
   });
 
-  it('calls onFocus prop when select gains focus', async () => {
+  it('calls onFocus prop when select gains focus', () => {
     const onFocusMock = jest.fn();
-    const component = create(
+    render(
       <SelectList id="test" onChange={jest.fn()} onFocus={onFocusMock}>
         {options}
-      </SelectList>,
+      </SelectList>
     );
 
-    const select = component.root.findByType('select');
-
-    await act(async () => {
-      select.props.onFocus({
-        target: { value: 'value1' },
-      });
-    });
+    const select = screen.getByRole('combobox');
+    fireEvent.focus(select, { target: { value: 'value1' } });
 
     expect(onFocusMock).toHaveBeenCalledWith({
       event: expect.any(Object),

--- a/packages/gestalt/src/SelectList.test.tsx
+++ b/packages/gestalt/src/SelectList.test.tsx
@@ -1,4 +1,4 @@
-import { create } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
 import SelectList from './SelectList';
 
 const options = [
@@ -86,5 +86,49 @@ describe('SelectList', () => {
       </SelectList>,
     ).toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('calls onBlur prop when select loses focus', () => {
+    const onBlurMock = jest.fn();
+    const component = create(
+      <SelectList id="test" onBlur={onBlurMock} onChange={jest.fn()}>
+        {options}
+      </SelectList>,
+    );
+
+    const select = component.root.findByType('select');
+
+    act(() => {
+      select.props.onBlur({
+        target: { value: 'value1' },
+      });
+    });
+
+    expect(onBlurMock).toHaveBeenCalledWith({
+      event: expect.any(Object),
+      value: 'value1',
+    });
+  });
+
+  it('calls onFocus prop when select gains focus', () => {
+    const onFocusMock = jest.fn();
+    const component = create(
+      <SelectList id="test" onFocus={onFocusMock} onChange={jest.fn()}>
+        {options}
+      </SelectList>,
+    );
+
+    const select = component.root.findByType('select');
+
+    act(() => {
+      select.props.onFocus({
+        target: { value: 'value1' },
+      });
+    });
+
+    expect(onFocusMock).toHaveBeenCalledWith({
+      event: expect.any(Object),
+      value: 'value1',
+    });
   });
 });

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -12,7 +12,6 @@ import FormHelperText from './sharedSubcomponents/FormHelperText';
 import FormLabel from './sharedSubcomponents/FormLabel';
 import formElement from './sharedSubcomponents/FormElement.css';
 
-
 type Props = {
   /**
    * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, ChangeEvent, FocusEvent, useState} from 'react';
+import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
 import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
@@ -7,10 +7,11 @@ import layout from './Layout.css';
 import styles from './SelectList.css';
 import SelectListGroup from './SelectList/SelectListGroup';
 import SelectListOption from './SelectList/SelectListOption';
-import formElement from './sharedSubcomponents/FormElement.css';
 import FormErrorMessage from './sharedSubcomponents/FormErrorMessage';
 import FormHelperText from './sharedSubcomponents/FormHelperText';
 import FormLabel from './sharedSubcomponents/FormLabel';
+import formElement from './sharedSubcomponents/FormElement.css';
+
 
 type Props = {
   /**

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
-import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
+import classnames from 'classnames';
 import Box from './Box';
 import Icon from './Icon';
 import layout from './Layout.css';

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState, FocusEvent, ChangeEvent } from 'react';
+import { ReactNode, ChangeEvent, FocusEvent, useState} from 'react';
 import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
@@ -109,17 +109,17 @@ function SelectList({
   };
 
   const handleBlur = (event: FocusEvent<HTMLSelectElement>) => {
-    const value = event.target.value;
+    const { value: eventValue } = event.target;
     if (onBlur) {
-      onBlur({ event, value });
+      onBlur({ event, value: eventValue });
     }
     setFocused(false);
   };
 
   const handleFocus = (event: FocusEvent<HTMLSelectElement>) => {
-    const value = event.target.value;
+    const { value: eventValue } = event.target;
     if (onFocus) {
-      onFocus({ event, value });
+      onFocus({ event, value: eventValue });
     }
     setFocused(true);
   };

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState, FocusEvent, ChangeEvent, FC } from 'react';
+import { ReactNode, useState, FocusEvent, ChangeEvent } from 'react';
 import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
@@ -52,7 +52,7 @@ type Props = {
   /**
    * Callback triggered when the user blurs the input.
    */
-  onBlur?: (arg1: { event: FocusEvent<HTMLInputElement> | FocusEvent<HTMLSelectElement>; value: string }) => void;
+  onBlur?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
   /**
   /**
    * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
@@ -75,11 +75,6 @@ type Props = {
    */
   value?: string | null | undefined;
 };
-
-interface HandleChangeParams<E> {
-  event: FocusEvent<E, Element> | ChangeEvent<E>;
-  value: string;
-}
 
 /**
  * [SelectList](https://gestalt.pinterest.systems/web/selectlist) displays a list of actions or options using the browser’s native select.

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, useState, FocusEvent, ChangeEvent, FC } from 'react';
 import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
@@ -50,9 +50,18 @@ type Props = {
    */
   name?: string;
   /**
+   * Callback triggered when the user blurs the input.
+   */
+  onBlur?: (arg1: { event: FocusEvent<HTMLInputElement> | FocusEvent<HTMLSelectElement>; value: string }) => void;
+  /**
+  /**
    * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
-  onChange: (arg1: { event: React.ChangeEvent<HTMLSelectElement>; value: string }) => void;
+  onChange: (arg1: { event: ChangeEvent<HTMLSelectElement>; value: string }) => void;
+  /**
+   * Callback triggered when the user focuses the input.
+   */
+  onFocus?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
   /**
    * If not provided, the first item in the list will be shown. Be sure to localize the text. See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
@@ -66,6 +75,11 @@ type Props = {
    */
   value?: string | null | undefined;
 };
+
+interface HandleChangeParams<E> {
+  event: FocusEvent<E, Element> | ChangeEvent<E>;
+  value: string;
+}
 
 /**
  * [SelectList](https://gestalt.pinterest.systems/web/selectlist) displays a list of actions or options using the browser’s native select.
@@ -84,17 +98,35 @@ function SelectList({
   label,
   labelDisplay = 'visible',
   name,
+  onBlur,
   onChange,
+  onFocus,
   placeholder,
   size = 'md',
   value,
 }: Props) {
   const [focused, setFocused] = useState(false);
 
-  const handleOnChange: (event: React.ChangeEvent<HTMLSelectElement>) => void = (event) => {
+  const handleOnChange = (event: ChangeEvent<HTMLSelectElement>) => {
     if (value !== event.target.value) {
       onChange({ event, value: event.target.value });
     }
+  };
+
+  const handleBlur = (event: FocusEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (onBlur) {
+      onBlur({ event, value });
+    }
+    setFocused(false);
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
+    if (onFocus) {
+      onFocus({ event, value });
+    }
+    setFocused(true);
   };
 
   const classes = classnames(
@@ -160,12 +192,9 @@ function SelectList({
           disabled={disabled}
           id={id}
           name={name}
-          onBlur={(event) => {
-            setFocused(false);
-            handleOnChange(event);
-          }}
+          onBlur={handleBlur}
           onChange={handleOnChange}
-          onFocus={() => setFocused(true)}
+          onFocus={handleFocus}
           // @ts-expect-error - TS2322 - Type 'string | null | undefined' is not assignable to type 'string | number | readonly string[] | undefined'.
           value={showPlaceholder ? placeholder : value}
         >


### PR DESCRIPTION
#### What changed?

- Added onBlur Prop: This prop allows developers to provide custom callback functions that are triggered when the element loses focus.
- Added onFocus Prop: This prop allows for custom callback functions to be provided, which are triggered when the element gains focus.

#### Why?

Standardized Prop Availability: Ensures consistency across Gestalt components by providing a standardized set of props (onBlur and onFocus) for handling focus events.

### Links

- [Jira](https://jira.pinadmin.com/browse/CPW-6880)
- [TDD](https://docs.google.com/document/d/1KxDV6YoKpeq-6Vff1TPu6E1bFdgzSY-sTz9qCcyCBIU/edit#heading=h.qvamkklezmc7)

### Checklist

- [X] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
