### PR TITLE
Masonry: Ensure zero height items dont have a gutter

### DIFF
--- a/packages/gestalt/src/Masonry/defaultLayout.test.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.ts
@@ -246,6 +246,44 @@ describe.each([undefined, getColumnSpanConfig])('default layout tests', (_getCol
       { top: 0, left: 600, width: 100, height: 100 },
     ]);
   });
+
+  test('correctly positions items with no height', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100 },
+      { 'name': 'Pin 1', 'height': 120 },
+      { 'name': 'Pin 2', 'height': 0 },
+      { 'name': 'Pin 3', 'height': 100 },
+      { 'name': 'Pin 4', 'height': 100 },
+      { 'name': 'Pin 5', 'height': 120 },
+      { 'name': 'Pin 6', 'height': 80 },
+      { 'name': 'Pin 7', 'height': 100 },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultLayout({
+      align: 'end',
+      measurementCache: measurementStore,
+      positionCache,
+      layout: 'basic',
+      minCols: 2,
+      rawItemCount: items.length,
+      width: 1000,
+      _getColumnSpanConfig,
+    });
+
+    const positions = layout(items);
+    const pin2Position = positions[2];
+    const pin3Position = positions[3];
+
+    expect(pin2Position.height).toBe(0);
+    expect(pin2Position.top).toBe(0);
+    expect(pin3Position.top).toBe(0);
+    expect(pin2Position.left).toBe(pin3Position.left);
+  });
 });
 
 describe('loadingStateItems', () => {

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -1,5 +1,5 @@
 import { Cache } from './Cache';
-import { getHeightAndGutter,offscreen } from './layoutHelpers';
+import { getHeightAndGutter, offscreen } from './layoutHelpers';
 import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -1,15 +1,9 @@
 import { Cache } from './Cache';
+import { getHeightAndGutter,offscreen } from './layoutHelpers';
 import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { Align, Layout, LoadingStateItem, Position } from './types';
-
-const offscreen = (width: number, height: number = Infinity) => ({
-  top: -9999,
-  left: -9999,
-  width,
-  height,
-});
 
 const calculateCenterOffset = ({
   align,
@@ -111,7 +105,7 @@ const defaultLayout =
           if (height == null) {
             position = offscreen(columnWidth);
           } else {
-            const heightAndGutter = height + gutter;
+            const heightAndGutter = getHeightAndGutter(height, gutter);
             const col = mindex(heights);
             const top = heights[col];
             const left = col * columnWidthAndGutter + centerOffset;

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -76,6 +76,43 @@ describe.each([undefined, getColumnSpanConfig])(
           .map((position) => position.top),
       ).toEqual([90, 110, 110, 130]);
     });
+
+    test('correctly positions items with no height', () => {
+      const measurementStore = new MeasurementStore<Record<any, any>, number>();
+      const positionCache = new MeasurementStore<Record<any, any>, Position>();
+      const items: ReadonlyArray<Item> = [
+        { 'name': 'Pin 0', 'height': 100 },
+        { 'name': 'Pin 1', 'height': 120 },
+        { 'name': 'Pin 2', 'height': 0 },
+        { 'name': 'Pin 3', 'height': 100 },
+        { 'name': 'Pin 4', 'height': 100 },
+        { 'name': 'Pin 5', 'height': 120 },
+        { 'name': 'Pin 6', 'height': 80 },
+        { 'name': 'Pin 7', 'height': 100 },
+      ];
+      items.forEach((item: any) => {
+        measurementStore.set(item, item.height);
+      });
+
+      const layout = fullWidthLayout({
+        measurementCache: measurementStore,
+        positionCache,
+        gutter: 10,
+        idealColumnWidth: 240,
+        minCols: 2,
+        width: 1000,
+        _getColumnSpanConfig,
+      });
+
+      const positions = layout(items);
+      const pin2Position = positions[2];
+      const pin3Position = positions[3];
+
+      expect(pin2Position.height).toBe(0);
+      expect(pin2Position.top).toBe(0);
+      expect(pin3Position.top).toBe(0);
+      expect(pin2Position.left).toBe(pin3Position.left);
+    });
   },
 );
 

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -1,4 +1,5 @@
 import { Cache } from './Cache';
+import { getHeightAndGutter } from './layoutHelpers';
 import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
@@ -72,11 +73,12 @@ const fullWidthLayout = <T>({
               height: Infinity,
             };
           } else {
+            const heightAndGutter = getHeightAndGutter(height, gutter);
             const col = mindex(heights);
             const top = heights[col];
             const left = col * columnWidthAndGutter + centerOffset;
 
-            heights[col] += height + gutter;
+            heights[col] += heightAndGutter;
             position = {
               top,
               left,

--- a/packages/gestalt/src/Masonry/layoutHelpers.ts
+++ b/packages/gestalt/src/Masonry/layoutHelpers.ts
@@ -1,0 +1,12 @@
+export function getHeightAndGutter(height: number, gutter: number) {
+  return height > 0 ? height + gutter : 0;
+}
+
+export function offscreen(width: number, height = Infinity) {
+  return {
+    top: -9999,
+    left: -9999,
+    width,
+    height,
+  };
+}

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -79,6 +79,40 @@ describe('one column layout test cases', () => {
       { top: 134, height: 100, left: 250, width: 236 },
     ]);
   });
+
+  test('correctly positions items with no height', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100 },
+      { 'name': 'Pin 1', 'height': 120 },
+      { 'name': 'Pin 2', 'height': 0 },
+      { 'name': 'Pin 3', 'height': 100 },
+      { 'name': 'Pin 4', 'height': 100 },
+      { 'name': 'Pin 5', 'height': 120 },
+      { 'name': 'Pin 6', 'height': 80 },
+      { 'name': 'Pin 7', 'height': 100 },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const positions = multiColumnLayout({
+      items,
+      columnCount: 4,
+      measurementCache: measurementStore,
+      positionCache,
+      _getColumnSpanConfig: getColumnSpanConfig,
+    });
+
+    const pin2Position = positions[2];
+    const pin3Position = positions[3];
+
+    expect(pin2Position.height).toBe(0);
+    expect(pin2Position.top).toBe(0);
+    expect(pin3Position.top).toBe(0);
+    expect(pin2Position.left).toBe(pin3Position.left);
+  });
 });
 
 describe('multi column layout test cases', () => {

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -1,5 +1,6 @@
 import { Cache } from './Cache';
 import Graph from './Graph';
+import { getHeightAndGutter,offscreen } from './layoutHelpers';
 import mindex from './mindex';
 import { NodeData, Position } from './types';
 
@@ -28,13 +29,6 @@ export function columnCountToGridSize(columnCount: number): GridSize {
   }
   return 'xl';
 }
-
-const offscreen = (width: number, height: number = Infinity) => ({
-  top: -9999,
-  left: -9999,
-  width,
-  height,
-});
 
 function getPositionsOnly<T>(
   positions: ReadonlyArray<{
@@ -223,7 +217,7 @@ function getOneColumnItemPositions<T>({
       }
 
       if (height != null) {
-        const heightAndGutter = height + gutter;
+        const heightAndGutter = getHeightAndGutter(height, gutter);
         const col = mindex(heights);
         const top = heights[col];
         const left = col * columnWidthAndGutter + centerOffset;
@@ -288,7 +282,7 @@ function getMultiColItemPosition<T>({
     };
   }
 
-  const heightAndGutter = height + gutter;
+  const heightAndGutter = getHeightAndGutter(height, gutter);
 
   // Find height deltas for each column as compared to the next column
   const adjacentColumnHeightDeltas = getAdjacentColumnHeightDeltas(heights, columnSpan);

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -1,6 +1,6 @@
 import { Cache } from './Cache';
 import Graph from './Graph';
-import { getHeightAndGutter,offscreen } from './layoutHelpers';
+import { getHeightAndGutter, offscreen } from './layoutHelpers';
 import mindex from './mindex';
 import { NodeData, Position } from './types';
 


### PR DESCRIPTION
### Summary
This PR updates Masonry to ensure that items with zero height do not actually occupy any space

At the moment, if Masonry renders a component with zero height (i.e. an item that returns `null`), it could still end up occupying space since we still add the `gutter` to the position. This results in subsequent items in the column being pushed down.

<img width="877" alt="image" src="https://github.com/user-attachments/assets/d853520b-e141-44cf-ad8c-0255a3d40a81">

This PR addresses this by updating the `heightAndGutter` logic to only return height + gutter if height > 0. I also took the opportunity to clean up the code a tad
