### PR TITLE
SelectList: Added onBlur/onFocus props

### DIFF
--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,16 +1,16 @@
 import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
-import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import classnames from 'classnames';
+import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens'
 import Box from './Box';
 import Icon from './Icon';
 import layout from './Layout.css';
 import styles from './SelectList.css';
 import SelectListGroup from './SelectList/SelectListGroup';
 import SelectListOption from './SelectList/SelectListOption';
+import formElement from './sharedSubcomponents/FormElement.css';
 import FormErrorMessage from './sharedSubcomponents/FormErrorMessage';
 import FormHelperText from './sharedSubcomponents/FormHelperText';
 import FormLabel from './sharedSubcomponents/FormLabel';
-import formElement from './sharedSubcomponents/FormElement.css';
 
 type Props = {
   /**

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,16 +1,16 @@
-import { ReactNode, useState } from 'react';
-import classnames from 'classnames';
+import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
+import classnames from 'classnames';
 import Box from './Box';
 import Icon from './Icon';
 import layout from './Layout.css';
 import styles from './SelectList.css';
 import SelectListGroup from './SelectList/SelectListGroup';
 import SelectListOption from './SelectList/SelectListOption';
-import formElement from './sharedSubcomponents/FormElement.css';
 import FormErrorMessage from './sharedSubcomponents/FormErrorMessage';
 import FormHelperText from './sharedSubcomponents/FormHelperText';
 import FormLabel from './sharedSubcomponents/FormLabel';
+import formElement from './sharedSubcomponents/FormElement.css';
 
 type Props = {
   /**
@@ -50,9 +50,18 @@ type Props = {
    */
   name?: string;
   /**
+   * Callback triggered when the user blurs the input.
+   */
+  onBlur?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
+  /**
+  /**
    * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
-  onChange: (arg1: { event: React.ChangeEvent<HTMLSelectElement>; value: string }) => void;
+  onChange: (arg1: { event: ChangeEvent<HTMLSelectElement>; value: string }) => void;
+  /**
+   * Callback triggered when the user focuses the input.
+   */
+  onFocus?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
   /**
    * If not provided, the first item in the list will be shown. Be sure to localize the text. See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
@@ -84,17 +93,35 @@ function SelectList({
   label,
   labelDisplay = 'visible',
   name,
+  onBlur,
   onChange,
+  onFocus,
   placeholder,
   size = 'md',
   value,
 }: Props) {
   const [focused, setFocused] = useState(false);
 
-  const handleOnChange: (event: React.ChangeEvent<HTMLSelectElement>) => void = (event) => {
+  const handleOnChange = (event: ChangeEvent<HTMLSelectElement>) => {
     if (value !== event.target.value) {
       onChange({ event, value: event.target.value });
     }
+  };
+
+  const handleBlur = (event: FocusEvent<HTMLSelectElement>) => {
+    const { value: eventValue } = event.target;
+    if (onBlur) {
+      onBlur({ event, value: eventValue });
+    }
+    setFocused(false);
+  };
+
+  const handleFocus = (event: FocusEvent<HTMLSelectElement>) => {
+    const { value: eventValue } = event.target;
+    if (onFocus) {
+      onFocus({ event, value: eventValue });
+    }
+    setFocused(true);
   };
 
   const classes = classnames(
@@ -160,12 +187,9 @@ function SelectList({
           disabled={disabled}
           id={id}
           name={name}
-          onBlur={(event) => {
-            setFocused(false);
-            handleOnChange(event);
-          }}
+          onBlur={handleBlur}
           onChange={handleOnChange}
-          onFocus={() => setFocused(true)}
+          onFocus={handleFocus}
           // @ts-expect-error - TS2322 - Type 'string | null | undefined' is not assignable to type 'string | number | readonly string[] | undefined'.
           value={showPlaceholder ? placeholder : value}
         >

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
 import classnames from 'classnames';
-import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens'
+import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
 import Icon from './Icon';
 import layout from './Layout.css';

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FocusEvent, ReactNode, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import classnames from 'classnames';
 import { TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY } from 'gestalt-design-tokens';
 import Box from './Box';
@@ -52,16 +52,16 @@ type Props = {
   /**
    * Callback triggered when the user blurs the input.
    */
-  onBlur?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
+  onBlur?: (arg1: { event: React.FocusEvent<HTMLSelectElement>; value: string }) => void;
   /**
   /**
    * Callback triggered when the user selects a new option.  See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
-  onChange: (arg1: { event: ChangeEvent<HTMLSelectElement>; value: string }) => void;
+  onChange: (arg1: { event: React.ChangeEvent<HTMLSelectElement>; value: string }) => void;
   /**
    * Callback triggered when the user focuses the input.
    */
-  onFocus?: (arg1: { event: FocusEvent<HTMLSelectElement>; value: string }) => void;
+  onFocus?: (arg1: { event: React.FocusEvent<HTMLSelectElement>; value: string }) => void;
   /**
    * If not provided, the first item in the list will be shown. Be sure to localize the text. See the [controlled component](https://gestalt.pinterest.systems/web/selectlist#Controlled-component) variant to learn more.
    */
@@ -102,25 +102,22 @@ function SelectList({
 }: Props) {
   const [focused, setFocused] = useState(false);
 
-  const handleOnChange = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleOnChange: (event: React.ChangeEvent<HTMLSelectElement>) => void = (event) => {
     if (value !== event.target.value) {
       onChange({ event, value: event.target.value });
     }
   };
 
-  const handleBlur = (event: FocusEvent<HTMLSelectElement>) => {
+  const handleBlur = (event: React.FocusEvent<HTMLSelectElement>) => {
     const { value: eventValue } = event.target;
-    if (onBlur) {
-      onBlur({ event, value: eventValue });
-    }
+    onBlur?.({ event, value: eventValue });
+    handleOnChange(event);
     setFocused(false);
   };
 
-  const handleFocus = (event: FocusEvent<HTMLSelectElement>) => {
+  const handleFocus = (event: React.FocusEvent<HTMLSelectElement>) => {
     const { value: eventValue } = event.target;
-    if (onFocus) {
-      onFocus({ event, value: eventValue });
-    }
+    onFocus?.({ event, value: eventValue });
     setFocused(true);
   };
 


### PR DESCRIPTION
#### What changed?

- Added onBlur Prop: This prop allows developers to provide custom callback functions that are triggered when the element loses focus.
- Added onFocus Prop: This prop allows for custom callback functions to be provided, which are triggered when the element gains focus.

#### Why?

Standardized Prop Availability: Ensures consistency across Gestalt components by providing a standardized set of props (onBlur and onFocus) for handling focus events.

### Links

- [Jira](https://jira.pinadmin.com/browse/CPW-6880)
- [TDD](https://docs.google.com/document/d/1KxDV6YoKpeq-6Vff1TPu6E1bFdgzSY-sTz9qCcyCBIU/edit#heading=h.qvamkklezmc7)