### PR TITLE
IconButton, Pog: New background for classic IconButton

### DIFF
--- a/docs/docs-components/CombinationNew.tsx
+++ b/docs/docs-components/CombinationNew.tsx
@@ -85,7 +85,9 @@ export default function CombinationNew({
     if (combinationTitles.some((title) => title.includes('"light"'))) {
       cardShadeColor = 'darkWash';
     }
-    if (combinationTitles.some((title) => title.includes('"dark"'))) {
+    if (
+      combinationTitles.some((title) => title.includes('"washLight"') || title.includes('"dark"'))
+    ) {
       cardShadeColor = 'lightWash';
     }
 

--- a/docs/pages/web/iconbutton.tsx
+++ b/docs/pages/web/iconbutton.tsx
@@ -203,7 +203,7 @@ Follow these guidelines for \`iconColor\`
           title="Icon color"
         >
           {/* @ts-expect-error - TS2322 - Type '{ children: ({ iconColor }: { [key: string]: any; }) => Element; iconColor: string[]; }' is not assignable to type 'IntrinsicAttributes & Props'. */}
-          <CombinationNew iconColor={['red', 'darkGray', 'gray', 'white', 'brandPrimary']}>
+          <CombinationNew iconColor={['red', 'dark', 'darkGray', 'gray', 'white', 'brandPrimary']}>
             {({ iconColor }) => (
               <IconButton
                 accessibilityLabel={`Example icon color ${iconColor}`}
@@ -223,14 +223,23 @@ Follow these guidelines for \`bgColor\`
 2. Light Gray ("lightGray"). Medium emphasis, used for secondary actions.
 3. Transparent Dark Gray ("transparentDarkGray"). Medium emphasis, used for secondary actions, usually above a colored background.
 4. Gray ("gray"). Used for tertiary actions or in cases where the primary "red" is not an option. Medium emphasis when placed on dark backgrounds, used for secondary actions.
-5. White ("white"). Used when there is a need of an IconButton over an image or colored background to provide better contrast and visibility.
-6. Transparent ("transparent"). Used when there is a need to have an IconButton over an image without a background.
+5. Light Wash ("washLight"). Used when there is a need of a semi-transparent IconButton with a light wash over an item, like an image.
+6. White ("white"). Used when there is a need of an IconButton over an image or colored background to provide better contrast and visibility.
+7. Transparent ("transparent"). Used when there is a need to have an IconButton over an image without a background.
 `}
           title="Background color"
         >
           <CombinationNew
             // @ts-expect-error - TS2322 - Type '{ children: ({ bgColor }: { [key: string]: any; }) => Element; bgColor: string[]; }' is not assignable to type 'IntrinsicAttributes & Props'.
-            bgColor={['red', 'lightGray', 'transparentDarkGray', 'gray', 'white', 'transparent']}
+            bgColor={[
+              'red',
+              'lightGray',
+              'transparentDarkGray',
+              'gray',
+              'washLight',
+              'white',
+              'transparent',
+            ]}
           >
             {({ bgColor }) => (
               <IconButton

--- a/docs/pages/web/iconbutton.tsx
+++ b/docs/pages/web/iconbutton.tsx
@@ -203,7 +203,7 @@ Follow these guidelines for \`iconColor\`
           title="Icon color"
         >
           {/* @ts-expect-error - TS2322 - Type '{ children: ({ iconColor }: { [key: string]: any; }) => Element; iconColor: string[]; }' is not assignable to type 'IntrinsicAttributes & Props'. */}
-          <CombinationNew iconColor={['red', 'dark', 'darkGray', 'gray', 'white', 'brandPrimary']}>
+          <CombinationNew iconColor={['red', 'darkGray', 'gray', 'white', 'brandPrimary']}>
             {({ iconColor }) => (
               <IconButton
                 accessibilityLabel={`Example icon color ${iconColor}`}

--- a/docs/pages/web/pog.tsx
+++ b/docs/pages/web/pog.tsx
@@ -57,13 +57,14 @@ Follow these guidelines for \`bgColor\`
 Follow these guidelines for \`bgColor\`
 
 1. Transparent Dark Gray ("transparentDarkGray"). Medium emphasis, used for secondary actions, usually above a colored background.
-2. White ("white"). Used when there is a need of an IconButton over an image or colored background to provide better contrast and visibility.
-3. Transparent ("transparent"). Used when there is a need to have an IconButton over an image without a background.
+2. Wash Light ("washLight"). Used when there is a need of an IconButton over an image or colored background to provide a semi-transparent IconButton with a light wash.
+3. White ("white"). Used when there is a need of an IconButton over an image or colored background to provide better contrast and visibility.
+4. Transparent ("transparent"). Used when there is a need to have an IconButton over an image without a background.
 `}
           title="Background colors on color/image backgrounds"
         >
           {/* @ts-expect-error - TS2322 - Type '{ children: ({ bgColor }: { [key: string]: any; }) => Element; bgColor: string[]; }' is not assignable to type 'IntrinsicAttributes & Props'. */}
-          <CombinationNew bgColor={['transparentDarkGray', 'white', 'transparent']}>
+          <CombinationNew bgColor={['transparentDarkGray', 'washLight', 'white', 'transparent']}>
             {({ bgColor }) => <Pog bgColor={bgColor} icon="heart" />}
           </CombinationNew>
         </MainSection.Subsection>

--- a/packages/gestalt/src/IconButton.tsx
+++ b/packages/gestalt/src/IconButton.tsx
@@ -62,7 +62,7 @@ type Props = {
   /**
    * Primary color to apply to the [Icon](/web/icon). See [icon color](https://gestalt.pinterest.systems/web/iconbutton#Icon-color) variant to learn more.
    */
-  iconColor?: 'dark' | 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
   /**
    * The name attribute specifies the name of the button element. The name attribute is used to reference form-data after the form has been submitted and for [testing](https://testing-library.com/docs/queries/about/#priority).
    */

--- a/packages/gestalt/src/IconButton.tsx
+++ b/packages/gestalt/src/IconButton.tsx
@@ -33,7 +33,14 @@ type Props = {
   /**
    * Primary colors to apply to the IconButton background.
    */
-  bgColor?: 'transparent' | 'transparentDarkGray' | 'gray' | 'lightGray' | 'white' | 'red';
+  bgColor?:
+    | 'transparent'
+    | 'transparentDarkGray'
+    | 'gray'
+    | 'lightGray'
+    | 'washLight'
+    | 'white'
+    | 'red';
   /**
    * Defines a new icon different from the built-in Gestalt icons.
    */
@@ -55,7 +62,7 @@ type Props = {
   /**
    * Primary color to apply to the [Icon](/web/icon). See [icon color](https://gestalt.pinterest.systems/web/iconbutton#Icon-color) variant to learn more.
    */
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
+  iconColor?: 'dark' | 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
   /**
    * The name attribute specifies the name of the button element. The name attribute is used to reference form-data after the form has been submitted and for [testing](https://testing-library.com/docs/queries/about/#priority).
    */

--- a/packages/gestalt/src/Pog.css
+++ b/packages/gestalt/src/Pog.css
@@ -62,6 +62,15 @@
   background-color: var(--color-background-button-tertiary-active);
 }
 
+.washLight {
+  background-color: var(--color-background-button-semitransparentwhite-default);
+}
+
+.washLight.hovered,
+.washLight.focused {
+  background-color: var(--color-background-button-semitransparentwhite-hover);
+}
+
 .white {
   background-color: var(--color-background-button-white-default);
 }

--- a/packages/gestalt/src/Pog.tsx
+++ b/packages/gestalt/src/Pog.tsx
@@ -21,7 +21,6 @@ const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
 
 const OLD_TO_NEW_COLOR_MAP = {
   white: 'inverse',
-  dark: 'dark',
   gray: 'subtle',
   darkGray: 'default',
   red: 'error',
@@ -80,7 +79,7 @@ type Props = {
   /**
    * Color applied to the [Icon](https://gestalt.pinterest.systems/web/icon). See [color combinations](https://gestalt.pinterest.systems/web/pog#iconColorCombinations) for more details.
    */
-  iconColor?: 'dark' | 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
+  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
   /**
    * Padding in boints. If omitted, padding is derived from the \`size\` prop. See [padding combinations](https://gestalt.pinterest.systems/web/pog#paddingCombinations) for more details.
    */

--- a/packages/gestalt/src/Pog.tsx
+++ b/packages/gestalt/src/Pog.tsx
@@ -21,6 +21,7 @@ const SIZE_NAME_TO_ICON_SIZE_PIXEL = {
 
 const OLD_TO_NEW_COLOR_MAP = {
   white: 'inverse',
+  dark: 'dark',
   gray: 'subtle',
   darkGray: 'default',
   red: 'error',
@@ -33,6 +34,7 @@ const defaultIconButtonIconColors = {
   transparent: 'darkGray',
   red: 'white',
   transparentDarkGray: 'white',
+  washLight: 'darkGray',
   white: 'darkGray',
 } as const;
 
@@ -49,7 +51,14 @@ type Props = {
   /**
    * The background color. See [color combinations](https://gestalt.pinterest.systems/web/pog#backgroundColorCombinations) for more details.
    */
-  bgColor?: 'transparent' | 'transparentDarkGray' | 'gray' | 'lightGray' | 'white' | 'red';
+  bgColor?:
+    | 'transparent'
+    | 'transparentDarkGray'
+    | 'gray'
+    | 'lightGray'
+    | 'washLight'
+    | 'white'
+    | 'red';
   /**
    * Used for custom icons within Pog. Make sure that the viewbox around the SVG path is 24x24.
    */
@@ -71,7 +80,7 @@ type Props = {
   /**
    * Color applied to the [Icon](https://gestalt.pinterest.systems/web/icon). See [color combinations](https://gestalt.pinterest.systems/web/pog#iconColorCombinations) for more details.
    */
-  iconColor?: 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
+  iconColor?: 'dark' | 'gray' | 'darkGray' | 'red' | 'white' | 'brandPrimary';
   /**
    * Padding in boints. If omitted, padding is derived from the \`size\` prop. See [padding combinations](https://gestalt.pinterest.systems/web/pog#paddingCombinations) for more details.
    */


### PR DESCRIPTION
### Summary

#### What changed?

Added the washLight color to IconButton background options, It uses the same background color as Button semi-transparent white.

The same was added to Pog, for consistency.

![image](https://github.com/pinterest/gestalt/assets/4423381/3dd39077-d017-4726-938f-947b7c0bb58b)
![image](https://github.com/pinterest/gestalt/assets/4423381/3ae4e11d-d6e5-4a6f-a52b-b1aa1ee00325)

#### Why?

To comply with a component update request @ https://pinterest.slack.com/archives/D060Y91C4D9/p1719955590973859

### Links

- [Jira](https://jira.pinadmin.com/browse/CPW-7039)
- [Figma](https://www.figma.com/design/n5FTA5WAunEJmbIPsMBkcR/Leading-icon-to-Button%3A-Gestalt-classic-component-updates?node-id=64-1688&t=Uz5vAftxjqVy3yrj-0)