### PR TITLE
Sticky: Updating Types to avoid Prop Issues

### DIFF
--- a/packages/gestalt/src/Sticky.tsx
+++ b/packages/gestalt/src/Sticky.tsx
@@ -7,21 +7,37 @@ type PositionType = number | string;
 type Threshold =
   | {
       top: PositionType;
+      bottom?: never;
+      left?: never;
+      right?: never;
     }
   | {
+      top?: never;
       bottom: PositionType;
+      left?: never;
+      right?: never;
     }
   | {
+      top?: never;
+      bottom?: never;
       left: PositionType;
+      right?: never;
     }
   | {
+      top?: never;
+      bottom?: never;
+      left?: never;
       right: PositionType;
     }
   | {
       top: PositionType;
       bottom: PositionType;
+      left?: never;
+      right?: never;
     }
   | {
+      top?: never;
+      bottom?: never;
       left: PositionType;
       right: PositionType;
     }
@@ -55,19 +71,7 @@ const DEFAULT_ZINDEX = new FixedZIndex(1);
  * ![Sticky](https://raw.githubusercontent.com/pinterest/gestalt/master/docs/graphics/building-blocks/Sticky.svg)
  */
 
-export default function Sticky({
-  // @ts-expect-error - TS2339 - Property 'bottom' does not exist on type 'Props'.
-  bottom,
-  children,
-  height,
-  // @ts-expect-error - TS2339 - Property 'left' does not exist on type 'Props'.
-  left,
-  // @ts-expect-error - TS2339 - Property 'right' does not exist on type 'Props'.
-  right,
-  // @ts-expect-error - TS2339 - Property 'top' does not exist on type 'Props'.
-  top,
-  zIndex,
-}: Props) {
+export default function Sticky({ bottom, children, height, left, right, top, zIndex }: Props) {
   const style = {
     ...(height !== undefined ? { height } : {}),
     top: top != null ? top : undefined,


### PR DESCRIPTION
# Pull Request Instructions

### Summary

We've gotten flagged for the following issue:
```
./node_modules/.pnpm/gestalt@159.0.0_react-dom@18.3.1+react@18.3.1/node_modules/gestalt/dist/Sticky.d.ts:43:27
Type error: Property 'bottom' does not exist on type 'Props'.
```

This is causing issues with ITP upgrades. It seems like we have TS suppressions to overcome this. This replaces the missing type options with a `never` and always ensures the property type is defined.

#### What changed?

Adding missing types for properties that previously were unset.

#### Why?
ITP and other TS repos are unable to upgrade

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
