### PR TITLE
Toast: VR implementation changes

### DIFF
--- a/docs/examples/defaultlabelprovider/translations.tsx
+++ b/docs/examples/defaultlabelprovider/translations.tsx
@@ -111,7 +111,7 @@ const labels = {
     tooltipMessage: myI18nTranslator('Click to learn more'),
   },
   Toast: {
-    accessibilityDismissButtonLabel: myI18nTranslator('Dismiss toast'),
+    accessibilityDismissButtonLabel: myI18nTranslator('Dismiss message'),
     accessibilityIconSuccessLabel: myI18nTranslator('Success message'),
     accessibilityIconErrorLabel: myI18nTranslator('Error message'),
     accessibilityProcessingLabel: myI18nTranslator('Processing message'),

--- a/docs/pages/web/utilities/defaultlabelprovider.tsx
+++ b/docs/pages/web/utilities/defaultlabelprovider.tsx
@@ -275,7 +275,7 @@ function getLabelsTable(/* fallbackLabels: { [string]: { [string]: mixed } } */)
     {
       component: 'Toast',
       prop: 'accessibilityDismissButtonLabel',
-      label: 'Dismiss toast',
+      label: 'Dismiss message',
     },
     {
       component: 'Toast',

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.tsx
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.jsdom.test.tsx
@@ -112,7 +112,7 @@ describe('useDefaultLabelContext', () => {
             tooltipMessage: 'Click to learn more',
           },
           Toast: {
-            accessibilityDismissButtonLabel: 'Dismiss toast',
+            accessibilityDismissButtonLabel: 'Dismiss message',
             accessibilityIconSuccessLabel: 'Success message',
             accessibilityIconErrorLabel: 'Error message',
             accessibilityProcessingLabel: 'Processing message',

--- a/packages/gestalt/src/contexts/DefaultLabelProvider.tsx
+++ b/packages/gestalt/src/contexts/DefaultLabelProvider.tsx
@@ -229,7 +229,7 @@ export const fallbackLabels: DefaultLabelContextType = {
     tooltipMessage: 'Click to learn more',
   },
   Toast: {
-    accessibilityDismissButtonLabel: 'Dismiss toast',
+    accessibilityDismissButtonLabel: 'Dismiss message',
     accessibilityIconSuccessLabel: 'Success message',
     accessibilityIconErrorLabel: 'Error message',
     accessibilityProcessingLabel: 'Processing message',

--- a/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
@@ -168,6 +168,10 @@ export function TypeThumbnail({ type }: { type: 'default' | 'success' | 'error' 
     accessibilityIconErrorLabel,
     accessibilityProcessingLabel,
   } = useDefaultLabelContext('Toast');
+  const isInExperiment = useInExperiment({
+    webExperimentName: 'web_gestalt_visualRefresh',
+    mwebExperimentName: 'web_gestalt_visualRefresh',
+  });
 
   return (
     <Fragment>
@@ -186,7 +190,7 @@ export function TypeThumbnail({ type }: { type: 'default' | 'success' | 'error' 
         >
           <Icon
             accessibilityLabel={accessibilityIconSuccessLabel}
-            color="success"
+            color={isInExperiment ? 'default' : 'success'}
             icon="workflow-status-ok"
             size={SIZE_ICON}
           />


### PR DESCRIPTION
### Summary

#### What changed?

Changed default accessibility label for Toast to 'dismiss message' instead of 'dismiss toast'. Also changed VR color for the success icon to 'default', as a special case for Toast.

#### Why?

https://pinterest.slack.com/archives/C014X9LTRCN/p1722364602407439?thread_ts=1721244858.309079&cid=C014X9LTRCN