### PR TITLE
Masonry: Change whitespace logging from one number to an array

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -118,7 +118,7 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _logTwoColWhitespace?: (arg1: number) => void;
+  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
   /**
    * Experimental prop to define how many columns a module should span. This is also used to enable multi-column support
    * _getColumnSpanConfig is a function that takes an individual grid item as an input and returns a ColumnSpanConfig. ColumnSpanConfig can be one of two things:

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -66,7 +66,7 @@ const defaultLayout =
     measurementCache: Cache<T, number>;
     _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
     whitespaceThreshold?: number;
-    logWhitespace?: (arg1: number) => void;
+    logWhitespace?: (arg1: ReadonlyArray<number>) => void;
     renderLoadingState?: boolean;
   }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) =>
   (items): ReadonlyArray<Position> => {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -22,7 +22,7 @@ const fullWidthLayout = <T>({
   measurementCache: Cache<T, number>;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
-  logWhitespace?: (arg1: number) => void;
+  logWhitespace?: (arg1: ReadonlyArray<number>) => void;
   renderLoadingState?: boolean;
 }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) => {
   if (width == null) {

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -28,7 +28,7 @@ export default function getLayoutAlgorithm<T>({
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-  _logTwoColWhitespace?: (arg1: number) => void;
+  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
 }): (forItems: ReadonlyArray<T>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
     return fullWidthLayout({

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -29,10 +29,6 @@ export function columnCountToGridSize(columnCount: number): GridSize {
   return 'xl';
 }
 
-function isNil(value: unknown): boolean {
-  return value === null || value === undefined;
-}
-
 const offscreen = (width: number, height: number = Infinity) => ({
   top: -9999,
   left: -9999,
@@ -196,8 +192,12 @@ function getOneColumnItemPositions<T>({
   heights: ReadonlyArray<number>;
 } {
   const heights = [...heightsArg];
-  const positions = items.reduce<Array<any>>(
-    // @ts-expect-error - TS2345 - Argument of type '(positionsSoFar: readonly { item: T; position: Position; }[], item: T) => readonly { item: T; position: Position; }[] | { item: T; position: { top: number; left: number; width: number; height: number | ... 1 more ... | undefined; }; }[]' is not assignable to parameter of type '(previousValue: any[], currentValue: T, currentIndex: number, array: readonly T[]) => any[]'.
+  const positions = items.reduce<
+    ReadonlyArray<{
+      item: T;
+      position: Position;
+    }>
+  >(
     (
       positionsSoFar: ReadonlyArray<{
         item: T;
@@ -212,8 +212,7 @@ function getOneColumnItemPositions<T>({
         return [...positionsSoFar, { item, position: cachedPosition }];
       }
 
-      if (!isNil(height)) {
-        // @ts-expect-error - TS2533 - Object is possibly 'null' or 'undefined'.
+      if (height != null) {
         const heightAndGutter = height + gutter;
         const col = mindex(heights);
         const top = heights[col];
@@ -239,7 +238,6 @@ function getOneColumnItemPositions<T>({
     [],
   );
 
-  // @ts-expect-error - TS2322 - Type 'T' is not assignable to type 'readonly { item: T; position: Position; }[]'.
   return { positions, heights };
 }
 
@@ -265,14 +263,14 @@ function getMultiColItemPosition<T>({
   positionCache?: Cache<T, Position>;
   fitsFirstRow: boolean;
 }): {
-  additionalWhitespace: number | null;
+  additionalWhitespace: ReadonlyArray<number> | null;
   heights: ReadonlyArray<number>;
   position: Position;
 } {
   const heights = [...heightsArg];
   const height = measurementCache.get(item);
 
-  if (isNil(height)) {
+  if (height == null) {
     return {
       additionalWhitespace: null,
       heights,
@@ -280,7 +278,6 @@ function getMultiColItemPosition<T>({
     };
   }
 
-  // @ts-expect-error - TS2533 - Object is possibly 'null' or 'undefined'.
   const heightAndGutter = height + gutter;
 
   // Find height deltas for each column as compared to the next column
@@ -310,13 +307,15 @@ function getMultiColItemPosition<T>({
   }
 
   return {
-    additionalWhitespace: adjacentColumnHeightDeltas[lowestAdjacentColumnHeightDeltaIndex],
+    additionalWhitespace: adjacentColumnHeightDeltas.slice(
+      lowestAdjacentColumnHeightDeltaIndex,
+      lowestAdjacentColumnHeightDeltaIndex + columnSpan - 1,
+    ),
     heights,
     position: {
       top,
       left,
       width: calculateMultiColumnModuleWidth(columnWidth, gutter, columnSpan),
-      // @ts-expect-error - TS2322 - Type 'number | null | undefined' is not assignable to type 'number'.
       height,
     },
   };
@@ -344,14 +343,10 @@ function getGraphPositions<T>({
   gutter: number;
   measurementCache: Cache<T, number>;
   positionCache?: Cache<T, Position>;
-}): {
-  winningNode: NodeData<T>;
-  additionalWhitespace: number;
-} {
+}): NodeData<T> {
   // When whitespace threshold is set this variables store the score and node if found
   let bailoutScore;
-  // @ts-expect-error - TS7034 - Variable 'bailoutNode' implicitly has type 'any' in some locations where its type cannot be determined.
-  let bailoutNode;
+  let bailoutNode: NodeData<T> | undefined;
 
   // Initialize the graph
   const graph = new Graph<T>();
@@ -382,7 +377,6 @@ function getGraphPositions<T>({
     heightsArr: ReadonlyArray<number>;
     itemsSoFar?: ReadonlyArray<T>;
   }) {
-    // @ts-expect-error - TS7005 - Variable 'bailoutNode' implicitly has an 'any' type.
     if (bailoutNode) {
       return;
     }
@@ -453,11 +447,12 @@ function getGraphPositions<T>({
         lowestScore: bailoutScore ?? 0,
       }
     : graph.findLowestScore(startNodeData);
+  // const { lowestScoreNode, lowestScore } = graph.findLowestScore(startNodeData);
 
   // The best solution may be "no solution", i.e. laying out the multi column item first
   return lowestScore === null || lowestScore < startingLowestAdjacentColumnHeightDelta
-    ? { winningNode: lowestScoreNode, additionalWhitespace: lowestScore ?? 0 }
-    : { winningNode: startNodeData, additionalWhitespace: startingLowestAdjacentColumnHeightDelta };
+    ? lowestScoreNode
+    : startNodeData;
 }
 
 function getPositionsWithMultiColumnItem<T>({
@@ -479,7 +474,7 @@ function getPositionsWithMultiColumnItem<T>({
     position: Position;
   }>;
   whitespaceThreshold?: number;
-  logWhitespace?: (arg1: number) => void;
+  logWhitespace?: (arg1: ReadonlyArray<number>) => void;
   columnCount: number;
   centerOffset: number;
   columnWidth: number;
@@ -551,7 +546,7 @@ function getPositionsWithMultiColumnItem<T>({
   });
 
   // Get a node with the required whitespace
-  const { winningNode, additionalWhitespace } = getGraphPositions({
+  const winningNode = getGraphPositions({
     items: graphBatch,
     positions: paintedItemPositions,
     heights: paintedItemHeights,
@@ -561,7 +556,11 @@ function getPositionsWithMultiColumnItem<T>({
   });
 
   // Insert multi column item(s)
-  const { heights: updatedHeights, position: multiColItemPosition } = getMultiColItemPosition<T>({
+  const {
+    heights: updatedHeights,
+    position: multiColItemPosition,
+    additionalWhitespace,
+  } = getMultiColItemPosition<T>({
     item: multiColumnItem,
     heights: winningNode.heights,
     columnSpan: multiColumnItemColumnSpan,
@@ -590,7 +589,9 @@ function getPositionsWithMultiColumnItem<T>({
 
   // Log additional whitespace shown above the multi column module
   // This may need to be tweaked or removed if pin leveling is implemented
-  logWhitespace?.(additionalWhitespace);
+  if (additionalWhitespace) {
+    logWhitespace?.(additionalWhitespace);
+  }
 
   finalPositions.forEach(({ item, position }) => {
     positionCache.set(item, position);
@@ -621,7 +622,7 @@ const multiColumnLayout = <T>({
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
   whitespaceThreshold?: number;
-  logWhitespace?: (arg1: number) => void;
+  logWhitespace?: (arg1: ReadonlyArray<number>) => void;
   _getColumnSpanConfig: (item: T) => ColumnSpanConfig;
 }): ReadonlyArray<Position> => {
   if (!items.every((item) => measurementCache.has(item))) {

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -122,7 +122,7 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _logTwoColWhitespace?: (arg1: number) => void;
+  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
   /**
    * Experimental prop to measure all items in one batch
    */
@@ -362,7 +362,7 @@ function useLayout<T>({
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
   heightUpdateTrigger: number;
-  _logTwoColWhitespace?: (arg1: number) => void;
+  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
   _measureAll?: boolean;
   _useRAF?: boolean;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;


### PR DESCRIPTION
### Summary

We plan to add whitespace metrics to helium, for this we wanted to have a more robust insight on how the whitespace behaves and that means to add not just one number but all the gaps for modules that have 3 or more columns.

#### What changed?

- All the references of the log whitespace function are changed from `number` to `ReadOnlyArray<number>`
- Removed the whitespace metric from `getGraphPositions` and instead use `getMultiColItemPosition` (This because on the later we have the info of all the whitespaces not just the node score)
- Changed the logic for whitespace to return the array with the corresponding whitespaces

## Extra

- Also removed all the typescript suppression errors from `multiColumnLayout.ts`