### PR TITLE
Fix incorrect values on whitespace logging

### DIFF
--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -731,6 +731,63 @@ describe('multi column layout test cases', () => {
       });
     },
   );
+
+  test.each([
+    // This will be on top row so we expect 0 whitespace
+    [1, 2, [0, 0]],
+    // This will be on second row first column
+    [5, 3, [0, 5, 5]],
+    // This will be on second row first column
+    [5, 4, [35, 40, 40, 0]],
+  ])(
+    'logging function returns whitespace deltas correctly',
+    (multiColumnModuleIndex: number, columnSpan: number, expectedWhitespace: ReadonlyArray<number>) => {
+      const measurementStore = new MeasurementStore<Record<any, any>, number>();
+      const positionCache = new MeasurementStore<Record<any, any>, Position>();
+      const items = [
+        { name: 'Pin 0', height: 105, color: '#E230BA' },
+        { name: 'Pin 1', height: 100, color: '#FAB032' },
+        { name: 'Pin 2', height: 100, color: '#EDF21D' },
+        { name: 'Pin 3', height: 140, color: '#CF4509' },
+        { name: 'Pin 4', height: 180, color: '#230BAF' },
+        { name: 'Pin 5', height: 100, color: '#67076F' },
+        { name: 'Pin 6', height: 100, color: '#AB032E' },
+        { name: 'Pin 7', height: 100, color: '#DF21DC' },
+        { name: 'Pin 8', height: 100, color: '#F45098' },
+        { name: 'Pin 9', height: 100, color: '#F67076' },
+      ];
+
+      const mockItems = [
+        ...items.slice(0, multiColumnModuleIndex),
+        { ...items[multiColumnModuleIndex], columnSpan },
+        ...items.slice(multiColumnModuleIndex + 1),
+      ];
+      mockItems.forEach((item: any) => {
+        measurementStore.set(item, item.height);
+      });
+
+      const logWhitespace = jest.fn();
+
+      const layout = (itemsToLayout: Item[]) =>
+        multiColumnLayout({
+          items: itemsToLayout,
+          gutter: 0,
+          columnWidth: 240,
+          columnCount: 5,
+          centerOffset: 0,
+          measurementCache: measurementStore,
+          positionCache,
+          _getColumnSpanConfig: getColumnSpanConfig,
+          logWhitespace,
+        });
+
+      layout(mockItems);
+
+      expect(logWhitespace.mock.calls).toHaveLength(1);
+      expect(logWhitespace.mock.calls[0][0]).toHaveLength(columnSpan);
+      expect(logWhitespace.mock.calls[0][0]).toStrictEqual(expectedWhitespace);
+    },
+  );
 });
 
 describe('responsive module layout test cases', () => {

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -59,6 +59,16 @@ function calculateActualColumnSpan<T>(props: {
   return Math.min(columnSpan, columnCount);
 }
 
+function getAdjacentWhitespaceOnIndex(
+  heights: ReadonlyArray<number>,
+  columnSpan: number,
+  index: number,
+): ReadonlyArray<number> {
+  const subArray = heights.slice(index, index + columnSpan);
+  const maxHeight = Math.max(...subArray);
+  return subArray.map((h) => maxHeight - h);
+}
+
 function getAdjacentColumnHeightDeltas(
   heights: ReadonlyArray<number>,
   columnSpan: number,
@@ -302,15 +312,18 @@ function getMultiColItemPosition<T>({
   // Increase the heights of both adjacent columns
   const tallestColumnFinalHeight = heights[tallestColumn] + heightAndGutter;
 
+  const additionalWhitespace = getAdjacentWhitespaceOnIndex(
+    heights,
+    columnSpan,
+    lowestAdjacentColumnHeightDeltaIndex,
+  );
+
   for (let i = 0; i < columnSpan; i += 1) {
     heights[i + lowestAdjacentColumnHeightDeltaIndex] = tallestColumnFinalHeight;
   }
 
   return {
-    additionalWhitespace: adjacentColumnHeightDeltas.slice(
-      lowestAdjacentColumnHeightDeltaIndex,
-      lowestAdjacentColumnHeightDeltaIndex + columnSpan - 1,
-    ),
+    additionalWhitespace,
     heights,
     position: {
       top,


### PR DESCRIPTION
### Summary

In a previous [PR](https://github.com/pinterest/gestalt/pull/3727), we changed the whitespace logging from one number to an array that has the whitespace for each column. But with some tests we found that this number was actually not for each column but just the average. This PR fixes that returning a number for each column comparing it to the column that has the biggest value.

- Added unit test