### PR TITLE
Masonry: Support flexible and uniformRow layouts for rendering loading state items

### DIFF
--- a/docs/pages/visual-test/Masonry-renderLoadingItems-flexible.tsx
+++ b/docs/pages/visual-test/Masonry-renderLoadingItems-flexible.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, ColorSchemeProvider, Flex, Image, Masonry } from 'gestalt';
+import { TOKEN_COLOR_GRAY_ROBOFLOW_300 } from 'gestalt-design-tokens';
+
+type Pin = {
+  color: string;
+  naturalHeight: number;
+  src: string;
+  width: number;
+  name: string;
+};
+
+const pins = [
+  {
+    color: '#2b3938',
+    naturalHeight: 316,
+    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+    width: 474,
+    name: 'the Hang Son Doong cave in Vietnam',
+  },
+  {
+    color: '#8e7439',
+    naturalHeight: 1081,
+    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+    width: 474,
+    name: 'La Gran Muralla, Pekín, China',
+  },
+  {
+    color: '#698157',
+    naturalHeight: 711,
+    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+    width: 474,
+    name: 'Plitvice Lakes National Park, Croatia',
+  },
+  {
+    color: '#4e5d50',
+    naturalHeight: 632,
+    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+    width: 474,
+    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+  },
+  {
+    color: '#6d6368',
+    naturalHeight: 710,
+    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+    width: 474,
+    name: 'Border of China and Vietnam',
+  },
+];
+
+function getPins(): Promise<Array<Pin>> {
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  return Promise.resolve(pinList);
+}
+
+const styles = {
+  backgroundColor: `${TOKEN_COLOR_GRAY_ROBOFLOW_300}`,
+  backgroundSize: '200vw 100%',
+  content: '',
+  position: 'relative',
+  width: '100%',
+} as const;
+
+function SkeletonPin({ data }: { data: { height: number } }) {
+  const { height } = data;
+  return (
+    <div style={styles}>
+      <Box height={height} />
+    </div>
+  );
+}
+
+function GridComponent({
+  data,
+}: {
+  data: {
+    name: string;
+    color: string;
+    naturalHeight: number;
+    width: number;
+    src: string;
+  };
+}) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.naturalHeight}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+    </Flex>
+  );
+}
+
+const randomPinHeight = () => Math.random() * 200 + 100;
+
+const skeletonPins = [...new Array(3)]
+  .map(() => [
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+  ])
+  .flat();
+
+export default function Snapshot() {
+  const [items, setItems] = useState<Array<Pin>>([]);
+  const scrollContainerRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      getPins().then(setItems);
+    }, 2500);
+  }, []);
+
+  return (
+    <ColorSchemeProvider colorScheme="light">
+      <div
+        ref={scrollContainerRef}
+        style={{ overflowY: 'scroll', height: '100vh', width: '100vw' }}
+      >
+        <Masonry
+          _loadingStateItems={skeletonPins}
+          // Since we are prefixing this prop with "_", we get this eslint warning
+          // eslint-disable-next-line react/no-unstable-nested-components
+          _renderLoadingStateItems={({ data }) => <SkeletonPin data={data} />}
+          columnWidth={170}
+          gutterWidth={20}
+          items={items}
+          layout="flexible"
+          renderItem={({ data }) => <GridComponent data={data} />}
+        />
+      </div>
+    </ColorSchemeProvider>
+  );
+}

--- a/docs/pages/visual-test/Masonry-renderLoadingItems-uniformRow.tsx
+++ b/docs/pages/visual-test/Masonry-renderLoadingItems-uniformRow.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from 'react';
+import { Box, ColorSchemeProvider, Flex, Image, Masonry } from 'gestalt';
+import { TOKEN_COLOR_GRAY_ROBOFLOW_300 } from 'gestalt-design-tokens';
+
+type Pin = {
+  color: string;
+  naturalHeight: number;
+  src: string;
+  width: number;
+  name: string;
+};
+
+const pins = [
+  {
+    color: '#2b3938',
+    naturalHeight: 316,
+    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+    width: 474,
+    name: 'the Hang Son Doong cave in Vietnam',
+  },
+  {
+    color: '#8e7439',
+    naturalHeight: 1081,
+    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+    width: 474,
+    name: 'La Gran Muralla, Pekín, China',
+  },
+  {
+    color: '#698157',
+    naturalHeight: 711,
+    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+    width: 474,
+    name: 'Plitvice Lakes National Park, Croatia',
+  },
+  {
+    color: '#4e5d50',
+    naturalHeight: 632,
+    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+    width: 474,
+    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+  },
+  {
+    color: '#6d6368',
+    naturalHeight: 710,
+    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+    width: 474,
+    name: 'Border of China and Vietnam',
+  },
+];
+
+function getPins(): Promise<Array<Pin>> {
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  return Promise.resolve(pinList);
+}
+
+const styles = {
+  backgroundColor: `${TOKEN_COLOR_GRAY_ROBOFLOW_300}`,
+  backgroundSize: '200vw 100%',
+  content: '',
+  position: 'relative',
+  width: '100%',
+} as const;
+
+function SkeletonPin({ data }: { data: { height: number } }) {
+  const { height } = data;
+  return (
+    <div style={styles}>
+      <Box height={height} />
+    </div>
+  );
+}
+
+function GridComponent({
+  data,
+}: {
+  data: {
+    name: string;
+    color: string;
+    naturalHeight: number;
+    width: number;
+    src: string;
+  };
+}) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.naturalHeight}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+    </Flex>
+  );
+}
+
+const randomPinHeight = () => Math.random() * 200 + 100;
+
+const skeletonPins = [...new Array(3)]
+  .map(() => [
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+    { height: randomPinHeight() },
+  ])
+  .flat();
+
+export default function Snapshot() {
+  const [items, setItems] = useState<Array<Pin>>([]);
+  const scrollContainerRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      getPins().then(setItems);
+    }, 2500);
+  }, []);
+
+  return (
+    <ColorSchemeProvider colorScheme="light">
+      <div
+        ref={scrollContainerRef}
+        style={{ overflowY: 'scroll', height: '100vh', width: '100vw' }}
+      >
+        <Masonry
+          _loadingStateItems={skeletonPins}
+          // Since we are prefixing this prop with "_", we get this eslint warning
+          // eslint-disable-next-line react/no-unstable-nested-components
+          _renderLoadingStateItems={({ data }) => <SkeletonPin data={data} />}
+          columnWidth={170}
+          gutterWidth={20}
+          items={items}
+          layout="uniformRow"
+          renderItem={({ data }) => <GridComponent data={data} />}
+        />
+      </div>
+    </ColorSchemeProvider>
+  );
+}

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -550,7 +550,9 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       items.length === 0 && _loadingStateItems && _renderLoadingStateItems,
     );
 
-    let getPositions;
+    let getPositions: (
+      itemsToGetPosition: readonly T[] | readonly LoadingStateItem[],
+    ) => ReadonlyArray<Position>;
 
     if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
       getPositions = fullWidthLayout({
@@ -562,6 +564,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         width,
         logWhitespace: _logTwoColWhitespace,
         _getColumnSpanConfig,
+        renderLoadingState,
       });
     } else if (layout === 'uniformRow') {
       getPositions = uniformRowLayout({
@@ -580,10 +583,11 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         gutter,
         layout,
         minCols,
-        rawItemCount: items.length,
+        rawItemCount: renderLoadingState ? _loadingStateItems.length : items.length,
         width,
         logWhitespace: _logTwoColWhitespace,
         _getColumnSpanConfig,
+        renderLoadingState,
       });
     }
 
@@ -652,20 +656,6 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       // div to collect the width for layout
       gridBody = <div ref={this.setGridWrapperRef} style={{ width: '100%' }} />;
     } else if (renderLoadingState) {
-      getPositions = defaultLayout({
-        align,
-        measurementCache: measurementStore,
-        positionCache: positionStore,
-        columnWidth,
-        gutter,
-        layout,
-        minCols,
-        rawItemCount: _loadingStateItems.length,
-        width,
-        logWhitespace: _logTwoColWhitespace,
-        _getColumnSpanConfig,
-        renderLoadingState,
-      });
       const positions = getPositions(_loadingStateItems);
       const height = positions.length
         ? Math.max(...positions.map((pos) => pos.top + pos.height))

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -573,6 +573,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         gutter,
         minCols,
         width,
+        renderLoadingState,
       });
     } else {
       getPositions = defaultLayout({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -78,3 +78,69 @@ describe.each([undefined, getColumnSpanConfig])(
     });
   },
 );
+
+describe('loadingStateItems', () => {
+  test("uses the loadingStateItem's height", () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const loadingStateItems: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100 },
+      { 'name': 'Pin 1', 'height': 120 },
+      { 'name': 'Pin 2', 'height': 80 },
+      { 'name': 'Pin 3', 'height': 100 },
+    ];
+
+    const layout = fullWidthLayout({
+      measurementCache: measurementStore,
+      positionCache,
+      gutter: 10,
+      idealColumnWidth: 240,
+      minCols: 2,
+      width: 1000,
+      _getColumnSpanConfig: getColumnSpanConfig,
+      renderLoadingState: true,
+    });
+
+    expect(layout(loadingStateItems)).toEqual([
+      { top: 0, height: 100, left: 5, width: 240 },
+      { top: 0, height: 120, left: 255, width: 240 },
+      { top: 0, height: 80, left: 505, width: 240 },
+      { top: 0, height: 100, left: 755, width: 240 },
+    ]);
+  });
+
+  test('uses the measurementCache height when not a loadingStateitem', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100 },
+      { 'name': 'Pin 1', 'height': 120 },
+      { 'name': 'Pin 2', 'height': 80 },
+      { 'name': 'Pin 3', 'height': 100 },
+    ];
+    items.forEach((item: any) => {
+      /**
+       * Forcing the height to be different here since we always want to get the height from the measurement cache
+       * We only want to use the item's height if we are rendering loading state items
+       */
+      measurementStore.set(item, item.height + 1);
+    });
+
+    const layout = fullWidthLayout({
+      measurementCache: measurementStore,
+      positionCache,
+      gutter: 10,
+      idealColumnWidth: 240,
+      minCols: 2,
+      width: 1000,
+      _getColumnSpanConfig: getColumnSpanConfig,
+    });
+
+    expect(layout(items)).toEqual([
+      { top: 0, height: 101, left: 5, width: 240 },
+      { top: 0, height: 121, left: 255, width: 240 },
+      { top: 0, height: 81, left: 505, width: 240 },
+      { top: 0, height: 101, left: 755, width: 240 },
+    ]);
+  });
+});

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -44,7 +44,7 @@ const fullWidthLayout = <T>({
   const columnWidthAndGutter = columnWidth + gutter;
   const centerOffset = gutter / 2;
 
-  return (items: ReadonlyArray<T>) => {
+  return (items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => {
     const heights = new Array<number>(columnCount).fill(0);
     return _getColumnSpanConfig && !isLoadingStateItems(items, renderLoadingState)
       ? multiColumnLayout({

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -1,7 +1,8 @@
 import { Cache } from './Cache';
+import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
-import { Position } from './types';
+import { LoadingStateItem, Position } from './types';
 
 const fullWidthLayout = <T>({
   width,
@@ -10,6 +11,7 @@ const fullWidthLayout = <T>({
   minCols = 2,
   measurementCache,
   _getColumnSpanConfig,
+  renderLoadingState,
   ...otherProps
 }: {
   idealColumnWidth?: number;
@@ -21,7 +23,8 @@ const fullWidthLayout = <T>({
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
   logWhitespace?: (arg1: number) => void;
-}): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) => {
+  renderLoadingState?: boolean;
+}): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) => {
   if (width == null) {
     return (items) =>
       items.map(() => ({
@@ -43,7 +46,7 @@ const fullWidthLayout = <T>({
 
   return (items: ReadonlyArray<T>) => {
     const heights = new Array<number>(columnCount).fill(0);
-    return _getColumnSpanConfig
+    return _getColumnSpanConfig && !isLoadingStateItems(items, renderLoadingState)
       ? multiColumnLayout({
           items,
           columnWidth,
@@ -56,7 +59,9 @@ const fullWidthLayout = <T>({
         })
       : items.reduce<Array<any>>((acc, item) => {
           const positions = acc;
-          const height = measurementCache.get(item);
+          const height = isLoadingStateItem(item, renderLoadingState)
+            ? item.height
+            : measurementCache.get(item);
           let position;
 
           if (height == null) {

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.ts
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.ts
@@ -102,3 +102,27 @@ test('multiple rows, unequal heights', () => {
     { top: 134, left: 0, width: 236, height: 100 },
   ]);
 });
+
+describe('loadingStateItems', () => {
+  test("uses the loadingStateItem's height", () => {
+    const loadingStateItems = [
+      { 'name': 'Pin 0', 'height': 100 },
+      { 'name': 'Pin 1', 'height': 120 },
+      { 'name': 'Pin 2', 'height': 80 },
+      { 'name': 'Pin 3', 'height': 100 },
+    ];
+
+    const layout = uniformRowLayout({
+      cache: stubCache(),
+      width: 500,
+      renderLoadingState: true,
+    });
+
+    expect(layout(loadingStateItems)).toEqual([
+      { top: 0, height: 100, left: 0, width: 236 },
+      { top: 0, height: 120, left: 250, width: 236 },
+      { top: 0, height: 80, left: 500, width: 236 },
+      { top: 134, height: 100, left: 0, width: 236 },
+    ]);
+  });
+});

--- a/packages/gestalt/src/Masonry/uniformRowLayout.ts
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.ts
@@ -1,5 +1,6 @@
 import { Cache } from './Cache';
-import { Position } from './types';
+import { isLoadingStateItem } from './loadingStateUtils';
+import { LoadingStateItem, Position } from './types';
 
 const offscreen = (width: number, height: number = Infinity) => ({
   top: -9999,
@@ -15,14 +16,16 @@ const uniformRowLayout =
     gutter = 14,
     width,
     minCols = 3,
+    renderLoadingState,
   }: {
     cache: Cache<T, number>;
     columnWidth?: number;
     gutter?: number;
     width?: number | null | undefined;
     minCols?: number;
-  }): ((items: ReadonlyArray<T>) => ReadonlyArray<Position>) =>
-  (items: ReadonlyArray<T>): ReadonlyArray<Position> => {
+    renderLoadingState?: boolean;
+  }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) =>
+  (items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>): ReadonlyArray<Position> => {
     if (width == null) {
       return items.map(() => offscreen(columnWidth));
     }
@@ -35,7 +38,8 @@ const uniformRowLayout =
 
     for (let i = 0; i < items.length; i += 1) {
       let position;
-      const height = cache.get(items[i]);
+      const item = items[i];
+      const height = isLoadingStateItem(item, renderLoadingState) ? item.height : cache.get(item);
 
       if (height == null) {
         position = offscreen(columnWidth);


### PR DESCRIPTION
### Summary

#### What changed?

- Support the `flexible` and `uniformRow` layouts for rendering loading state items
- Add Masonry-renderLoadingItems-flexible visual test page
- Add Masonry-renderLoadingItems-uniformRow visual test page

#### Why?

- Allows us to use the shimmering skeleton loading state for all layouts now

### Checklist

- [x] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
