### PR TITLE
TextField, SearchField, TextArea, SelectList: fix Label implementation consistency

### DIFF
--- a/packages/gestalt/src/SearchField.tsx
+++ b/packages/gestalt/src/SearchField.tsx
@@ -37,6 +37,10 @@ type Props = {
    */
   label?: string;
   /**
+   * Whether the legend should be visible or not. If `hidden`, the legend is still available for screen reader users, but does not appear visually. See the [label visibility variant](https://gestalt.pinterest.systems/web/searchfield#Visible-label) for more info.
+   */
+  labelDisplay?: 'visible' | 'hidden';
+  /**
    *
    */
   onBlur?: (arg1: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void;
@@ -88,6 +92,7 @@ const SearchFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function S
     autoComplete,
     id,
     label,
+    labelDisplay = 'visible',
     onBlur,
     onChange,
     onFocus,
@@ -157,7 +162,7 @@ const SearchFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function S
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} />}
       <Box
         alignItems="center"
         display="flex"

--- a/packages/gestalt/src/SelectList.tsx
+++ b/packages/gestalt/src/SelectList.tsx
@@ -123,7 +123,7 @@ function SelectList({
 
   return (
     <Box>
-      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} />}
       <Box
         dangerouslySetInlineStyle={{
           __style: { backgroundColor: TOKEN_COLOR_BACKGROUND_FORMFIELD_PRIMARY },

--- a/packages/gestalt/src/TextArea.tsx
+++ b/packages/gestalt/src/TextArea.tsx
@@ -162,6 +162,7 @@ const TextAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function T
   const classes = classnames(
     styles.textArea,
     formElement.base,
+    formElement.base.lg,
     disabled ? formElement.disabled : formElement.enabled,
     (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     tags
@@ -216,7 +217,7 @@ const TextAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function T
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} />}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size="lg" />}
       {tags ? (
         <div className={classes} style={tagsWrapperStyle}>
           {tags.map((tag, tagIndex) => (

--- a/packages/gestalt/src/TextField/InternalTextField.css
+++ b/packages/gestalt/src/TextField/InternalTextField.css
@@ -5,20 +5,14 @@
 }
 
 .textField.sm {
-  border-radius: var(--rounding-200);
-  font-size: var(--font-size-200);
   padding: var(--space-100) var(--space-200);
 }
 
 .textField.md {
-  border-radius: var(--rounding-300);
-  font-size: var(--font-size-300);
   padding: var(--space-200) var(--space-300);
 }
 
 .textField.lg {
-  border-radius: var(--rounding-400);
-  font-size: var(--font-size-300);
   padding: var(--space-300) var(--space-400);
 }
 

--- a/packages/gestalt/src/TextField/InternalTextField.tsx
+++ b/packages/gestalt/src/TextField/InternalTextField.tsx
@@ -196,6 +196,9 @@ const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(func
     disabled ? formElement.disabled : formElement.enabled,
     (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     {
+      [formElement.base.sm]: size === 'sm',
+      [formElement.base.md]: size === 'md',
+      [formElement.base.lg]: size === 'lg',
       // note: layout CSS controls min-height of element
       [layout.small]: size === 'sm',
       [layout.medium]: size === 'md',
@@ -270,7 +273,7 @@ const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(func
 
   return (
     <span>
-      {label ? <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} /> : null}
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} /> }
 
       <Box position="relative">
         {tags ? (

--- a/packages/gestalt/src/TextField/InternalTextField.tsx
+++ b/packages/gestalt/src/TextField/InternalTextField.tsx
@@ -196,9 +196,9 @@ const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(func
     disabled ? formElement.disabled : formElement.enabled,
     (hasError || hasErrorMessage) && !focused ? formElement.errored : formElement.normal,
     {
-      [formElement.base.sm]: size === 'sm',
-      [formElement.base.md]: size === 'md',
-      [formElement.base.lg]: size === 'lg',
+      [formElement.sm]: size === 'sm',
+      [formElement.md]: size === 'md',
+      [formElement.lg]: size === 'lg',
       // note: layout CSS controls min-height of element
       [layout.small]: size === 'sm',
       [layout.medium]: size === 'md',
@@ -273,7 +273,7 @@ const InternalTextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(func
 
   return (
     <span>
-      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} /> }
+      {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size={size} />}
 
       <Box position="relative">
         {tags ? (

--- a/packages/gestalt/src/__snapshots__/BannerUpsell.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/BannerUpsell.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`<BannerUpsell /> message + title + dismissButton + image + form 1`] = `
                     >
                       <input
                         aria-invalid="false"
-                        className="textField base enabled normal medium md truncate"
+                        className="textField base enabled normal md medium md truncate"
                         disabled={false}
                         id="name"
                         onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/BannerUpsellForm.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/BannerUpsellForm.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`BannerUpsellForm renders 1`] = `
           >
             <input
               aria-invalid="false"
-              className="textField base enabled normal medium md truncate"
+              className="textField base enabled normal md medium md truncate"
               disabled={false}
               id="name"
               onBlur={[Function]}

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`ComboBox Controlled ComboBox renders basic controlled components 1`] = 
           <input
             aria-invalid="false"
             autocomplete="off"
-            class="textField base enabled normal medium actionButton md truncate"
+            class="textField base enabled normal md medium actionButton md truncate"
             id="combobox-test"
             placeholder="placeholder"
             type="text"
@@ -110,7 +110,7 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
           class="box relative"
         >
           <div
-            class="textField base enabled normal medium actionButton md textFieldWrapper"
+            class="textField base enabled normal md medium actionButton md textFieldWrapper"
           >
             <div
               class="box marginEnd1"
@@ -637,7 +637,7 @@ exports[`ComboBox Uncontrolled ComboBox renders default 1`] = `
           <input
             aria-invalid="false"
             autocomplete="off"
-            class="textField base enabled normal medium actionButton md truncate"
+            class="textField base enabled normal md medium actionButton md truncate"
             id="combobox-test"
             placeholder="placeholder"
             type="text"
@@ -717,7 +717,7 @@ exports[`ComboBox Uncontrolled ComboBox renders disabled state 1`] = `
           <input
             aria-invalid="false"
             autocomplete="off"
-            class="textField base disabled normal medium actionButton md truncate"
+            class="textField base disabled normal md medium actionButton md truncate"
             disabled=""
             id="combobox-test"
             placeholder="placeholder"

--- a/packages/gestalt/src/__snapshots__/NumberField.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/NumberField.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`NumberField NumberField normal 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -30,7 +30,7 @@ exports[`NumberField NumberField with autocomplete 1`] = `
     <input
       aria-invalid="false"
       autoComplete="on"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       name="email"
@@ -53,7 +53,7 @@ exports[`NumberField NumberField with enterKeyHint 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       enterKeyHint="go"
       id="test"
@@ -76,7 +76,7 @@ exports[`NumberField NumberField with error 1`] = `
   >
     <input
       aria-invalid="true"
-      className="textField base enabled errored medium md truncate"
+      className="textField base enabled errored md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -142,7 +142,7 @@ exports[`NumberField NumberField with name 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       name="email"

--- a/packages/gestalt/src/__snapshots__/TextField.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/TextField.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TextField TextField normal 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -30,7 +30,7 @@ exports[`TextField TextField with autocomplete 1`] = `
     <input
       aria-invalid="false"
       autoComplete="email"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       name="email"
@@ -53,7 +53,7 @@ exports[`TextField TextField with disabled 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base disabled normal medium md truncate"
+      className="textField base disabled normal md medium md truncate"
       disabled={true}
       id="test"
       onBlur={[Function]}
@@ -75,7 +75,7 @@ exports[`TextField TextField with enterKeyHint 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       enterKeyHint="go"
       id="test"
@@ -98,7 +98,7 @@ exports[`TextField TextField with error 1`] = `
   >
     <input
       aria-invalid="true"
-      className="textField base enabled errored medium md truncate"
+      className="textField base enabled errored md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -164,7 +164,7 @@ exports[`TextField TextField with hasError 1`] = `
   >
     <input
       aria-invalid="true"
-      className="textField base enabled errored medium md truncate"
+      className="textField base enabled errored md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -186,7 +186,7 @@ exports[`TextField TextField with maxLength character counter 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       maxLength={20}
@@ -279,7 +279,7 @@ exports[`TextField TextField with name 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       name="email"
@@ -302,7 +302,7 @@ exports[`TextField TextField with readOnly 1`] = `
   >
     <input
       aria-invalid="false"
-      className="textField base enabled normal medium md truncate"
+      className="textField base enabled normal md medium md truncate"
       disabled={false}
       id="test"
       onBlur={[Function]}
@@ -323,7 +323,7 @@ exports[`TextField TextField with tags 1`] = `
     className="box relative"
   >
     <div
-      className="textField base enabled normal medium md textFieldWrapper"
+      className="textField base enabled normal md medium md textFieldWrapper"
     >
       <div
         className="box marginEnd1"

--- a/packages/gestalt/src/sharedSubcomponents/FormElement.css
+++ b/packages/gestalt/src/sharedSubcomponents/FormElement.css
@@ -1,9 +1,23 @@
 .base {
   composes: accessibilityOutline from "../Focus.css";
   appearance: none;
-  border-radius: var(--rounding-400);
   border-style: solid;
   border-width: 2px;
+}
+
+.base.sm {
+  border-radius: var(--rounding-200);
+  font-size: var(--font-size-200);
+}
+
+.base.md {
+  border-radius: var(--rounding-300);
+  font-size: var(--font-size-300);
+}
+
+.base.lg {
+  border-radius: var(--rounding-400);
+  font-size: var(--font-size-300);
 }
 
 .normal {


### PR DESCRIPTION
### Summary

#### What changed?

TextField, SearchField, TextArea, SelectList: fix Label implementation consistency

#### BEFORE
MD (TextArea only LG)

- SelectList rounding
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/bc6eea38-71b5-451e-a1aa-9bed1b9c7e56)
LG
- Label spacing

![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/ca711c58-c85e-42b8-af12-ec6ad9f1eea9)

#### AFTER
MD  (TextArea only LG)
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/f684b65d-74d6-4d41-8534-d18c14dc749f)

LG
![Screenshot by Dropbox Capture](https://github.com/pinterest/gestalt/assets/10593890/3b8992d1-ac3a-4c35-ba20-2cccb34e368d)

#### Why?

Inconsistencies

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
