### PR TITLE
TextArea, TextField: Add support for Tags with internal TagArea #3710

### DIFF
--- a/docs/examples/textarea/tags.tsx
+++ b/docs/examples/textarea/tags.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Box, Tag, TextArea } from 'gestalt';
+import { Box, Flex, Tag, TextArea } from 'gestalt';
 
 type ChangeTagHandler = (arg1: {
   event: React.ChangeEvent<HTMLTextAreaElement>;
@@ -64,15 +64,27 @@ export default function Example() {
 
   return (
     <Box padding={8} width="100%">
-      <TextArea
-        ref={ref}
-        id="variants-tags"
-        label="Emails"
-        onChange={onChangeTagManagement}
-        onKeyDown={onKeyDownTagManagement}
-        tags={renderedTags}
-        value={value}
-      />
+      <Flex direction="column" gap={4}>
+        <TextArea
+          ref={ref}
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          tags={renderedTags}
+          value={value}
+        />
+        <TextArea
+          ref={ref}
+          disabled
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          tags={renderedTags}
+          value={value}
+        />
+      </Flex>
     </Box>
   );
 }

--- a/docs/examples/textarea/tags.tsx
+++ b/docs/examples/textarea/tags.tsx
@@ -11,21 +11,18 @@ type KeyDownHandler = (arg1: {
   value: string;
 }) => void;
 
-const CITIES = ['San Francisco', 'New York'];
-
 export default function Example() {
   const [value, setValue] = useState('');
-  const [tags, setTags] = useState(CITIES);
-
+  const [tags, setTags] = useState(['a@pinterest.com', 'b@pinterest.com']);
   const ref = useRef<HTMLTextAreaElement | null>(null);
 
   const onChangeTagManagement: ChangeTagHandler = (e) => {
-    // Create new tags around new lines
-    const tagInput = e.value.split(/\\n+/);
+    // Create new tags around spaces, commas, and semicolons.
+    const tagInput = e.value.split(/[\\s,;]+/);
     if (tagInput.length > 1) {
       setTags([
         ...tags,
-        // Avoid creating a tag on content on the last line, and filter out
+        // Avoid creating a tag on content after the separators, and filter out
         // empty tags
         ...tagInput.splice(0, tagInput.length - 1).filter((val) => val !== ''),
       ]);
@@ -42,6 +39,10 @@ export default function Example() {
     if (keyCode === 8 /* Backspace */ && selectionEnd === 0) {
       // Remove tag on backspace if the cursor is at the beginning of the field
       setTags([...tags.slice(0, -1)]);
+    } else if (keyCode === 13 /* Enter */ && value.trim() !== '') {
+      // Create a new tag on enter
+      setTags([...tags, value.trim()]);
+      setValue('');
     }
   };
 
@@ -53,7 +54,9 @@ export default function Example() {
         const newTags = [...tags];
         newTags.splice(idx, 1);
         setTags([...newTags]);
-        ref.current?.focus();
+        if (ref.current) {
+          ref.current.focus();
+        }
       }}
       text={tag}
     />
@@ -63,11 +66,10 @@ export default function Example() {
     <Box padding={8} width="100%">
       <TextArea
         ref={ref}
-        id="cities"
-        label="Cities"
+        id="variants-tags"
+        label="Emails"
         onChange={onChangeTagManagement}
         onKeyDown={onKeyDownTagManagement}
-        placeholder={value.length > 0 || tags.length > 0 ? '' : "Cities you've lived in"}
         tags={renderedTags}
         value={value}
       />

--- a/docs/examples/textarea/tags.tsx
+++ b/docs/examples/textarea/tags.tsx
@@ -84,6 +84,26 @@ export default function Example() {
           tags={renderedTags}
           value={value}
         />
+        <TextArea
+          ref={ref}
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          readOnly
+          tags={renderedTags}
+          value={value}
+        />
+        <TextArea
+          ref={ref}
+          errorMessage="Select minimum of five"
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          tags={renderedTags}
+          value={value}
+        />
       </Flex>
     </Box>
   );

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { Box, Tag, TextField } from 'gestalt';
+import { Box, Flex, Tag, TextField } from 'gestalt';
 
 type ChangeTagHandler = (arg1: {
   event: React.ChangeEvent<HTMLInputElement>;
@@ -64,17 +64,44 @@ export default function Example() {
 
   return (
     <Box padding={8} width="100%">
-      <TextField
-        // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
-        ref={ref}
-        autoComplete="off"
-        id="variants-tags"
-        label="Emails"
-        onChange={onChangeTagManagement}
-        onKeyDown={onKeyDownTagManagement}
-        tags={renderedTags}
-        value={value}
-      />
+      <Flex direction="column" gap={2}>
+        <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref}
+          autoComplete="off"
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          size="sm"
+          tags={renderedTags}
+          value={value}
+        />
+        <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref}
+          autoComplete="off"
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          tags={renderedTags}
+          value={value}
+          size="md"
+        />
+        <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref}
+          autoComplete="off"
+          id="variants-tags"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          tags={renderedTags}
+          value={value}
+          size="lg"
+        />
+      </Flex>
     </Box>
   );
 }

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { Box, Flex, Tag, TextField } from 'gestalt';
+import { errorMessage } from '../../../packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright';
 
 type ChangeTagHandler = (arg1: {
   event: React.ChangeEvent<HTMLInputElement>;
@@ -109,6 +110,34 @@ export default function Example() {
           ref={ref}
           autoComplete="off"
           disabled
+          helperText="Select your target locations"
+          id="variants-tag-sm"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          size="sm"
+          tags={renderedTags}
+          value={value}
+        />
+         <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref}
+          autoComplete="off"
+          helperText="Select your target locations"
+          id="variants-tag-sm"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          readOnly
+          size="sm"
+          tags={renderedTags}
+          value={value}
+        />
+        <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref}
+          autoComplete="off"
+          errorMessage="Select minimum of five"
           helperText="Select your target locations"
           id="variants-tag-sm"
           label="Emails"

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -118,7 +118,7 @@ export default function Example() {
           tags={renderedTags}
           value={value}
         />
-         <TextField
+        <TextField
           // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
           ref={ref}
           autoComplete="off"

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -103,9 +103,11 @@ export default function Example() {
           size="lg"
           tags={renderedTags}
           value={value}
-        />   <TextField
+        />
+        <TextField
           // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
-          ref={ref} autoComplete="off"
+          ref={ref}
+          autoComplete="off"
           disabled
           helperText="Select your target locations"
           id="variants-tag-sm"

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react';
 import { Box, Flex, Tag, TextField } from 'gestalt';
-import { errorMessage } from '../../../packages/eslint-plugin-gestalt/src/no-box-marginleft-marginright';
 
 type ChangeTagHandler = (arg1: {
   event: React.ChangeEvent<HTMLInputElement>;

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -64,12 +64,13 @@ export default function Example() {
 
   return (
     <Box padding={8} width="100%">
-      <Flex direction="column" gap={2}>
+      <Flex direction="column" gap={4}>
         <TextField
           // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
           ref={ref}
           autoComplete="off"
-          id="variants-tags"
+          helperText="Select your target locations"
+          id="variants-tag-sm"
           label="Emails"
           onChange={onChangeTagManagement}
           onKeyDown={onKeyDownTagManagement}
@@ -81,25 +82,39 @@ export default function Example() {
           // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
           ref={ref}
           autoComplete="off"
-          id="variants-tags"
+          helperText="Select your target locations"
+          id="variants-tags-md"
           label="Emails"
           onChange={onChangeTagManagement}
           onKeyDown={onKeyDownTagManagement}
+          size="md"
           tags={renderedTags}
           value={value}
-          size="md"
         />
         <TextField
           // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
           ref={ref}
           autoComplete="off"
-          id="variants-tags"
+          helperText="Select your target locations"
+          id="variants-tags-lg"
           label="Emails"
           onChange={onChangeTagManagement}
           onKeyDown={onKeyDownTagManagement}
+          size="lg"
           tags={renderedTags}
           value={value}
-          size="lg"
+        />   <TextField
+          // @ts-expect-error - TS2322 - Type 'MutableRefObject<HTMLElement | null>' is not assignable to type 'LegacyRef<HTMLInputElement> | undefined'.
+          ref={ref} autoComplete="off"
+          disabled
+          helperText="Select your target locations"
+          id="variants-tag-sm"
+          label="Emails"
+          onChange={onChangeTagManagement}
+          onKeyDown={onKeyDownTagManagement}
+          size="sm"
+          tags={renderedTags}
+          value={value}
         />
       </Flex>
     </Box>

--- a/docs/pages/web/textarea.tsx
+++ b/docs/pages/web/textarea.tsx
@@ -369,7 +369,7 @@ The first example shows an empty TextArea with \`maxLength\` set to 200 characte
     This example showcases the recommended behavior.`}
           title="Tags"
         >
-          <MainSection.Card sandpackExample={<SandpackExample code={tags} name="Tags Example" />} />
+          <MainSection.Card sandpackExample={<SandpackExample code={tags} name="Tags Example"  previewHeight={600}/>} />
         </MainSection.Subsection>
       </MainSection>
 

--- a/docs/pages/web/textarea.tsx
+++ b/docs/pages/web/textarea.tsx
@@ -369,7 +369,11 @@ The first example shows an empty TextArea with \`maxLength\` set to 200 characte
     This example showcases the recommended behavior.`}
           title="Tags"
         >
-          <MainSection.Card sandpackExample={<SandpackExample code={tags} name="Tags Example"  previewHeight={600}/>} />
+          <MainSection.Card
+            sandpackExample={
+              <SandpackExample code={tags} name="Tags Example" previewHeight={600} />
+            }
+          />
         </MainSection.Subsection>
       </MainSection>
 

--- a/docs/pages/web/textfield.tsx
+++ b/docs/pages/web/textfield.tsx
@@ -429,7 +429,7 @@ The first example shows an empty Textfield with \`maxLength\` set to 20 characte
           title="Tags"
         >
           <MainSection.Card
-            sandpackExample={<SandpackExample code={tags} name="Tags Text Field Example" />}
+            sandpackExample={<SandpackExample code={tags} name="Tags Text Field Example" previewHeight={600} />}
           />
         </MainSection.Subsection>
         <MainSection.Subsection

--- a/docs/pages/web/textfield.tsx
+++ b/docs/pages/web/textfield.tsx
@@ -429,7 +429,9 @@ The first example shows an empty Textfield with \`maxLength\` set to 20 characte
           title="Tags"
         >
           <MainSection.Card
-            sandpackExample={<SandpackExample code={tags} name="Tags Text Field Example" previewHeight={600} />}
+            sandpackExample={
+              <SandpackExample code={tags} name="Tags Text Field Example" previewHeight={600} />
+            }
           />
         </MainSection.Subsection>
         <MainSection.Subsection

--- a/packages/gestalt/src/TagArea/TagArea.css
+++ b/packages/gestalt/src/TagArea/TagArea.css
@@ -25,22 +25,6 @@
   flex-wrap: wrap;
 }
 
-.md_input {
-  font-size: var(--sema-font-size-ui-md);
-  min-height: 36px;
-  padding-bottom: var(--sema-space-gap-vertical-lg);
-}
-
-html[dir="rtl"] .md_inputHorizontalPadding {
-  padding-left: var(--sema-space-padding-horizontal-lg);
-  padding-right: var(--sema-space-padding-horizontal-xl);
-}
-
-html:not([dir="rtl"]) .md_inputHorizontalPadding {
-  padding-left: var(--sema-space-padding-horizontal-xl);
-  padding-right: var(--sema-space-padding-horizontal-lg);
-}
-
 .disabled {
   background-color: var(--sema-color-background-disabled);
   border: 1px solid var(--sema-color-border-disabled);
@@ -84,6 +68,62 @@ html:not([dir="rtl"]) .md_inputHorizontalPadding {
   border: 1.5px solid var(--sema-color-hover-border-error);
 }
 
+.label {
+  color: inherit;
+  font-size: var(--sema-font-size-ui-xs);
+  font-weight: var(--sema-font-weight-ui);
+  line-height: var(--sema-font-lineheight-UI-XS);
+  padding: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+/* sm */
+
+.sm_input {
+  font-size: var(--sema-font-size-ui-sm);
+  min-height: 28px;
+  padding-bottom: var(--sema-space-gap-vertical-sm);
+}
+
+html[dir="rtl"] .sm_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-sm);
+  padding-right: var(--sema-space-padding-horizontal-lg);
+}
+
+html:not([dir="rtl"]) .sm_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-lg);
+  padding-right: var(--sema-space-padding-horizontal-sm);
+}
+
+.sm_visibleLabel {
+  padding-top: calc(
+    var(--sema-space-gap-vertical-sm) + (var(--sema-font-size-ui-sm) * 1.1)
+  );
+}
+
+.sm_noLabel {
+  padding-top: var(--sema-space-gap-vertical-sm);
+}
+
+/* md */
+
+.md_input {
+  font-size: var(--sema-font-size-ui-md);
+  min-height: 36px;
+  padding-bottom: var(--sema-space-gap-vertical-lg);
+}
+
+html[dir="rtl"] .md_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-lg);
+  padding-right: var(--sema-space-padding-horizontal-xl);
+}
+
+html:not([dir="rtl"]) .md_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-xl);
+  padding-right: var(--sema-space-padding-horizontal-lg);
+}
+
 .md_visibleLabel {
   padding-top: calc(
     var(--sema-space-padding-horizontal-xl) +
@@ -93,16 +133,6 @@ html:not([dir="rtl"]) .md_inputHorizontalPadding {
 
 .md_noLabel {
   padding-top: var(--sema-space-gap-vertical-lg);
-}
-
-.label {
-  color: inherit;
-  font-size: var(--sema-font-size-ui-xs);
-  font-weight: var(--sema-font-weight-ui);
-  line-height: var(--sema-font-lineheight-UI-XS);
-  padding: 0;
-  position: absolute;
-  z-index: 1;
 }
 
 html[dir="rtl"] .md_label {
@@ -117,4 +147,60 @@ html:not([dir="rtl"]) .md_label {
 
 .md_labelPos {
   top: var(--sema-space-gap-vertical-lg);
+}
+
+html[dir="rtl"] .sm_label {
+  left: calc(var(--sema-space-padding-horizontal-lg));
+  right: calc(var(--sema-space-padding-horizontal-lg) + 1px);
+}
+
+html:not([dir="rtl"]) .sm_label {
+  left: calc(var(--sema-space-padding-horizontal-lg) + 1px);
+  right: calc(var(--sema-space-padding-horizontal-lg));
+}
+
+.sm_labelPos {
+  top: var(--sema-space-gap-vertical-sm);
+}
+
+/* lg */
+
+.lg_input {
+  font-size: var(--sema-font-size-ui-md);
+  min-height: 48px;
+  padding-bottom: var(--sema-space-gap-vertical-xl);
+}
+
+html[dir="rtl"] .lg_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-xl);
+  padding-right: var(--sema-space-padding-horizontal-xxl);
+}
+
+html:not([dir="rtl"]) .lg_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-xxl);
+  padding-right: var(--sema-space-padding-horizontal-xl);
+}
+
+.lg_visibleLabel {
+  padding-top: calc(
+    var(--sema-space-gap-vertical-xxl) + (var(--sema-font-size-ui-md) * 1.1)
+  );
+}
+
+.lg_noLabel {
+  padding-top: var(--sema-space-gap-vertical-xl);
+}
+
+html[dir="rtl"] .lg_label {
+  left: calc(var(--sema-space-padding-horizontal-xxl));
+  right: calc(var(--sema-space-padding-horizontal-xxl) + 1px);
+}
+
+html:not([dir="rtl"]) .lg_label {
+  left: calc(var(--sema-space-padding-horizontal-xxl) + 1px);
+  right: calc(var(--sema-space-padding-horizontal-xxl));
+}
+
+.lg_labelPos {
+  top: var(--sema-space-gap-vertical-xl);
 }

--- a/packages/gestalt/src/TagArea/TagArea.css
+++ b/packages/gestalt/src/TagArea/TagArea.css
@@ -1,0 +1,120 @@
+.inputParent {
+  border-radius: var(--sema-rounding-md);
+  box-sizing: border-box;
+  display: block;
+  position: relative;
+  width: 100%;
+}
+
+.input {
+  appearance: none;
+  background: none;
+  border: none;
+  color: inherit;
+  display: block;
+  font-size: var(--sema-font-size-UI-MD);
+  font-weight: var(--sema-font-weight-body);
+  line-height: 1.5;
+  outline: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.inliner {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.md_input {
+  font-size: var(--sema-font-size-ui-md);
+  min-height: 36px;
+  padding-bottom: var(--sema-space-gap-vertical-lg);
+}
+
+html[dir="rtl"] .md_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-lg);
+  padding-right: var(--sema-space-padding-horizontal-xl);
+}
+
+html:not([dir="rtl"]) .md_inputHorizontalPadding {
+  padding-left: var(--sema-space-padding-horizontal-xl);
+  padding-right: var(--sema-space-padding-horizontal-lg);
+}
+
+.disabled {
+  background-color: var(--sema-color-background-disabled);
+  border: 1px solid var(--sema-color-border-disabled);
+}
+
+.disabledText {
+  color: var(--sema-color-text-disabled);
+}
+
+.enabledText {
+  color: var(--sema-color-text-default);
+}
+
+.enabled {
+  background: var(--sema-color-background-default);
+}
+
+.borderFocus {
+  border: 1px solid var(--sema-color-border-focus-inner-default);
+  outline: 2px solid var(--sema-color-border-focus-outer-default);
+}
+
+.errorBorderFocus {
+  border: 1.5px solid var(--sema-color-border-focus-inner-default);
+  outline: 2px solid var(--sema-color-border-focus-outer-default);
+}
+
+.enabledBorder {
+  border: 1px solid var(--sema-color-border-interactive);
+}
+
+.enabledBorderHover {
+  border: 1px solid var(--sema-color-hover-border-interactive);
+}
+
+.errorBorder {
+  border: 1.5px solid var(--sema-color-border-error);
+}
+
+.errorBorderHover {
+  border: 1.5px solid var(--sema-color-hover-border-error);
+}
+
+.md_visibleLabel {
+  padding-top: calc(
+    var(--sema-space-padding-horizontal-xl) +
+      (var(--sema-font-size-ui-md) * 1.1)
+  );
+}
+
+.md_noLabel {
+  padding-top: var(--sema-space-gap-vertical-lg);
+}
+
+.label {
+  color: inherit;
+  font-size: var(--sema-font-size-ui-xs);
+  font-weight: var(--sema-font-weight-ui);
+  line-height: var(--sema-font-lineheight-UI-XS);
+  padding: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+html[dir="rtl"] .md_label {
+  left: calc(var(--sema-space-padding-horizontal-xl));
+  right: calc(var(--sema-space-padding-horizontal-xl) + 1px);
+}
+
+html:not([dir="rtl"]) .md_label {
+  left: calc(var(--sema-space-padding-horizontal-xl) + 1px);
+  right: calc(var(--sema-space-padding-horizontal-xl));
+}
+
+.md_labelPos {
+  top: var(--sema-space-gap-vertical-lg);
+}

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -210,7 +210,7 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
                   }}
                   marginEnd={1}
                 >
-                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm', disabled })}
+                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm', disabled: disabled || readOnly })}
                 </Box>
               ))}
               <Flex.Item flex="grow">

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -96,6 +96,9 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
   const hasErrorMessage = Boolean(errorMessage);
 
   const isLabelVisible = labelDisplay === 'visible';
+  const isSM = size === 'sm';
+  const isMD = size === 'md';
+  const isLG = size === 'lg';
 
   const isEllipsisActive = (element: HTMLElement) =>
     element.offsetHeight < element.scrollHeight || element.offsetWidth < element.scrollWidth;
@@ -141,8 +144,7 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
         <div
           className={classnames(
             styles.inputParent,
-            styles.md_input,
-            styles.md_inputHorizontalPadding,
+
             {
               [styles.disabled]: disabled,
               [styles.disabledText]: disabled,
@@ -154,9 +156,21 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
               [styles.enabledBorderHover]: !disabled && !isFocused && !hasErrorMessage && isHovered,
               [styles.errorBorder]: !disabled && !isFocused && hasErrorMessage,
               [styles.errorBorderHover]: !disabled && !isFocused && hasErrorMessage && isHovered,
+              // sm
+              [styles.sm_input]: isSM,
+              [styles.sm_inputHorizontalPadding]: isSM,
+              [styles.sm_visibleLabel]: isSM && label && isLabelVisible,
+              [styles.sm_noLabel]: (isSM && !label) || (label && !isLabelVisible),
               // md
-              [styles.md_visibleLabel]: label && isLabelVisible,
-              [styles.md_noLabel]: !label || (label && !isLabelVisible),
+              [styles.md_input]: isMD,
+              [styles.md_inputHorizontalPadding]: isMD,
+              [styles.md_visibleLabel]: isMD && label && isLabelVisible,
+              [styles.md_noLabel]: (isMD && !label) || (label && !isLabelVisible),
+              // lg
+              [styles.lg_input]: isLG,
+              [styles.lg_inputHorizontalPadding]: isLG,
+              [styles.lg_visibleLabel]: isLG && label && isLabelVisible,
+              [styles.lg_noLabel]: (isLG && !label) || (label && !isLabelVisible),
             },
           )}
         >
@@ -165,10 +179,18 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
               ref={labelRef}
               className={classnames(
                 styles.label,
-                styles.md_label,
-                styles.md_labelPos,
+
                 typographyStyle.truncate,
                 {
+                  // sm
+                  [styles.sm_label]: isSM,
+                  [styles.sm_labelPos]: isSM,
+                  // md
+                  [styles.md_label]: isMD,
+                  [styles.md_labelPos]: isMD,
+                  // lg
+                  [styles.lg_label]: isLG,
+                  [styles.lg_labelPos]: isLG,
                   [boxStyles.visuallyHidden]: !isLabelVisible,
                 },
               )}

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -210,7 +210,10 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
                   }}
                   marginEnd={1}
                 >
-                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm', disabled: disabled || readOnly })}
+                  {cloneElement(tag, {
+                    size: size === 'lg' ? 'md' : 'sm',
+                    disabled: disabled || readOnly,
+                  })}
                 </Box>
               ))}
               <Flex.Item flex="grow">

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -210,7 +210,7 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
                   }}
                   marginEnd={1}
                 >
-                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm' })}
+                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm', disabled })}
                 </Box>
               ))}
               <Flex.Item flex="grow">

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -1,0 +1,253 @@
+import {
+  cloneElement,
+  forwardRef,
+  Fragment,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import classnames from 'classnames';
+import { TOKEN_SPACE_100 } from 'gestalt-design-tokens';
+import styles from './TagArea.css';
+import Box from '../Box';
+import boxStyles from '../Box.css';
+import Flex from '../Flex';
+import FormErrorMessage from '../sharedSubcomponents/FormErrorMessage';
+import FormHelperText from '../sharedSubcomponents/FormHelperText';
+import { MaxLength } from '../TextField';
+import typographyStyle from '../Typography.css';
+import useInteractiveStates from '../utils/useInteractiveStates';
+
+type Props = {
+  // REQUIRED
+  id: string;
+  onChange: (arg1: { event: React.ChangeEvent<HTMLInputElement>; value: string }) => void;
+  // OPTIONAL
+  accessibilityControls?: string;
+  accessibilityActiveDescendant?: string;
+  dataTestId?: string;
+  disabled?: boolean;
+  errorMessage?: ReactNode;
+  hasError?: boolean;
+  helperText?: string;
+  label?: string;
+  labelDisplay?: 'visible' | 'hidden';
+  maxLength?: MaxLength | null | undefined;
+  name?: string;
+  onBlur?: (arg1: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void;
+  onClick?: (arg1: { event: React.MouseEvent<HTMLInputElement>; value: string }) => void;
+  onFocus?: (arg1: { event: React.FocusEvent<HTMLInputElement>; value: string }) => void;
+  onKeyDown?: (arg1: { event: React.KeyboardEvent<HTMLInputElement>; value: string }) => void;
+  placeholder?: string;
+  readOnly?: boolean;
+  size: 'sm' | 'md' | 'lg';
+  tags: ReadonlyArray<ReactElement>;
+  value?: string;
+};
+
+const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function TagArea(
+  {
+    accessibilityControls,
+    accessibilityActiveDescendant,
+    dataTestId,
+    disabled = false,
+    errorMessage,
+    hasError = false,
+    helperText,
+    id,
+    label,
+    labelDisplay,
+    maxLength,
+    name,
+    onBlur,
+    onChange,
+    onClick,
+    onFocus,
+    onKeyDown,
+    placeholder,
+    readOnly,
+    size,
+    tags,
+    value,
+  }: Props,
+  ref,
+) {
+  const innerRef = useRef<null | HTMLDivElement>(null);
+  const labelRef = useRef<null | HTMLLabelElement>(null);
+
+  const [ellipsisActive, setEllipsisActive] = useState(false);
+
+  const {
+    handleOnBlur,
+    handleOnFocus,
+    handleOnMouseEnter,
+    handleOnMouseLeave,
+    isHovered,
+    isFocused,
+  } = useInteractiveStates();
+
+  // @ts-expect-error - TS2322 - Type 'HTMLDivElement | HTMLTextAreaElement | null' is not assignable to type 'HTMLTextAreaElement'.
+  useImperativeHandle(ref, () => innerRef.current);
+
+  const hasErrorMessage = Boolean(errorMessage);
+
+  const isLabelVisible = labelDisplay === 'visible';
+
+  const isEllipsisActive = (element: HTMLElement) =>
+    element.offsetHeight < element.scrollHeight || element.offsetWidth < element.scrollWidth;
+
+  const checkEllipsisActive = useCallback(() => {
+    if (labelRef.current && !ellipsisActive && isEllipsisActive(labelRef?.current)) {
+      setEllipsisActive(true);
+    } else if (labelRef.current && ellipsisActive && !isEllipsisActive(labelRef?.current)) {
+      setEllipsisActive(false);
+    }
+  }, [ellipsisActive]);
+
+  useEffect(() => {
+    if (!label) return () => {};
+
+    checkEllipsisActive();
+
+    if (typeof window !== 'undefined') window.addEventListener('resize', checkEllipsisActive);
+
+    return () => {
+      if (typeof window !== 'undefined') window?.removeEventListener('resize', checkEllipsisActive);
+    };
+  }, [label, checkEllipsisActive]);
+
+  // ==== STATE ====
+  const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
+
+  // ==== A11Y ====
+
+  let ariaDescribedby;
+
+  if (hasErrorMessage) {
+    ariaDescribedby = `${id}-error`;
+  }
+
+  if (helperText || maxLength) {
+    ariaDescribedby = `${id}-helperText`;
+  }
+
+  return (
+    <Fragment>
+      <div ref={innerRef} onMouseEnter={handleOnMouseEnter} onMouseLeave={handleOnMouseLeave}>
+        <div
+          className={classnames(
+            styles.inputParent,
+            styles.md_input,
+            styles.md_inputHorizontalPadding,
+            {
+              [styles.disabled]: disabled,
+              [styles.disabledText]: disabled,
+              [styles.enabled]: !disabled,
+              [styles.enabledText]: !disabled,
+              [styles.borderFocus]: !disabled && isFocused && !hasErrorMessage,
+              [styles.errorBorderFocus]: !disabled && isFocused && hasErrorMessage,
+              [styles.enabledBorder]: !disabled && !isFocused && !hasErrorMessage && !isHovered,
+              [styles.enabledBorderHover]: !disabled && !isFocused && !hasErrorMessage && isHovered,
+              [styles.errorBorder]: !disabled && !isFocused && hasErrorMessage,
+              [styles.errorBorderHover]: !disabled && !isFocused && hasErrorMessage && isHovered,
+              // md
+              [styles.md_visibleLabel]: label && isLabelVisible,
+              [styles.md_noLabel]: !label || (label && !isLabelVisible),
+            },
+          )}
+        >
+          {label && (
+            <label
+              ref={labelRef}
+              className={classnames(
+                styles.label,
+                styles.md_label,
+                styles.md_labelPos,
+                typographyStyle.truncate,
+                {
+                  [boxStyles.visuallyHidden]: !isLabelVisible,
+                },
+              )}
+              htmlFor={id}
+              title={ellipsisActive ? label : ''}
+            >
+              {label}
+            </label>
+          )}
+          <Flex gap={1}>
+            <Flex wrap>
+              {tags.map((tag, tagIndex) => (
+                <Box
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={tagIndex}
+                  dangerouslySetInlineStyle={{
+                    __style: {
+                      marginBottom: size === 'sm' || size === 'md' ? '2px' : TOKEN_SPACE_100,
+                    },
+                  }}
+                  marginEnd={1}
+                >
+                  {cloneElement(tag, { size: size === 'lg' ? 'md' : 'sm' })}
+                </Box>
+              ))}
+              <Flex.Item flex="grow">
+                <input
+                  aria-activedescendant={accessibilityActiveDescendant}
+                  aria-controls={accessibilityControls}
+                  // checking for "focused" is not required by screenreaders but it prevents a11y integration tests to complain about missing label, as aria-describedby seems to shadow label in tests though it's a W3 accepeted pattern https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html
+                  aria-describedby={isFocused ? ariaDescribedby : undefined}
+                  aria-invalid={hasErrorMessage || hasError ? 'true' : 'false'}
+                  className={classnames(styles.input)}
+                  data-test-id={dataTestId}
+                  disabled={disabled}
+                  id={id}
+                  maxLength={maxLength?.characterCount}
+                  name={name}
+                  onBlur={(event) => {
+                    handleOnBlur();
+                    onBlur?.({ event, value: event.currentTarget.value });
+                  }}
+                  onChange={(event) => {
+                    setCurrentLength(event.currentTarget.value?.length ?? 0);
+                    onChange({ event, value: event.currentTarget.value });
+                  }}
+                  onClick={(event) => onClick?.({ event, value: event.currentTarget.value })}
+                  onFocus={(event) => {
+                    handleOnFocus();
+                    onFocus?.({ event, value: event.currentTarget.value });
+                  }}
+                  onKeyDown={(event) => onKeyDown?.({ event, value: event.currentTarget.value })}
+                  placeholder={placeholder}
+                  readOnly={readOnly}
+                  value={value}
+                />
+              </Flex.Item>
+            </Flex>
+          </Flex>
+        </div>
+      </div>
+      {(helperText || maxLength) && !hasErrorMessage ? (
+        <FormHelperText
+          currentLength={currentLength}
+          disabled={disabled}
+          id={`${id}-helperText`}
+          maxLength={maxLength}
+          size="md"
+          text={helperText}
+        />
+      ) : null}
+
+      {!disabled && hasErrorMessage ? (
+        <FormErrorMessage id={`${id}-error`} size="md" text={errorMessage} />
+      ) : null}
+    </Fragment>
+  );
+});
+
+TagAreaWithForwardRef.displayName = 'TagArea';
+
+export default TagAreaWithForwardRef;

--- a/packages/gestalt/src/TagArea/TagArea.tsx
+++ b/packages/gestalt/src/TagArea/TagArea.tsx
@@ -79,8 +79,12 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
   const innerRef = useRef<null | HTMLDivElement>(null);
   const labelRef = useRef<null | HTMLLabelElement>(null);
 
-  const [ellipsisActive, setEllipsisActive] = useState(false);
+  // @ts-expect-error - TS2322 - Type 'HTMLDivElement | HTMLTextAreaElement | null' is not assignable to type 'HTMLTextAreaElement'.
+  useImperativeHandle(ref, () => innerRef.current);
 
+  // ==== STATE ====
+  const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
+  const [ellipsisActive, setEllipsisActive] = useState(false);
   const {
     handleOnBlur,
     handleOnFocus,
@@ -89,16 +93,6 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
     isHovered,
     isFocused,
   } = useInteractiveStates();
-
-  // @ts-expect-error - TS2322 - Type 'HTMLDivElement | HTMLTextAreaElement | null' is not assignable to type 'HTMLTextAreaElement'.
-  useImperativeHandle(ref, () => innerRef.current);
-
-  const hasErrorMessage = Boolean(errorMessage);
-
-  const isLabelVisible = labelDisplay === 'visible';
-  const isSM = size === 'sm';
-  const isMD = size === 'md';
-  const isLG = size === 'lg';
 
   const isEllipsisActive = (element: HTMLElement) =>
     element.offsetHeight < element.scrollHeight || element.offsetWidth < element.scrollWidth;
@@ -111,6 +105,24 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
     }
   }, [ellipsisActive]);
 
+  // ==== VARIABLES ====
+
+  const hasErrorMessage = Boolean(errorMessage);
+  const isLabelVisible = labelDisplay === 'visible';
+  const isSM = size === 'sm';
+  const isMD = size === 'md';
+  const isLG = size === 'lg';
+
+  let ariaDescribedby;
+
+  if (hasErrorMessage) {
+    ariaDescribedby = `${id}-error`;
+  }
+
+  if (helperText || maxLength) {
+    ariaDescribedby = `${id}-helperText`;
+  }
+
   useEffect(() => {
     if (!label) return () => {};
 
@@ -122,21 +134,6 @@ const TagAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function Ta
       if (typeof window !== 'undefined') window?.removeEventListener('resize', checkEllipsisActive);
     };
   }, [label, checkEllipsisActive]);
-
-  // ==== STATE ====
-  const [currentLength, setCurrentLength] = useState(value?.length ?? 0);
-
-  // ==== A11Y ====
-
-  let ariaDescribedby;
-
-  if (hasErrorMessage) {
-    ariaDescribedby = `${id}-error`;
-  }
-
-  if (helperText || maxLength) {
-    ariaDescribedby = `${id}-helperText`;
-  }
 
   return (
     <Fragment>

--- a/packages/gestalt/src/TextArea.tsx
+++ b/packages/gestalt/src/TextArea.tsx
@@ -6,6 +6,7 @@ import formElement from './sharedSubcomponents/FormElement.css';
 import FormErrorMessage from './sharedSubcomponents/FormErrorMessage';
 import FormHelperText from './sharedSubcomponents/FormHelperText';
 import FormLabel from './sharedSubcomponents/FormLabel';
+import TagArea from './TagArea/TagArea';
 import styles from './TextArea.css';
 import VRTextArea from './TextArea/VRTextArea';
 import useInExperiment from './useInExperiment';
@@ -222,29 +223,63 @@ const TextAreaWithForwardRef = forwardRef<HTMLTextAreaElement, Props>(function T
     maxHeight: rows * ROW_HEIGHT + INPUT_PADDING_WITH_TAGS,
   } as const;
 
-  return isInVRExperiment ? (
-    <VRTextArea
-      ref={ref}
-      dataTestId={dataTestId}
-      disabled={disabled}
-      errorMessage={errorMessage}
-      hasError={hasError}
-      helperText={helperText}
-      id={id}
-      label={label}
-      labelDisplay={labelDisplay}
-      maxLength={maxLength}
-      name={name}
-      onBlur={onBlur}
-      onChange={onChange}
-      onFocus={onFocus}
-      onKeyDown={onKeyDown}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      rows={rows}
-      value={value}
-    />
-  ) : (
+  if (isInVRExperiment && !tags)
+    return (
+      <VRTextArea
+        ref={ref}
+        dataTestId={dataTestId}
+        disabled={disabled}
+        errorMessage={errorMessage}
+        hasError={hasError}
+        helperText={helperText}
+        id={id}
+        label={label}
+        labelDisplay={labelDisplay}
+        maxLength={maxLength}
+        name={name}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        rows={rows}
+        value={value}
+      />
+    );
+
+  if (isInVRExperiment && tags)
+    return (
+      <TagArea
+        ref={ref}
+        dataTestId={dataTestId}
+        disabled={disabled}
+        errorMessage={errorMessage}
+        hasError={hasError}
+        helperText={helperText}
+        id={id}
+        label={label}
+        labelDisplay={labelDisplay}
+        maxLength={maxLength}
+        name={name}
+        // @ts-expect-error - TS2322
+        onBlur={onBlur}
+        // @ts-expect-error - TS2322
+        onChange={onChange}
+        // @ts-expect-error - TS2322
+        onFocus={onFocus}
+        // @ts-expect-error - TS2322
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        rows={rows}
+        size="md"
+        tags={tags}
+        value={value}
+      />
+    );
+
+  return (
     <span>
       {label && <FormLabel id={id} label={label} labelDisplay={labelDisplay} size="lg" />}
       {tags ? (

--- a/packages/gestalt/src/TextField.tsx
+++ b/packages/gestalt/src/TextField.tsx
@@ -120,7 +120,7 @@ type Props = {
  *
  */
 
-const TextFieldWithForwardRef = forwardRef<HTMLInputElement , Props>(function TextField(
+const TextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function TextField(
   {
     autoComplete,
     dataTestId,
@@ -247,7 +247,6 @@ const TextFieldWithForwardRef = forwardRef<HTMLInputElement , Props>(function Te
         tags={tags}
         value={value}
       />
-
     );
 
   return (

--- a/packages/gestalt/src/TextField.tsx
+++ b/packages/gestalt/src/TextField.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, ReactElement, ReactNode, useEffect, useState } from 'react';
 import { useDefaultLabelContext } from './contexts/DefaultLabelProvider';
+import TagArea from './TagArea/TagArea';
 import InternalTextField, { autoCompleteType } from './TextField/InternalTextField';
 import PasswordIconButton from './TextField/PasswordIconButton';
 import VRInternalTextField from './TextField/VRInternalTextField';
@@ -119,7 +120,7 @@ type Props = {
  *
  */
 
-const TextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function TextField(
+const TextFieldWithForwardRef = forwardRef<HTMLInputElement , Props>(function TextField(
   {
     autoComplete,
     dataTestId,
@@ -189,35 +190,67 @@ const TextFieldWithForwardRef = forwardRef<HTMLInputElement, Props>(function Tex
     />
   ) : undefined;
 
-  return isInVRExperiment ? (
-    <VRInternalTextField
-      ref={ref}
-      autoComplete={autoComplete}
-      dataTestId={dataTestId}
-      disabled={disabled}
-      errorMessage={errorMessage}
-      hasError={hasError}
-      helperText={helperText}
-      iconButton={iconButton}
-      id={id}
-      label={label}
-      labelDisplay={labelDisplay}
-      maxLength={maxLength}
-      mobileEnterKeyHint={mobileEnterKeyHint}
-      mobileInputMode={mobileInputMode}
-      name={name}
-      onBlur={onBlur}
-      onChange={onChange}
-      onFocus={onFocus}
-      onKeyDown={onKeyDown}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      size={size}
-      tags={tags}
-      type={type}
-      value={value}
-    />
-  ) : (
+  if (isInVRExperiment && !tags) {
+    return (
+      <VRInternalTextField
+        ref={ref}
+        autoComplete={autoComplete}
+        dataTestId={dataTestId}
+        disabled={disabled}
+        errorMessage={errorMessage}
+        hasError={hasError}
+        helperText={helperText}
+        iconButton={iconButton}
+        id={id}
+        label={label}
+        labelDisplay={labelDisplay}
+        maxLength={maxLength}
+        mobileEnterKeyHint={mobileEnterKeyHint}
+        mobileInputMode={mobileInputMode}
+        name={name}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        size={size}
+        tags={tags}
+        type={type}
+        value={value}
+      />
+    );
+  }
+
+  if (isInVRExperiment && tags)
+    return (
+      <TagArea
+        // @ts-expect-error - TS2322
+        ref={ref}
+        dataTestId={dataTestId}
+        disabled={disabled}
+        errorMessage={errorMessage}
+        hasError={hasError}
+        helperText={helperText}
+        id={id}
+        label={label}
+        labelDisplay={labelDisplay}
+        maxLength={maxLength}
+        name={name}
+        onBlur={onBlur}
+        onChange={onChange}
+        onFocus={onFocus}
+        onKeyDown={onKeyDown}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        size={size}
+        tags={tags}
+        value={value}
+      />
+
+    );
+
+  return (
     <InternalTextField
       ref={ref}
       autoComplete={autoComplete}


### PR DESCRIPTION
TextArea, TextField: Add support for Tags with internal TagArea #3710

Both are the same for TextField and TextArea

## Classic
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/c5814202-c8f8-4cbc-b5b8-35713cfb5af4)

## VR

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/4297dfba-4393-46fe-844e-d66c66254f54)


![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/9386ab43-3911-456c-8774-54b4b246c13d)
