### PR TITLE
Internal: Upgrade TypeScript to 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "stylelint-config-standard": "^23.0.0",
     "stylelint-order": "^5.0.0",
     "sucrase": "^3.35.0",
-    "typescript": "5.5.2",
+    "typescript": "5.6.2",
     "typescript-plugin-css-modules": "^5.1.0",
     "xml2js": "^0.5.0"
   },

--- a/packages/gestalt/src/AvatarGroup/PositioningWrapper.tsx
+++ b/packages/gestalt/src/AvatarGroup/PositioningWrapper.tsx
@@ -15,11 +15,13 @@ export default function PositioningWrapper({ size, pileCount, index, children }:
 
   const isFitSize = size === 'fit';
 
-  let marginStart = index === 0 ? '0px' : `${(-1 * Number(SIZE_MAP[size]) ?? 0) / 3}px`;
+  let marginStart: string;
 
   if (isFitSize) {
     // Each avatar superposes a third of the previous one. Each avatar equals 3/3 parts. Two avatars are 5/5, each of them being 3/5 parts of the whole sharing a 1/5 overlapping part, and so forth. To provide a perfect-pixel positioning on any responsive size, we use the 2/3 part on each index position to place the next superposed avatar.
     marginStart = `${((2 * index) / FIT_SIZING_DENOMINATOR) * 100}%`;
+  } else {
+    marginStart = index === 0 ? '0px' : `${(-1 * SIZE_MAP[size]) / 3}px`;
   }
 
   // To provide a perfect-pixel width for each responsive avatar, we use the ratio of 3 parts of the total parts of the whole AvatarGroup. A 4-avatar component has 9 total parts, and each avatar's witdh is 3/9 of the total width.

--- a/yarn.lock
+++ b/yarn.lock
@@ -20002,10 +20002,10 @@ typescript-plugin-css-modules@^5.1.0:
     stylus "^0.62.0"
     tsconfig-paths "^4.2.0"
 
-typescript@5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.2.tgz#c26f023cb0054e657ce04f72583ea2d85f8d0507"
-  integrity sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==
+typescript@5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
+  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
 typescript@^3.9.10:
   version "3.9.10"


### PR DESCRIPTION
## What changed?

Upgrade TypeScript from v5.5 to v5.6.

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/ for the v5.6 release notes.

See also the previous v5.5 upgrade PR: https://github.com/pinterest/gestalt/pull/3643

## Why?

Stay current
