### PR TITLE
Masonry: Fix full-width module support

### DIFF
--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -56,11 +56,10 @@ function calculateActualColumnSpan<T>(props: {
 }): number {
   const { columnCount, item, _getColumnSpanConfig } = props;
   const columnSpanConfig = _getColumnSpanConfig(item);
-  if (typeof columnSpanConfig === 'number') {
-    return columnSpanConfig;
-  }
   const gridSize = columnCountToGridSize(columnCount);
-  return columnSpanConfig[gridSize] ?? 1;
+  const columnSpan = typeof columnSpanConfig === 'number' ? columnSpanConfig : (columnSpanConfig[gridSize] ?? 1);
+  // a multi column item can never span more columns than there are in the grid
+  return Math.min(columnSpan, columnCount);
 }
 
 function getAdjacentColumnHeightDeltas(
@@ -507,10 +506,7 @@ function getPositionsWithMultiColumnItem<T>({
   // items already positioned from previous batches
   const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
-  const multiColumnItemColumnSpan = Math.min(
-    calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpanConfig }),
-    columnCount,
-  );
+  const multiColumnItemColumnSpan = calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpanConfig });
 
   // Skip the graph logic if the two column item can be displayed on the first row,
   // this means graphBatch is empty and multi column item is positioned on its

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -57,7 +57,8 @@ function calculateActualColumnSpan<T>(props: {
   const { columnCount, item, _getColumnSpanConfig } = props;
   const columnSpanConfig = _getColumnSpanConfig(item);
   const gridSize = columnCountToGridSize(columnCount);
-  const columnSpan = typeof columnSpanConfig === 'number' ? columnSpanConfig : (columnSpanConfig[gridSize] ?? 1);
+  const columnSpan =
+    typeof columnSpanConfig === 'number' ? columnSpanConfig : columnSpanConfig[gridSize] ?? 1;
   // a multi column item can never span more columns than there are in the grid
   return Math.min(columnSpan, columnCount);
 }
@@ -506,7 +507,11 @@ function getPositionsWithMultiColumnItem<T>({
   // items already positioned from previous batches
   const emptyColumns = heights.reduce((acc, height) => (height === 0 ? acc + 1 : acc), 0);
 
-  const multiColumnItemColumnSpan = calculateActualColumnSpan({ columnCount, item: multiColumnItem, _getColumnSpanConfig });
+  const multiColumnItemColumnSpan = calculateActualColumnSpan({
+    columnCount,
+    item: multiColumnItem,
+    _getColumnSpanConfig,
+  });
 
   // Skip the graph logic if the two column item can be displayed on the first row,
   // this means graphBatch is empty and multi column item is positioned on its


### PR DESCRIPTION
### Summary
This PR fixes an issue where setting the multi-column module width to `Infinity` causes the browser to freeze by updating `calculateActualColumnSpan` to  return the _minimum_ of `columnCount` or the computed value of `getColumnSpanConfig`. 

This is accurate since an item can never span more columns than supported by the grid.  In the case of `Infinity`, this was previously causing an infinite loop since the value of `calculateActualColumnSpan` was being use to initialize the item heights array. 
