### PR TITLE
ButtonToggle: Add bounce animation

### DIFF
--- a/packages/gestalt/src/ButtonToggle.tsx
+++ b/packages/gestalt/src/ButtonToggle.tsx
@@ -180,6 +180,16 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
         onFocus={(event) => {
           onFocus?.({ event });
         }}
+        onKeyDown={(e) => {
+          if (isInVRExperiment) {
+            buttonToggleAnimation.handleKeyDown(e);
+          }
+        }}
+        onKeyUp={(e) => {
+          if (isInVRExperiment) {
+            buttonToggleAnimation.handleKeyUp(e);
+          }
+        }}
         onMouseDown={() => {
           handleMouseDown();
           if (isInVRExperiment) buttonToggleAnimation.handleMouseDown();
@@ -290,6 +300,16 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
       }}
       onFocus={(event) => {
         onFocus?.({ event });
+      }}
+      onKeyDown={(e) => {
+        if (isInVRExperiment) {
+          buttonToggleAnimation.handleKeyDown(e);
+        }
+      }}
+      onKeyUp={(e) => {
+        if (isInVRExperiment) {
+          buttonToggleAnimation.handleKeyUp(e);
+        }
       }}
       onMouseDown={() => {
         handleMouseDown();

--- a/packages/gestalt/src/ButtonToggle.tsx
+++ b/packages/gestalt/src/ButtonToggle.tsx
@@ -4,6 +4,7 @@ import borderStyles from './Borders.css';
 import styles from './ButtonToggle.css';
 import ColorPicker, { SkinColor } from './ButtonToggle/ColorPicker';
 import LabeledThumbnail from './ButtonToggle/LabeledThumbnail';
+import useButtonToggleAnimation from './ButtonToggle/useButtonToggleAnimation';
 import { useColorScheme } from './contexts/ColorSchemeProvider';
 import { useGlobalEventsHandlerContext } from './contexts/GlobalEventsHandlerProvider';
 import Flex from './Flex';
@@ -13,6 +14,7 @@ import icons from './icons/index';
 import touchableStyles from './TapArea.css';
 import Text from './Text';
 import useFocusVisible from './useFocusVisible';
+import useInExperiment from './useInExperiment';
 import useTapFeedback from './useTapFeedback';
 
 const DEFAULT_TEXT_COLORS = {
@@ -121,7 +123,6 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
 
   const {
     compressStyle,
-    isTapping,
     handleBlur,
     handleMouseDown,
     handleMouseUp,
@@ -139,6 +140,13 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
   const isDarkMode = colorSchemeName === 'darkMode';
   const isDarkModeRed = isDarkMode && color === 'red';
   const { isFocusVisible } = useFocusVisible();
+
+  const isInVRExperiment = useInExperiment({
+    webExperimentName: 'web_gestalt_visualRefresh',
+    mwebExperimentName: 'web_gestalt_visualRefresh',
+  });
+
+  const buttonToggleAnimation = useButtonToggleAnimation();
 
   const sharedTypeClasses = classnames(styles.button, {
     [focusStyles.hideOutline]: !disabled && !isFocusVisible,
@@ -172,8 +180,14 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
         onFocus={(event) => {
           onFocus?.({ event });
         }}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
+        onMouseDown={() => {
+          handleMouseDown();
+          if (isInVRExperiment) buttonToggleAnimation.handleMouseDown();
+        }}
+        onMouseUp={() => {
+          handleMouseUp();
+          if (isInVRExperiment) buttonToggleAnimation.handleMouseUp();
+        }}
         onTouchCancel={handleTouchCancel}
         onTouchEnd={handleTouchEnd}
         // @ts-expect-error - TS2322 - Type '(arg1: TouchEvent<HTMLDivElement>) => void' is not assignable to type 'TouchEventHandler<HTMLButtonElement>'.
@@ -182,12 +196,21 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
         onTouchStart={handleTouchStart}
         type="button"
       >
-        <ColorPicker colors={color} disabled={disabled} selected={selected} size={size} />
+        <div
+          ref={buttonToggleAnimation.elementRef}
+          className={classnames({
+            [buttonToggleAnimation.classes]: isInVRExperiment,
+          })}
+        >
+          <ColorPicker colors={color} disabled={disabled} selected={selected} size={size} />
+        </div>
       </button>
     );
   }
 
-  const baseTypeClasses = classnames(sharedTypeClasses, touchableStyles.tapTransition, {
+  const baseTypeClasses = classnames(sharedTypeClasses, {
+    [buttonToggleAnimation.classes]: isInVRExperiment,
+    [touchableStyles.tapTransition]: !isInVRExperiment,
     [styles.disabled]: disabled && (color !== 'red' || selected),
     [styles.disabledRed]: disabled && color === 'red' && !selected,
     [styles.disabledTransparent]: disabled && color === 'transparent' && !selected,
@@ -204,7 +227,6 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
     [styles.thumbnailMd]: size === 'md' && graphicSrc,
     [styles.thumbnailSm]: size === 'sm' && graphicSrc,
     [styles[color]]: !disabled && !selected,
-    [touchableStyles.tapCompress]: !disabled && isTapping,
   });
 
   const borderClasses = {
@@ -225,34 +247,29 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
     (isDarkModeRed && 'default') ||
     DEFAULT_TEXT_COLORS[color];
 
-  const renderContent = () =>
-    graphicSrc ? (
-      <LabeledThumbnail graphicSrc={graphicSrc} text={text} textColor={textColor} />
-    ) : (
-      <Flex
-        alignItems="center"
-        gap={{ row: text === '' ? 0 : 2, column: 0 }}
-        justifyContent="center"
+  const content = graphicSrc ? (
+    <LabeledThumbnail graphicSrc={graphicSrc} text={text} textColor={textColor} />
+  ) : (
+    <Flex alignItems="center" gap={{ row: text === '' ? 0 : 2, column: 0 }} justifyContent="center">
+      {iconStart && (
+        <Icon
+          accessibilityLabel=""
+          color={textColor as IconColor}
+          icon={iconStart}
+          size={SIZE_NAME_TO_PIXEL[size]}
+        />
+      )}
+      <Text
+        align="center"
+        color={textColor}
+        overflow="breakWord"
+        size={size === 'sm' ? '200' : '300'}
+        weight="bold"
       >
-        {iconStart && (
-          <Icon
-            accessibilityLabel=""
-            color={textColor as IconColor}
-            icon={iconStart}
-            size={SIZE_NAME_TO_PIXEL[size]}
-          />
-        )}
-        <Text
-          align="center"
-          color={textColor}
-          overflow="breakWord"
-          size={size === 'sm' ? '200' : '300'}
-          weight="bold"
-        >
-          {text}
-        </Text>
-      </Flex>
-    );
+        {text}
+      </Text>
+    </Flex>
+  );
 
   return (
     <button
@@ -274,8 +291,14 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
       onFocus={(event) => {
         onFocus?.({ event });
       }}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
+      onMouseDown={() => {
+        handleMouseDown();
+        if (isInVRExperiment) buttonToggleAnimation.handleMouseDown();
+      }}
+      onMouseUp={() => {
+        handleMouseUp();
+        if (isInVRExperiment) buttonToggleAnimation.handleMouseUp();
+      }}
       onTouchCancel={handleTouchCancel}
       onTouchEnd={handleTouchEnd}
       // @ts-expect-error - TS2322 - Type '(arg1: TouchEvent<HTMLDivElement>) => void' is not assignable to type 'TouchEventHandler<HTMLButtonElement>'.
@@ -284,8 +307,12 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
       onTouchStart={handleTouchStart}
       type="button"
     >
-      <div className={childrenDivClasses} style={compressStyle || undefined}>
-        {renderContent()}
+      <div
+        ref={buttonToggleAnimation.elementRef}
+        className={childrenDivClasses}
+        style={(!isInVRExperiment && compressStyle) || undefined}
+      >
+        {content}
       </div>
     </button>
   );

--- a/packages/gestalt/src/ButtonToggle/ButtonToggleAnimation.css
+++ b/packages/gestalt/src/ButtonToggle/ButtonToggleAnimation.css
@@ -25,3 +25,10 @@
     transform: scale(1);
   }
 }
+
+@media (prefers-reduced-motion) {
+  .tapScaleDown,
+  .tapScaleUp {
+    animation: none;
+  }
+}

--- a/packages/gestalt/src/ButtonToggle/ButtonToggleAnimation.css
+++ b/packages/gestalt/src/ButtonToggle/ButtonToggleAnimation.css
@@ -1,0 +1,27 @@
+.tapScaleDown {
+  animation: scaleDown calc(var(--base-motion-duration-150) / 2)
+    var(--base-motion-easing-linear) forwards;
+}
+
+.tapScaleUp {
+  animation: scaleUp calc(var(--base-motion-duration-150) / 2)
+    var(--base-motion-easing-linear) forwards;
+}
+
+@keyframes scaleDown {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.95);
+  }
+}
+
+@keyframes scaleUp {
+  from {
+    transform: scale(0.95);
+  }
+  to {
+    transform: scale(1);
+  }
+}

--- a/packages/gestalt/src/ButtonToggle/useButtonToggleAnimation.ts
+++ b/packages/gestalt/src/ButtonToggle/useButtonToggleAnimation.ts
@@ -2,6 +2,9 @@ import { useEffect, useRef, useState } from 'react';
 import classnames from 'classnames';
 import styles from './ButtonToggleAnimation.css';
 
+const shouldKeyPressTriggerTap = (event: React.KeyboardEvent): boolean =>
+  ['Space', 'Enter'].includes(event.code);
+
 export default function useButtonToggleAnimation() {
   const elementRef = useRef<HTMLDivElement | null>(null);
   const [animatingScaleDown, setAnimatingScaleDown] = useState(false);
@@ -9,6 +12,8 @@ export default function useButtonToggleAnimation() {
   const [isTapping, setTapping] = useState(false);
 
   const handleMouseDown = () => {
+    if (isTapping) return;
+
     setTapping(true);
     setAnimatingScaleDown(true);
     setAnimatingScaleUp(false);
@@ -18,6 +23,14 @@ export default function useButtonToggleAnimation() {
     setTapping(false);
 
     if (!animatingScaleDown) setAnimatingScaleUp(true);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (shouldKeyPressTriggerTap(event)) handleMouseDown();
+  };
+
+  const handleKeyUp = (event: React.KeyboardEvent) => {
+    if (shouldKeyPressTriggerTap(event)) handleMouseUp();
   };
 
   useEffect(() => {
@@ -45,5 +58,7 @@ export default function useButtonToggleAnimation() {
     classes,
     handleMouseDown,
     handleMouseUp,
+    handleKeyDown,
+    handleKeyUp,
   };
 }

--- a/packages/gestalt/src/ButtonToggle/useButtonToggleAnimation.ts
+++ b/packages/gestalt/src/ButtonToggle/useButtonToggleAnimation.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react';
+import classnames from 'classnames';
+import styles from './ButtonToggleAnimation.css';
+
+export default function useButtonToggleAnimation() {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const [animatingScaleDown, setAnimatingScaleDown] = useState(false);
+  const [animatingScaleUp, setAnimatingScaleUp] = useState(false);
+  const [isTapping, setTapping] = useState(false);
+
+  const handleMouseDown = () => {
+    setTapping(true);
+    setAnimatingScaleDown(true);
+    setAnimatingScaleUp(false);
+  };
+
+  const handleMouseUp = () => {
+    setTapping(false);
+
+    if (!animatingScaleDown) setAnimatingScaleUp(true);
+  };
+
+  useEffect(() => {
+    const element = elementRef.current;
+
+    const handleAnimationEnd = () => {
+      setAnimatingScaleUp(!isTapping && animatingScaleDown);
+      setAnimatingScaleDown(false);
+    };
+
+    element?.addEventListener('animationend', handleAnimationEnd);
+
+    return () => {
+      element?.removeEventListener('animationend', handleAnimationEnd);
+    };
+  }, [animatingScaleDown, isTapping]);
+
+  const classes = classnames({
+    [styles.tapScaleDown]: isTapping || animatingScaleDown,
+    [styles.tapScaleUp]: animatingScaleUp,
+  });
+
+  return {
+    elementRef,
+    classes,
+    handleMouseDown,
+    handleMouseUp,
+  };
+}


### PR DESCRIPTION
### Summary

1. Added click animations to VR ButtonToggle. 
2. `compressStyle` from `useTapFeedback` is not applied.
3. Used CSS animations instead of transitions. Because clicks can happen within milliseconds and transitions may not be noticable (see "before" examples below).

#### What changed?

**BEFORE**
![ezgif-1-7e543f1e09](https://github.com/user-attachments/assets/15612e2e-1d43-48b0-a838-af2528869fd6)
![ezgif-1-ec45a3a6fb](https://github.com/user-attachments/assets/750e3157-2550-446d-9fbc-cbe44bda20e5)


**AFTER**
![ezgif-4-500140c784](https://github.com/user-attachments/assets/0a91ee15-d15a-410c-a179-2df0097c051e)
![ezgif-1-1ce8dc860c](https://github.com/user-attachments/assets/6b3be54c-349a-41c4-aebc-8d759903f682)

#### Why?


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-8275)
- [TDD](https://docs.google.com/document/d/1J6QYhY81mnpZRc0e7wTW7EelUNW7i_u5C8iQsRO6soo/edit?usp=sharing)
- [Figma](https://www.figma.com/design/pMibC8csfCbNMU4jgLVUJh/Motion-Pilot-specs?node-id=2006-82&t=t1XAu3T8peiaefDL-1)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
