### PR TITLE
Badge: adopted TextUI

### DIFF
--- a/packages/gestalt/src/Accordion/__snapshots__/ExpandableItem.test.tsx.snap
+++ b/packages/gestalt/src/Accordion/__snapshots__/ExpandableItem.test.tsx.snap
@@ -167,7 +167,7 @@ exports[`AccordionExpandableItem renders correctly with badge 1`] = `
                             className="box contentCenter xsDisplayFlex"
                           >
                             <span
-                              className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                              className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                             >
                               Try it out!
                             </span>

--- a/packages/gestalt/src/Badge.tsx
+++ b/packages/gestalt/src/Badge.tsx
@@ -5,7 +5,7 @@ import Box from './Box';
 import Flex from './Flex';
 import Icon from './Icon';
 import TapArea from './TapArea';
-import Text from './Text';
+import TextUI from './TextUI';
 import Tooltip from './Tooltip';
 import useFocusVisible from './useFocusVisible';
 import useInExperiment from './useInExperiment';
@@ -166,15 +166,14 @@ export default function Badge({
         </Box>
       ) : null}
       <Box alignContent="center" display="flex">
-        <Text
+        <TextUI
           color={isInVRExperiment || type.endsWith('Wash') ? COLOR_TEXT_MAP[type] : 'inverse'}
           dataTestId={dataTestIdText}
           inline
-          size="200"
-          weight={isInVRExperiment ? 'normal' : 'bold'}
+          size="sm"
         >
           {text}
-        </Text>
+        </TextUI>
       </Box>
     </Flex>
   );

--- a/packages/gestalt/src/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Accordion.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Accordion renders a badge correctly 1`] = `
                     className="box contentCenter xsDisplayFlex"
                   >
                     <span
-                      className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                      className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                     >
                       Try it out!
                     </span>

--- a/packages/gestalt/src/__snapshots__/Badge.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Badge.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Badge renders 1`] = `
         className="box contentCenter xsDisplayFlex"
       >
         <span
-          className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+          className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
         >
           Badge
         </span>

--- a/packages/gestalt/src/__snapshots__/Datapoint.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Datapoint.test.tsx.snap
@@ -162,7 +162,7 @@ exports[`Datapoint renders a badge 1`] = `
                 className="box contentCenter xsDisplayFlex"
               >
                 <span
-                  className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                  className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                 >
                   Early access
                 </span>

--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.tsx.snap
@@ -790,7 +790,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                                   class="box contentCenter xsDisplayFlex"
                                 >
                                   <span
-                                    class="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                                    class="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                                   >
                                     New
                                   </span>
@@ -869,7 +869,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                                     class="box contentCenter xsDisplayFlex"
                                   >
                                     <span
-                                      class="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                                      class="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                                     >
                                       New
                                     </span>

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.tsx.snap
@@ -227,7 +227,7 @@ exports[`PageHeader renders badge with type 1`] = `
                                     className="box contentCenter xsDisplayFlex"
                                   >
                                     <span
-                                      className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                                      className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                                     >
                                       Needs attention
                                     </span>

--- a/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/SideNavigation.test.tsx.snap
@@ -370,7 +370,7 @@ exports[`SideNavigation renders Icon + Badge/Notification + Counter + Border 1`]
                                           className="box contentCenter xsDisplayFlex"
                                         >
                                           <span
-                                            className="inverse alignStart breakWord Text fontSize200 fontWeightSemiBold"
+                                            className="inverse alignStart breakWord Text fontWeightSemiBold fontSize200"
                                           >
                                             New
                                           </span>


### PR DESCRIPTION
Badge: adopted TextUI 

|   |  before | after  |
|---|---|---|
| classic  |  ![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/44550241-de22-4a99-a69b-8874d77d30b7) |  ![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/c9a220a0-f02f-4dcf-9bc5-5debac940441) |
|  VR  |  ![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/a6ab1adb-d23d-4335-bec4-93a794e967d4)  |   ![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/2c8bfa82-939a-41ce-a62b-6e53684fda09) |
