### PR TITLE
Tokens: Move Component_Tokens to getStaticProps

### DIFF
--- a/docs/pages/foundations/design_tokens/component_tokens.tsx
+++ b/docs/pages/foundations/design_tokens/component_tokens.tsx
@@ -69,8 +69,12 @@ const components = [
   'video',
 ];
 
-export default function DesignTokensPage(props: { tokens: { name: string }[] }) {
-  const allTokens: ReadonlyArray<Token> = props.tokens;
+type Props = {
+  tokens: ReadonlyArray<Token>;
+};
+
+export default function DesignTokensPage({ tokens }: Props) {
+  const allTokens: ReadonlyArray<Token> = tokens;
 
   return (
     <Page title="Design component tokens">

--- a/docs/pages/foundations/design_tokens/component_tokens.tsx
+++ b/docs/pages/foundations/design_tokens/component_tokens.tsx
@@ -1,4 +1,4 @@
-import tokens from 'gestalt-design-tokens/dist/js/classic/tokens';
+import classicTokens from 'gestalt-design-tokens/dist/js/classic/tokens';
 import MainSection from '../../../docs-components/MainSection';
 import Page from '../../../docs-components/Page';
 import PageHeader from '../../../docs-components/PageHeader';
@@ -46,8 +46,6 @@ export type Token = {
   category: string;
 };
 
-const allTokens: ReadonlyArray<Token> = tokens;
-
 const components = [
   'avatar',
   'badge',
@@ -71,7 +69,9 @@ const components = [
   'video',
 ];
 
-export default function DesignTokensPage() {
+export default function DesignTokensPage(props: { tokens: { name: string }[] }) {
+  const allTokens: ReadonlyArray<Token> = props.tokens;
+
   return (
     <Page title="Design component tokens">
       <PageHeader
@@ -102,4 +102,12 @@ export default function DesignTokensPage() {
       ))}
     </Page>
   );
+}
+
+export async function getStaticProps() {
+  return {
+    props: {
+      tokens: classicTokens,
+    },
+  };
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4d2bffa5-a980-430f-9b20-fb52ebe2e878)

People are getting this error when visiting:
https://gestalt.pinterest.systems/foundations/design_tokens/component_tokens

Netlify has a limit of 62KB on a page. The imported tokens file is 61KB.

This moves the large import of classic tokens to a server-side-prop to see if it works