### PR TITLE
Accordion, Badge, Icon, Text, Tooltip: Adding data test id

### DIFF
--- a/packages/gestalt/src/Accordion.test.tsx
+++ b/packages/gestalt/src/Accordion.test.tsx
@@ -87,4 +87,49 @@ describe('Accordion', () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test('validate data test id for icon', () => {
+    const component = renderer.create(
+      <Accordion
+        dataTestId="test-accordion"
+        icon="lock"
+        iconAccessibilityLabel="there is an error"
+        id="accordion-test"
+        title="Testing"
+        type="error"
+      >
+        <Text>Testing</Text>
+      </Accordion>,
+    ).root;
+    expect(
+      component
+        .findAll((element) => element.type === 'svg')
+        .filter((node) => node.props['data-test-id'] === 'test-accordion-icon'),
+    ).toHaveLength(1);
+    expect(
+      component
+        .findAll((element) => element.type === 'div')
+        .filter((node) => node.props['data-test-id'] === 'test-accordion-text'),
+    ).toHaveLength(1);
+  });
+
+  test('validate data test id for badge', () => {
+    const component = renderer.create(
+      <Accordion
+        badge={{text: 'New', type: 'info'}}
+        dataTestId="test-accordion"
+        id="accordion-test"
+        title="Testing"
+        type="error"
+      >
+        <Text>Testing</Text>
+      </Accordion>,
+    ).root;
+    expect(
+      component
+        .findAll((element) => element.type === 'span')
+        .filter((node) => node.props['data-test-id'] === 'test-accordion-badge-text'),
+    ).toHaveLength(1);
+  });
+
 });

--- a/packages/gestalt/src/Accordion.test.tsx
+++ b/packages/gestalt/src/Accordion.test.tsx
@@ -116,7 +116,7 @@ describe('Accordion', () => {
   test('validate data test id for badge', () => {
     const component = renderer.create(
       <Accordion
-        badge={{text: 'New', type: 'info'}}
+        badge={{ text: 'New', type: 'info' }}
         dataTestId="test-accordion"
         id="accordion-test"
         title="Testing"
@@ -131,5 +131,4 @@ describe('Accordion', () => {
         .filter((node) => node.props['data-test-id'] === 'test-accordion-badge-text'),
     ).toHaveLength(1);
   });
-
 });

--- a/packages/gestalt/src/Accordion.tsx
+++ b/packages/gestalt/src/Accordion.tsx
@@ -34,6 +34,10 @@ type Props = {
    */
   children?: ReactNode;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Name of icon to display in front of title. Will not be displayed if `title` is not provided. Not to be used with `badge` or `iconButton`. For a full list of icons, see [Iconography and SVGs](https://gestalt.pinterest.systems/foundations/iconography/library#Search-icon-library). See the [icon variant](https://gestalt.pinterest.systems/web/accordion#Static-Icon) for more details.
    */
   icon?: keyof typeof icons;
@@ -74,6 +78,7 @@ export default function Accordion({
   badge,
   borderStyle = 'shadow',
   children,
+  dataTestId,
   icon,
   iconAccessibilityLabel,
   iconButton,
@@ -99,6 +104,7 @@ export default function Accordion({
         {title && (
           <AccordionTitle
             badge={badge}
+            dataTestId={dataTestId}
             icon={icon}
             iconAccessibilityLabel={iconAccessibilityLabel}
             iconButton={iconButton}

--- a/packages/gestalt/src/Accordion/Title.tsx
+++ b/packages/gestalt/src/Accordion/Title.tsx
@@ -68,7 +68,11 @@ export default function AccordionTitle(props: {
       {decoration === 'badge' && props.badge && (
         <Flex.Item minWidth={0}>
           <Box dangerouslySetInlineStyle={{ __style: { top: '1px' } }} position="relative">
-            <Badge dataTestId={dataTestIdBadge} text={props.badge.text} type={props.badge.type || 'info'} />
+            <Badge
+              dataTestId={dataTestIdBadge}
+              text={props.badge.text}
+              type={props.badge.type || 'info'}
+            />
           </Box>
         </Flex.Item>
       )}

--- a/packages/gestalt/src/Accordion/Title.tsx
+++ b/packages/gestalt/src/Accordion/Title.tsx
@@ -22,6 +22,7 @@ export type BadgeType = {
 
 export default function AccordionTitle(props: {
   badge?: BadgeType;
+  dataTestId?: string;
   icon?: keyof typeof icons;
   iconAccessibilityLabel?: string;
   iconButton?: ReactElement;
@@ -29,6 +30,10 @@ export default function AccordionTitle(props: {
   type?: 'error' | 'info';
   size?: 'sm' | 'md' | 'lg';
 }) {
+  const { dataTestId } = props;
+  const dataTestIdIcon = dataTestId && `${dataTestId}-icon`;
+  const dataTestIdText = dataTestId && `${dataTestId}-text`;
+  const dataTestIdBadge = dataTestId && `${dataTestId}-badge`;
   const { iconAccessibilityLabel = '', title, type = 'info', size = 'lg' } = props;
 
   // @ts-expect-error - TS7053 - Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{ badge?: BadgeType | undefined; icon?: "replace" | "search" | "link" | "text" | "dash" | "3D" | "3D-move" | "360" | "accessibility" | "ad" | "ad-group" | "add" | "add-circle" | ... 321 more ... | undefined; ... 4 more ...; size?: "sm" | ... 2 more ... | undefined; }'.
@@ -46,6 +51,7 @@ export default function AccordionTitle(props: {
           <Icon
             accessibilityLabel={iconAccessibilityLabel}
             color={textAndIconColor}
+            dataTestId={dataTestIdIcon}
             icon={hasError ? 'workflow-status-problem' : props.icon}
           />
         </Flex.Item>
@@ -53,7 +59,7 @@ export default function AccordionTitle(props: {
 
       {title && (
         <Flex.Item minWidth={0}>
-          <Text color={textAndIconColor} lineClamp={1} weight="bold">
+          <Text color={textAndIconColor} dataTestId={dataTestIdText} lineClamp={1} weight="bold">
             {title}
           </Text>
         </Flex.Item>
@@ -62,7 +68,7 @@ export default function AccordionTitle(props: {
       {decoration === 'badge' && props.badge && (
         <Flex.Item minWidth={0}>
           <Box dangerouslySetInlineStyle={{ __style: { top: '1px' } }} position="relative">
-            <Badge text={props.badge.text} type={props.badge.type || 'info'} />
+            <Badge dataTestId={dataTestIdBadge} text={props.badge.text} type={props.badge.type || 'info'} />
           </Box>
         </Flex.Item>
       )}

--- a/packages/gestalt/src/Badge.test.tsx
+++ b/packages/gestalt/src/Badge.test.tsx
@@ -20,3 +20,14 @@ it('should render with a wash', () => {
 
   expect(className).toContain('lightWash');
 });
+
+it('validate data test id for badge', () => {
+  const component = create(
+    <Badge dataTestId='test-badge' text='New' type='info' />
+  ).root;
+  expect(
+    component
+      .findAll((element) => element.type === 'span')
+      .filter((node) => node.props['data-test-id'] === 'test-badge-text'),
+  ).toHaveLength(1);
+});

--- a/packages/gestalt/src/Badge.test.tsx
+++ b/packages/gestalt/src/Badge.test.tsx
@@ -22,9 +22,7 @@ it('should render with a wash', () => {
 });
 
 it('validate data test id for badge', () => {
-  const component = create(
-    <Badge dataTestId='test-badge' text='New' type='info' />
-  ).root;
+  const component = create(<Badge dataTestId="test-badge" text="New" type="info" />).root;
   expect(
     component
       .findAll((element) => element.type === 'span')

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -71,7 +71,13 @@ type Props = {
  * ![Badge dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Badge-dark.spec.ts-snapshots/Badge-dark-chromium-darwin.png)
  *
  */
-export default function Badge({ dataTestId, position = 'middle', text, type = 'info', tooltip }: Props) {
+export default function Badge({
+  dataTestId,
+  position = 'middle',
+  text,
+  type = 'info',
+  tooltip,
+}: Props) {
   const isInVRExperiment = useInExperiment({
     webExperimentName: 'web_gestalt_visualRefresh',
     mwebExperimentName: 'web_gestalt_visualRefresh',

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -78,6 +78,7 @@ export default function Badge({ dataTestId, position = 'middle', text, type = 'i
   });
   const dataTestIdIcon = dataTestId && `${dataTestId}-icon`;
   const dataTestIdText = dataTestId && `${dataTestId}-text`;
+  const dataTestIdTooltip = dataTestId && `${dataTestId}-tooltip`;
 
   const { isFocusVisible } = useFocusVisible();
 
@@ -175,6 +176,7 @@ export default function Badge({ dataTestId, position = 'middle', text, type = 'i
   return shouldUseTooltip ? (
     <Tooltip
       accessibilityLabel=""
+      dataTestId={dataTestIdTooltip}
       idealDirection={tooltip.idealDirection}
       inline
       text={tooltip.text}

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -43,6 +43,10 @@ type InteractiveTypeOptions =
 
 type Props = {
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Badge position relative to its parent element. See the [positioning](https://gestalt.pinterest.systems/web/badge#Positioning) variant to learn more.
    */
   position?: Position;
@@ -67,11 +71,14 @@ type Props = {
  * ![Badge dark mode](https://raw.githubusercontent.com/pinterest/gestalt/master/playwright/visual-test/Badge-dark.spec.ts-snapshots/Badge-dark-chromium-darwin.png)
  *
  */
-export default function Badge({ position = 'middle', text, type = 'info', tooltip }: Props) {
+export default function Badge({ dataTestId, position = 'middle', text, type = 'info', tooltip }: Props) {
   const isInVRExperiment = useInExperiment({
     webExperimentName: 'web_gestalt_visualRefresh',
     mwebExperimentName: 'web_gestalt_visualRefresh',
   });
+  const dataTestIdIcon = dataTestId && `${dataTestId}-icon`;
+  const dataTestIdText = dataTestId && `${dataTestId}-text`;
+
   const { isFocusVisible } = useFocusVisible();
 
   const shouldUseTooltip = tooltip?.text;
@@ -144,6 +151,7 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
           <Icon
             accessibilityLabel=""
             color={isInVRExperiment || type.endsWith('Wash') ? COLOR_ICON_MAP[type] : 'inverse'}
+            dataTestId={dataTestIdIcon}
             icon={ICON_MAP[type] as ComponentProps<typeof Icon>['icon']}
             inline
             size={isInVRExperiment ? '12' : '14'}
@@ -153,6 +161,7 @@ export default function Badge({ position = 'middle', text, type = 'info', toolti
       <Box alignContent="center" display="flex">
         <Text
           color={isInVRExperiment || type.endsWith('Wash') ? COLOR_TEXT_MAP[type] : 'inverse'}
+          dataTestId={dataTestIdText}
           inline
           size="200"
           weight={isInVRExperiment ? 'normal' : 'bold'}

--- a/packages/gestalt/src/Icon.test.tsx
+++ b/packages/gestalt/src/Icon.test.tsx
@@ -25,7 +25,7 @@ test('Icon flipped if its in the flip on rtl list', () => {
 
 test('validate data test id for text', () => {
   const component = create(
-      <Icon accessibilityLabel="send" dataTestId='test-icon' icon="send" />,
+    <Icon accessibilityLabel="send" dataTestId="test-icon" icon="send" />,
   ).root;
   expect(
     component

--- a/packages/gestalt/src/Icon.test.tsx
+++ b/packages/gestalt/src/Icon.test.tsx
@@ -22,3 +22,14 @@ test('Icon flipped if its in the flip on rtl list', () => {
   const tree = create(<Icon accessibilityLabel="send" icon="send" />).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('validate data test id for text', () => {
+  const component = create(
+      <Icon accessibilityLabel="send" dataTestId='test-icon' icon="send" />,
+  ).root;
+  expect(
+    component
+      .findAll((element) => element.type === 'svg')
+      .filter((node) => node.props['data-test-id'] === 'test-icon'),
+  ).toHaveLength(1);
+});

--- a/packages/gestalt/src/Icon.tsx
+++ b/packages/gestalt/src/Icon.tsx
@@ -33,6 +33,10 @@ type Props = {
    */
   color?: IconColor;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * SVG icon from the Gestalt icon library to use within Icon.
    *
    * See the [icon library](https://gestalt.pinterest.systems/foundations/iconography/library) to explore available options.
@@ -101,6 +105,7 @@ function Icon({
   accessibilityLabel,
   color = 'subtle',
   dangerouslySetSvgPath,
+  dataTestId,
   icon,
   inline = false,
   size = 16,
@@ -130,6 +135,7 @@ function Icon({
       aria-hidden={ariaHidden}
       aria-label={accessibilityLabel}
       className={cs}
+      data-test-id={dataTestId}
       height={size}
       role="img"
       viewBox="0 0 24 24"

--- a/packages/gestalt/src/Text.test.tsx
+++ b/packages/gestalt/src/Text.test.tsx
@@ -39,9 +39,7 @@ test('Text lineClamp should not add a title when the children are objects', () =
 });
 
 test('validate data test id for text', () => {
-  const component = create(
-      <Text dataTestId="test-text">Testing</Text>,
-  ).root;
+  const component = create(<Text dataTestId="test-text">Testing</Text>).root;
   expect(
     component
       .findAll((element) => element.type === 'div')

--- a/packages/gestalt/src/Text.test.tsx
+++ b/packages/gestalt/src/Text.test.tsx
@@ -37,3 +37,14 @@ test('Text lineClamp should not add a title when the children are objects', () =
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });
+
+test('validate data test id for text', () => {
+  const component = create(
+      <Text dataTestId="test-text">Testing</Text>,
+  ).root;
+  expect(
+    component
+      .findAll((element) => element.type === 'div')
+      .filter((node) => node.props['data-test-id'] === 'test-text'),
+  ).toHaveLength(1);
+});

--- a/packages/gestalt/src/Text.tsx
+++ b/packages/gestalt/src/Text.tsx
@@ -38,6 +38,10 @@ type Props = {
     | 'light'
     | 'dark';
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Indicates how the text should flow with the surrounding content. See the [block vs inline variant](https://gestalt.pinterest.systems/web/text#Block-vs.-inline) for more details.
    */
   inline?: boolean;
@@ -86,6 +90,7 @@ const TextWithForwardRef = forwardRef<HTMLDivElement, Props>(function Text(
     align = 'start',
     children,
     color = 'default',
+    dataTestId,
     inline = false,
     italic = false,
     lineClamp,
@@ -137,6 +142,7 @@ const TextWithForwardRef = forwardRef<HTMLDivElement, Props>(function Text(
   return (
     <Tag
       className={cs}
+      data-test-id={dataTestId}
       title={
         title ?? (isNotNullish(lineClamp) && typeof children === 'string' ? children : undefined)
       }

--- a/packages/gestalt/src/Tooltip.jsdom.test.tsx
+++ b/packages/gestalt/src/Tooltip.jsdom.test.tsx
@@ -101,3 +101,16 @@ test('Tooltip renders with zIndex', () => {
   expect(layer && getComputedStyle(layer).zIndex).toEqual('100');
   expect(body && body.contains(screen.getByText('This is a tooltip'))).toBe(true);
 });
+
+test('validate data test id for icon', () => {
+  const component = create(
+    <Tooltip dataTestId='test-tooltip' text="This is a tooltip">
+      <div>Hi</div>
+    </Tooltip>,
+  ).root;
+  expect(
+    component
+      .findAll((element) => element.type === 'div')
+      .filter((node) => node.props['data-test-id'] === 'test-tooltip'),
+  ).toHaveLength(1);
+});

--- a/packages/gestalt/src/Tooltip.jsdom.test.tsx
+++ b/packages/gestalt/src/Tooltip.jsdom.test.tsx
@@ -104,7 +104,7 @@ test('Tooltip renders with zIndex', () => {
 
 test('validate data test id for icon', () => {
   const component = create(
-    <Tooltip dataTestId='test-tooltip' text="This is a tooltip">
+    <Tooltip dataTestId="test-tooltip" text="This is a tooltip">
       <div>Hi</div>
     </Tooltip>,
   ).root;

--- a/packages/gestalt/src/Tooltip.tsx
+++ b/packages/gestalt/src/Tooltip.tsx
@@ -12,6 +12,10 @@ type Props = {
    */
   children: ReactNode;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Specifies the preferred position of Tooltip relative to its anchor element. See the [ideal direction](https://gestalt.pinterest.systems/web/tooltip#Ideal-direction) variant to learn more.
    */
   idealDirection?: 'up' | 'right' | 'down' | 'left';
@@ -44,6 +48,7 @@ type Props = {
 export default function Tooltip({
   accessibilityLabel,
   children,
+  dataTestId,
   link,
   idealDirection = 'down',
   inline,
@@ -53,6 +58,7 @@ export default function Tooltip({
   return (
     <InternalTooltip
       accessibilityLabel={accessibilityLabel}
+      dataTestId={dataTestId}
       idealDirection={idealDirection}
       inline={inline}
       link={link}

--- a/packages/gestalt/src/Tooltip/InternalTooltip.tsx
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.tsx
@@ -56,6 +56,7 @@ const reducer = (
 type Props = {
   accessibilityLabel?: string;
   children?: ReactNode;
+  dataTestId?: string;
   /**
    * Whether to show the tooltip or not
    */
@@ -70,6 +71,7 @@ type Props = {
 export default function InternalTooltip({
   accessibilityLabel,
   children,
+  dataTestId,
   disabled,
   link,
   idealDirection,
@@ -166,7 +168,7 @@ export default function InternalTooltip({
               padding={2}
               tabIndex={0}
             >
-              <Text color="inverse" size="100">
+              <Text color="inverse" dataTestId={dataTestId} size="100">
                 {getTooltipText()}
               </Text>
 

--- a/packages/gestalt/src/Tooltip/InternalTooltip.tsx
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.tsx
@@ -129,6 +129,7 @@ export default function InternalTooltip({
   };
 
   const accessibilityLabelFallback = typeof text === 'string' ? text : text.join('');
+  const dataTestIdText = dataTestId && `${dataTestId}-text`;
 
   return (
     <Box display={inline ? 'inlineBlock' : 'block'}>
@@ -169,7 +170,7 @@ export default function InternalTooltip({
               padding={2}
               tabIndex={0}
             >
-              <Text color="inverse" dataTestId={dataTestId} size="100">
+              <Text color="inverse" dataTestId={dataTestIdText} size="100">
                 {getTooltipText()}
               </Text>
 

--- a/packages/gestalt/src/Tooltip/InternalTooltip.tsx
+++ b/packages/gestalt/src/Tooltip/InternalTooltip.tsx
@@ -137,6 +137,7 @@ export default function InternalTooltip({
         aria-label={
           accessibilityLabel != null && !disabled ? accessibilityLabel : accessibilityLabelFallback
         }
+        data-test-id={dataTestId}
         onBlur={handleIconMouseLeave}
         onFocus={handleIconMouseEnter}
         onMouseEnter={handleIconMouseEnter}


### PR DESCRIPTION
### Summary
Adding data test id for Accordion, Badge, Icon, Tooltip and Text Gestalt components
#### What changed?
New prop dataTestId for Accordion and its sub components Gestalt components
At a high level, what changes does this PR introduce?
Adding a new prop for some Gestalt components
#### Why?
To improve integration testing speed and accuracy

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [x] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
