### PR TITLE
SideNavigation: Use outline as border

### DIFF
--- a/packages/gestalt/src/SideNavigation/ItemContent.tsx
+++ b/packages/gestalt/src/SideNavigation/ItemContent.tsx
@@ -129,7 +129,7 @@ export default function ItemContent({
       color={itemColor}
       dangerouslySetInlineStyle={{
         __style: {
-          boxShadow: hasBorder ? `0 0 0 2px ${TOKEN_COLOR_BACKGROUND_SELECTED_BASE}` : undefined,
+          outline: hasBorder ? `2px solid ${TOKEN_COLOR_BACKGROUND_SELECTED_BASE}` : undefined,
           paddingInlineStart: collapsed ? undefined : nestingMargin,
           paddingInlineEnd: collapsed ? undefined : TOKEN_SPACE_400,
         },

--- a/packages/gestalt/src/SideNavigation/ItemContent.tsx
+++ b/packages/gestalt/src/SideNavigation/ItemContent.tsx
@@ -129,7 +129,7 @@ export default function ItemContent({
       color={itemColor}
       dangerouslySetInlineStyle={{
         __style: {
-          border: hasBorder ? `2px solid ${TOKEN_COLOR_BACKGROUND_SELECTED_BASE}` : undefined,
+          boxShadow: hasBorder ? `0 0 0 2px ${TOKEN_COLOR_BACKGROUND_SELECTED_BASE}` : undefined,
           paddingInlineStart: collapsed ? undefined : nestingMargin,
           paddingInlineEnd: collapsed ? undefined : TOKEN_SPACE_400,
         },

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
@@ -119,7 +119,7 @@ exports[`SideNavigation renders Header + Footer 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "border": undefined,
+                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
                           "paddingInlineEnd": "var(--space-400)",
@@ -300,7 +300,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -434,7 +434,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -646,7 +646,7 @@ exports[`SideNavigation renders Sections 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -770,7 +770,7 @@ exports[`SideNavigation renders basic Item 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "border": undefined,
+                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
                           "paddingInlineEnd": "var(--space-400)",
@@ -892,7 +892,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "border": undefined,
+                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
                           "paddingInlineEnd": "var(--space-400)",
@@ -971,7 +971,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "border": undefined,
+                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
                           "paddingInlineEnd": "var(--space-400)",
@@ -1072,7 +1072,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -1152,7 +1152,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -1270,7 +1270,7 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -1455,7 +1455,7 @@ exports[`SideNavigation renders expanded group 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "border": undefined,
+                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
                           "paddingInlineEnd": "var(--space-400)",
@@ -1575,7 +1575,7 @@ exports[`SideNavigation renders expanded group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -1633,7 +1633,7 @@ exports[`SideNavigation renders expanded group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -1731,7 +1731,7 @@ exports[`SideNavigation renders expanded group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "border": undefined,
+                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
                                   "paddingInlineEnd": "var(--space-400)",
@@ -1788,7 +1788,7 @@ exports[`SideNavigation renders expanded group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "border": undefined,
+                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
                                   "paddingInlineEnd": "var(--space-400)",
@@ -1894,7 +1894,7 @@ exports[`SideNavigation renders static group 1`] = `
                     className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                     style={
                       Object {
-                        "border": undefined,
+                        "boxShadow": undefined,
                         "height": undefined,
                         "minHeight": 44,
                         "paddingInlineEnd": "var(--space-400)",
@@ -1975,7 +1975,7 @@ exports[`SideNavigation renders static group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "border": undefined,
+                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
                               "paddingInlineEnd": "var(--space-400)",
@@ -2012,7 +2012,7 @@ exports[`SideNavigation renders static group 1`] = `
                         className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                         style={
                           Object {
-                            "border": undefined,
+                            "boxShadow": undefined,
                             "height": undefined,
                             "minHeight": 44,
                             "paddingInlineEnd": "var(--space-400)",
@@ -2071,7 +2071,7 @@ exports[`SideNavigation renders static group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "border": undefined,
+                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
                                   "paddingInlineEnd": "var(--space-400)",
@@ -2128,7 +2128,7 @@ exports[`SideNavigation renders static group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "border": undefined,
+                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
                                   "paddingInlineEnd": "var(--space-400)",

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
@@ -119,9 +119,9 @@ exports[`SideNavigation renders Header + Footer 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
+                          "outline": undefined,
                           "paddingInlineEnd": "var(--space-400)",
                           "paddingInlineStart": "var(--space-400)",
                           "width": undefined,
@@ -300,9 +300,9 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -434,9 +434,9 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -646,9 +646,9 @@ exports[`SideNavigation renders Sections 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -770,9 +770,9 @@ exports[`SideNavigation renders basic Item 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
+                          "outline": undefined,
                           "paddingInlineEnd": "var(--space-400)",
                           "paddingInlineStart": "var(--space-400)",
                           "width": undefined,
@@ -892,9 +892,9 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
+                          "outline": undefined,
                           "paddingInlineEnd": "var(--space-400)",
                           "paddingInlineStart": "var(--space-400)",
                           "width": undefined,
@@ -971,9 +971,9 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
+                          "outline": undefined,
                           "paddingInlineEnd": "var(--space-400)",
                           "paddingInlineStart": "var(--space-400)",
                           "width": undefined,
@@ -1072,9 +1072,9 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -1152,9 +1152,9 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -1270,9 +1270,9 @@ exports[`SideNavigation renders expandable nested directory 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-400)",
                               "width": undefined,
@@ -1455,9 +1455,9 @@ exports[`SideNavigation renders expanded group 1`] = `
                       className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                       style={
                         Object {
-                          "boxShadow": undefined,
                           "height": undefined,
                           "minHeight": 44,
+                          "outline": undefined,
                           "paddingInlineEnd": "var(--space-400)",
                           "paddingInlineStart": "var(--space-400)",
                           "width": undefined,
@@ -1575,9 +1575,9 @@ exports[`SideNavigation renders expanded group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-1200)",
                               "width": undefined,
@@ -1633,9 +1633,9 @@ exports[`SideNavigation renders expanded group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-1200)",
                               "width": undefined,
@@ -1731,9 +1731,9 @@ exports[`SideNavigation renders expanded group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
+                                  "outline": undefined,
                                   "paddingInlineEnd": "var(--space-400)",
                                   "paddingInlineStart": "68px",
                                   "width": undefined,
@@ -1788,9 +1788,9 @@ exports[`SideNavigation renders expanded group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
+                                  "outline": undefined,
                                   "paddingInlineEnd": "var(--space-400)",
                                   "paddingInlineStart": "68px",
                                   "width": undefined,
@@ -1894,9 +1894,9 @@ exports[`SideNavigation renders static group 1`] = `
                     className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                     style={
                       Object {
-                        "boxShadow": undefined,
                         "height": undefined,
                         "minHeight": 44,
+                        "outline": undefined,
                         "paddingInlineEnd": "var(--space-400)",
                         "paddingInlineStart": "var(--space-400)",
                         "width": undefined,
@@ -1975,9 +1975,9 @@ exports[`SideNavigation renders static group 1`] = `
                           className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                           style={
                             Object {
-                              "boxShadow": undefined,
                               "height": undefined,
                               "minHeight": 44,
+                              "outline": undefined,
                               "paddingInlineEnd": "var(--space-400)",
                               "paddingInlineStart": "var(--space-1200)",
                               "width": undefined,
@@ -2012,9 +2012,9 @@ exports[`SideNavigation renders static group 1`] = `
                         className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                         style={
                           Object {
-                            "boxShadow": undefined,
                             "height": undefined,
                             "minHeight": 44,
+                            "outline": undefined,
                             "paddingInlineEnd": "var(--space-400)",
                             "paddingInlineStart": "var(--space-1200)",
                             "width": undefined,
@@ -2071,9 +2071,9 @@ exports[`SideNavigation renders static group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
+                                  "outline": undefined,
                                   "paddingInlineEnd": "var(--space-400)",
                                   "paddingInlineStart": "68px",
                                   "width": undefined,
@@ -2128,9 +2128,9 @@ exports[`SideNavigation renders static group 1`] = `
                               className="box paddingXundefined paddingY2 paddingYundefined relative rounding2 xsDisplayFlex xsItemsCenter"
                               style={
                                 Object {
-                                  "boxShadow": undefined,
                                   "height": undefined,
                                   "minHeight": 44,
+                                  "outline": undefined,
                                   "paddingInlineEnd": "var(--space-400)",
                                   "paddingInlineStart": "68px",
                                   "width": undefined,


### PR DESCRIPTION
### Summary

Border width affects the content width of an element. That's why it was causing `SideNavigation.GroupItem` to squeeze its contents when it has border.

Using box-shadow as border solves the problem as box-shadow doesn't affect the width of its element.

**BEFORE**
![ezgif-3-290d3ebab8](https://github.com/pinterest/gestalt/assets/29589560/f0b85be9-b330-403c-ad24-1ce53928cc32)

**AFTER**
![ezgif-3-653357a497](https://github.com/pinterest/gestalt/assets/29589560/13a23f72-976c-41e7-afa3-efda694e3766)


### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
