### PR TITLE
Internal: Improve index access type safety with `noUncheckedIndexedAccess`

### DIFF
--- a/docs/docs-components/GeneratedPropTable.tsx
+++ b/docs/docs-components/GeneratedPropTable.tsx
@@ -68,11 +68,8 @@ export default function GeneratedPropTable({
   id,
   name,
 }: Props) {
-  // Using Object.keys because of https://github.com/facebook/flow/issues/2174
-  const props = Object.keys(generatedDocGen.props)
-    .map((key: string) => {
-      const { tsType, description, required, defaultValue } = generatedDocGen.props[key];
-
+  const props = Object.entries(generatedDocGen.props)
+    .map(([key, { tsType, description, required, defaultValue }]) => {
       // Filter out "_fooInternalProp" internal props that we don't want to document
       if (key.startsWith('_')) {
         return null;

--- a/docs/docs-components/Overview.tsx
+++ b/docs/docs-components/Overview.tsx
@@ -32,6 +32,9 @@ const categoryOrder: ReadonlyArray<ComponentCategory> = [
   'Utilities',
 ];
 
+type CategoryOrderType = typeof categoryOrder[number];
+type ComponentsByCategory = { [K in CategoryOrderType]: ReadonlyArray<PlatformData> };
+
 const headerCopyByPlatform = {
   web: 'Gestalt provides an extensive set of React components for use in building larger web experiences and patterns. They include interactive UI components and developer utilities to help with implemention.',
   ios: 'Gestalt provides a growing set of interactive UI components for use in building larger iOS experiences and patterns.',
@@ -47,15 +50,13 @@ export default function Overview({ platform }: Props) {
   const [order, setOrder] = useState<'alphabetical' | 'categorical'>('alphabetical');
 
   const platformComponentData = getByPlatform(componentData, { platform });
-  const componentsByCategory = categoryOrder.reduce<{
-    [key: string]: ReadonlyArray<PlatformData>;
-  }>(
+  const componentsByCategory = categoryOrder.reduce(
     (acc, cur) => ({
       ...acc,
       [`${cur}`]: getByCategory(componentData, { platform, category: cur }),
     }),
     {},
-  );
+  ) as ComponentsByCategory;
 
   const prettyPlatform = prettyPrintPlatform(platform);
 

--- a/docs/docs-components/OverviewList.tsx
+++ b/docs/docs-components/OverviewList.tsx
@@ -8,7 +8,7 @@ import { ComponentCategory, Platform, PlatformData } from './data/types';
 import IllustrationCard from './IllustrationCard';
 import IllustrationSection from './IllustrationSection';
 
-const getIllustrationCardColor = (category: ComponentCategory, hasDarkBackground?: boolean) => {
+const getIllustrationCardColor = (category?: ComponentCategory, hasDarkBackground?: boolean) => {
   const tealBackgrounds = ['Foundations'];
   const grayBackgrounds = ['Utilities', 'Building blocks'];
 
@@ -16,11 +16,11 @@ const getIllustrationCardColor = (category: ComponentCategory, hasDarkBackground
     return TOKEN_COLOR_GRAY_ROBOFLOW_600;
   }
 
-  if (tealBackgrounds.includes(category)) {
+  if (category && tealBackgrounds.includes(category)) {
     return TOKEN_COLOR_TEAL_SPABATTICAL_700;
   }
 
-  if (grayBackgrounds.includes(category)) {
+  if (category && grayBackgrounds.includes(category)) {
     return TOKEN_COLOR_GRAY_ROBOFLOW_100;
   }
 

--- a/docs/docs-components/buttons/OpenInCodeSandboxButton.tsx
+++ b/docs/docs-components/buttons/OpenInCodeSandboxButton.tsx
@@ -20,7 +20,7 @@ const getFileParameters = (
   const normalizedFiles = Object.keys(files).reduce<Record<string, any>>((prev, next) => {
     const fileName = next.replace('/', '');
     const value = {
-      content: files[next].code,
+      content: files[next]?.code,
       isBinary: false,
     } as const;
 

--- a/docs/docs-components/createHydra.ts
+++ b/docs/docs-components/createHydra.ts
@@ -48,12 +48,12 @@ function formatDisplayName(
     : `${slicedDisplayName}Context`;
 
   if (subjectDisplayName) {
-    const hocDisplayName = `with${displayName[0].toUpperCase()}${slicedDisplayName}(${subjectDisplayName})`;
+    const hocDisplayName = `with${displayName[0]?.toUpperCase()}${slicedDisplayName}(${subjectDisplayName})`;
     return { hocDisplayName };
   }
 
-  const propsDisplayName = `${displayName[0].toLowerCase()}${slicedDisplayName}`;
-  const messageDisplayName = `${displayName[0].toUpperCase()}${slicedDisplayName}`;
+  const propsDisplayName = `${displayName[0]?.toLowerCase()}${slicedDisplayName}`;
+  const messageDisplayName = `${displayName[0]?.toUpperCase()}${slicedDisplayName}`;
 
   return { propsDisplayName, messageDisplayName };
 }

--- a/docs/docs-components/data/utils/getByCategory.test.ts
+++ b/docs/docs-components/data/utils/getByCategory.test.ts
@@ -5,7 +5,7 @@ describe('getByCategory', () => {
   it('filters for Avatars on web', () => {
     const result = getByCategory(mockComponentList, { category: 'Avatars', platform: 'web' });
     expect(result).toHaveLength(1);
-    expect(result[0].name).toEqual('Avatar');
+    expect(result[0]?.name).toEqual('Avatar');
   });
 
   it('filters for Indicators on Android', () => {
@@ -14,7 +14,7 @@ describe('getByCategory', () => {
       platform: 'android',
     });
     expect(result).toHaveLength(1);
-    expect(result[0].name).toEqual('Badge');
+    expect(result[0]?.name).toEqual('Badge');
   });
 
   it('filters for Indicators on web', () => {

--- a/docs/docs-components/data/utils/getByPlatform.test.ts
+++ b/docs/docs-components/data/utils/getByPlatform.test.ts
@@ -5,7 +5,7 @@ describe('getByPlatform', () => {
   it('filters for figma components', () => {
     const result = getByPlatform(mockComponentList, { platform: 'figma' });
     expect(result).toHaveLength(1);
-    expect(result[0].name).toEqual('BoardRep');
+    expect(result[0]?.name).toEqual('BoardRep');
   });
 
   it('filters for web components', () => {

--- a/docs/docs-components/docgen.ts
+++ b/docs/docs-components/docgen.ts
@@ -1,27 +1,30 @@
 import metadata from './metadata';
 
+type DocGenProp = {
+  defaultValue:
+    | {
+        value: string;
+        computed: boolean;
+      }
+    | null
+    | undefined;
+  required: boolean;
+  description: string;
+  tsType: {
+    raw?: string;
+    nullable?: boolean;
+    name: string;
+    value?: string;
+  };
+};
+
 export type DocGen = {
   description: string;
   displayName: string;
   methods: ReadonlyArray<string>;
   props: {
-    [key: string]: {
-      defaultValue:
-        | {
-            value: string;
-            computed: boolean;
-          }
-        | null
-        | undefined;
-      required: boolean;
-      description: string;
-      tsType: {
-        raw?: string;
-        nullable?: boolean;
-        name: string;
-        value?: string;
-      };
-    };
+    [key: string]: DocGenProp;
+    children: DocGenProp;
   };
 };
 
@@ -34,21 +37,18 @@ export default function docGen(componentName: string): DocGen {
   return metadata[componentName];
 }
 
-export function multipleDocGen(componentNames: ReadonlyArray<string>): {
-  [key: string]: DocGen;
-} {
-  return componentNames.reduce<Record<string, any>>(
-    (
-      prevValue: {
-        [key: string]: DocGen;
-      },
-      currentComponentName: string,
-    ) => ({
+export type MultipleDocGenType<Name extends string> = { [K in Name]: DocGen };
+
+export function multipleDocGen<Name extends string>(
+  componentNames: ReadonlyArray<Name>,
+): MultipleDocGenType<Name> {
+  return componentNames.reduce(
+    (prevValue, currentComponentName: string) => ({
       ...prevValue,
       [currentComponentName]: docGen(currentComponentName),
     }),
     {},
-  );
+  ) as MultipleDocGenType<Name>;
 }
 
 export function overrideTypes(

--- a/docs/docs-components/siteIndex.ts
+++ b/docs/docs-components/siteIndex.ts
@@ -14,7 +14,7 @@ export type siteIndexType = {
 //    >>> page 2
 //    >>> page 3
 // Any new section/page must be added to siteIndex to be displayed.
-const siteIndex: ReadonlyArray<siteIndexType> = [
+const siteIndex: readonly [siteIndexType, ...siteIndexType[]] = [
   {
     sectionName: 'Get started',
     pages: [

--- a/docs/examples/accordion/sizesExample.tsx
+++ b/docs/examples/accordion/sizesExample.tsx
@@ -11,7 +11,9 @@ export default function Example() {
         <SegmentedControl
           items={sizes}
           onChange={({ activeIndex }) => {
-            setSize(sizes[activeIndex]);
+            if (sizes[activeIndex]) {
+              setSize(sizes[activeIndex]);
+            }
           }}
           selectedItemIndex={sizes.indexOf(size)}
         />

--- a/docs/examples/collage/main.tsx
+++ b/docs/examples/collage/main.tsx
@@ -1,4 +1,4 @@
-import { Collage, Flex, Image, Mask } from 'gestalt';
+import { Box, Collage, Flex, Image, Mask } from 'gestalt';
 
 export default function Example() {
   return (
@@ -45,17 +45,21 @@ export default function Example() {
               src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
             },
           ];
-          const image = images[index] || {};
+          const image = images[index];
           return (
             <Mask height={height} wash width={width}>
-              <Image
-                alt="collage image"
-                color={image.color}
-                fit="cover"
-                naturalHeight={image.naturalHeight}
-                naturalWidth={image.naturalWidth}
-                src={image.src}
-              />
+              {image ? (
+                <Image
+                  alt="collage image"
+                  color={image.color}
+                  fit="cover"
+                  naturalHeight={image.naturalHeight}
+                  naturalWidth={image.naturalWidth}
+                  src={image.src}
+                />
+              ) : (
+                <Box color="secondary" height={height} width={width} />
+              )}
             </Mask>
           );
         }}

--- a/docs/examples/collage/variantsColumns.tsx
+++ b/docs/examples/collage/variantsColumns.tsx
@@ -54,10 +54,10 @@ export default function Example() {
               columns={columns}
               height={150}
               renderImage={({ index, width, height }) => {
-                const image = images[index] || {};
+                const image = images[index];
                 return (
                   <Mask height={height} wash width={width}>
-                    {image.src ? (
+                    {image?.src ? (
                       <Image
                         alt="collage image"
                         color={image.color}

--- a/docs/examples/collage/variantsColumnsCoverImage.tsx
+++ b/docs/examples/collage/variantsColumnsCoverImage.tsx
@@ -54,10 +54,10 @@ export default function Example() {
               cover
               height={150}
               renderImage={({ index, width, height }) => {
-                const image = images[index] || {};
+                const image = images[index];
                 return (
                   <Mask height={height} wash width={width}>
-                    {image.src ? (
+                    {image?.src ? (
                       <Image
                         alt="collage image"
                         color={image.color}

--- a/docs/examples/collage/variantsCoverImage.tsx
+++ b/docs/examples/collage/variantsCoverImage.tsx
@@ -34,14 +34,18 @@ export default function Example() {
             const image = index === 0 ? coverImage : nonCoverImages[index - 1];
             return (
               <Mask height={height} width={width}>
-                <Image
-                  alt="cover image"
-                  color={image.color}
-                  fit="cover"
-                  naturalHeight={image.naturalHeight}
-                  naturalWidth={image.naturalWidth}
-                  src={image.src}
-                />
+                {image ? (
+                  <Image
+                    alt="cover image"
+                    color={image.color}
+                    fit="cover"
+                    naturalHeight={image.naturalHeight}
+                    naturalWidth={image.naturalWidth}
+                    src={image.src}
+                  />
+                ) : (
+                  <Box color="secondary" height={height} width={width} />
+                )}
               </Mask>
             );
           }}

--- a/docs/examples/collage/variantsGutter.tsx
+++ b/docs/examples/collage/variantsGutter.tsx
@@ -48,17 +48,21 @@ export default function Example() {
           gutter={8}
           height={300}
           renderImage={({ index, width, height }) => {
-            const image = images[index] || {};
+            const image = images[index];
             return (
               <Mask height={height} wash width={width}>
-                <Image
-                  alt="collage image"
-                  color={image.color}
-                  fit="cover"
-                  naturalHeight={image.naturalHeight}
-                  naturalWidth={image.naturalWidth}
-                  src={image.src}
-                />
+                {image ? (
+                  <Image
+                    alt="collage image"
+                    color={image.color}
+                    fit="cover"
+                    naturalHeight={image.naturalHeight}
+                    naturalWidth={image.naturalWidth}
+                    src={image.src}
+                  />
+                ) : (
+                  <Box color="secondary" height={height} width={width} />
+                )}
               </Mask>
             );
           }}

--- a/docs/examples/collage/variantsLayoutKey.tsx
+++ b/docs/examples/collage/variantsLayoutKey.tsx
@@ -54,17 +54,21 @@ export default function Example() {
               height={150}
               layoutKey={layoutKey}
               renderImage={({ index, width, height }) => {
-                const image = images[index] || {};
+                const image = images[index];
                 return (
                   <Mask height={height} wash width={width}>
-                    <Image
-                      alt="collage image"
-                      color={image.color}
-                      fit="cover"
-                      naturalHeight={image.naturalHeight}
-                      naturalWidth={image.naturalWidth}
-                      src={image.src}
-                    />
+                    {image ? (
+                      <Image
+                        alt="collage image"
+                        color={image.color}
+                        fit="cover"
+                        naturalHeight={image.naturalHeight}
+                        naturalWidth={image.naturalWidth}
+                        src={image.src}
+                      />
+                    ) : (
+                      <Box color="secondary" height={height} width={width} />
+                    )}
                   </Mask>
                 );
               }}

--- a/docs/examples/combobox/controlled.tsx
+++ b/docs/examples/combobox/controlled.tsx
@@ -57,7 +57,7 @@ const US_STATES = [
   'WI - Wisconsin',
   'WV - West Virginia',
   'WY - Wyoming',
-];
+] as const;
 
 export default function Example() {
   const usStatesOptions = US_STATES.map((pronoun, index) => ({
@@ -66,7 +66,7 @@ export default function Example() {
   }));
 
   const [suggestedOptions, setSuggestedOptions] = useState(usStatesOptions);
-  const [inputValue, setInputValue] = useState(usStatesOptions[5].label);
+  const [inputValue, setInputValue] = useState<string>(usStatesOptions[5]?.label ?? '');
   const [selected, setSelected] = useState<
     | undefined
     | {

--- a/docs/examples/numberfield/sizes.tsx
+++ b/docs/examples/numberfield/sizes.tsx
@@ -24,7 +24,9 @@ export default function Example() {
           <SegmentedControl
             items={sizes}
             onChange={({ activeIndex }) => {
-              setSize(sizes[activeIndex]);
+              if (sizes[activeIndex]) {
+                setSize(sizes[activeIndex]);
+              }
             }}
             selectedItemIndex={sizes.indexOf(size)}
             size="sm"

--- a/docs/examples/overlaypanel/subHeadingExample.tsx
+++ b/docs/examples/overlaypanel/subHeadingExample.tsx
@@ -34,7 +34,7 @@ export default function SubheadingExample() {
   }) => {
     event.preventDefault();
     setActiveTabIndex(activeTabIndexLocal);
-    refs[activeTabIndexLocal].current?.scrollIntoView({
+    refs[activeTabIndexLocal]?.current?.scrollIntoView({
       behavior: 'smooth',
     });
   };

--- a/docs/examples/table/dontUseExpandForDenseContent.tsx
+++ b/docs/examples/table/dontUseExpandForDenseContent.tsx
@@ -89,17 +89,21 @@ function ExpandedContents() {
                           src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
                         },
                       ];
-                      const image = images[index] || {};
+                      const image = images[index];
                       return (
                         <Mask height={height} wash width={width}>
-                          <Image
-                            alt="collage image"
-                            color={image.color}
-                            fit="cover"
-                            naturalHeight={image.naturalHeight}
-                            naturalWidth={image.naturalWidth}
-                            src={image.src}
-                          />
+                          {image ? (
+                            <Image
+                              alt="collage image"
+                              color={image.color}
+                              fit="cover"
+                              naturalHeight={image.naturalHeight}
+                              naturalWidth={image.naturalWidth}
+                              src={image.src}
+                            />
+                          ) : (
+                            <Box color="secondary" height={height} width={width} />
+                          )}
                         </Mask>
                       );
                     }}

--- a/docs/examples/textarea/tags.tsx
+++ b/docs/examples/textarea/tags.tsx
@@ -27,7 +27,7 @@ export default function Example() {
         ...tagInput.splice(0, tagInput.length - 1).filter((val) => val !== ''),
       ]);
     }
-    setValue(tagInput[tagInput.length - 1]);
+    setValue(tagInput[tagInput.length - 1]!);
   };
 
   const onKeyDownTagManagement: KeyDownHandler = ({

--- a/docs/examples/textarea/withTagsExample.tsx
+++ b/docs/examples/textarea/withTagsExample.tsx
@@ -30,7 +30,7 @@ export default function Example() {
         ...tagInput.splice(0, tagInput.length - 1).filter((val) => val !== ''),
       ]);
     }
-    setValue(tagInput[tagInput.length - 1]);
+    setValue(tagInput[tagInput.length - 1]!);
   };
 
   const onKeyDownTagManagement: KeyDownHandler = ({

--- a/docs/examples/textfield/tags.tsx
+++ b/docs/examples/textfield/tags.tsx
@@ -27,7 +27,7 @@ export default function Example() {
         ...tagInput.splice(0, tagInput.length - 1).filter((val) => val !== ''),
       ]);
     }
-    setValue(tagInput[tagInput.length - 1]);
+    setValue(tagInput[tagInput.length - 1]!);
   };
 
   const onKeyDownTagManagement: KeyDownHandler = ({

--- a/docs/examples/zindex_classes/foundationalComponentsExample.tsx
+++ b/docs/examples/zindex_classes/foundationalComponentsExample.tsx
@@ -48,23 +48,25 @@ function List({ title, onSelect }: { title: string; onSelect: (data: string) => 
       </Text>
 
       <Flex direction="column" gap={{ column: 4, row: 0 }}>
-        {[
+        {(
           [
-            'https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp',
-            'Fashion',
-            'Thumbnail image: a white dress with red flowers',
-          ],
-          [
-            'https://i.ibb.co/swC1qpp/IMG-0494.jpg',
-            'Food',
-            'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice',
-          ],
-          [
-            'https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp',
-            'Home',
-            'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture',
-          ],
-        ].map((data) => (
+            [
+              'https://i.ibb.co/s3PRJ8v/photo-1496747611176-843222e1e57c.webp',
+              'Fashion',
+              'Thumbnail image: a white dress with red flowers',
+            ],
+            [
+              'https://i.ibb.co/swC1qpp/IMG-0494.jpg',
+              'Food',
+              'Thumbnail image: a paella with shrimp, green peas, red peppers and yellow rice',
+            ],
+            [
+              'https://i.ibb.co/PFVF3JH/photo-1583847268964-b28dc8f51f92.webp',
+              'Home',
+              'Thumbnail image: a living room with a white couch, two paints in the wall and wooden furniture',
+            ],
+          ] as const
+        ).map((data) => (
           <TapArea key={data[1]} onTap={() => onSelect(data[1])} rounding={2}>
             <Flex alignItems="center" gap={{ row: 2, column: 0 }}>
               <Box height={50} overflow="hidden" rounding={2} width={50}>

--- a/docs/integration-test-helpers/masonry/items-utils/generateRealisticExampleItems.ts
+++ b/docs/integration-test-helpers/masonry/items-utils/generateRealisticExampleItems.ts
@@ -36,7 +36,7 @@ export default function generateRealisticExampleItems({
   return Array.from({ length: numberOfItems }).map((_, i) => {
     const pin = {
       name: `${name} ${i + previousItemCount}`,
-      height: pinHeightsSample[baseIndex + i],
+      height: pinHeightsSample[baseIndex + i]!,
       color: getRandomColor(getRandomNumber),
     } as const;
     return Boolean(twoColItemIndex) && i === twoColItemIndex

--- a/docs/pages/foundations/data_visualization/color/usage.tsx
+++ b/docs/pages/foundations/data_visualization/color/usage.tsx
@@ -56,7 +56,7 @@ const DO_NOT_PAIR_COLORS = [
   [7, 11],
   [4, 6],
   [6, 11],
-];
+] as const;
 
 const MAP = {
   '1': TOKEN_COLOR_DATA_VISUALIZATION_01,

--- a/docs/pages/get_started/developers/tooling/web.tsx
+++ b/docs/pages/get_started/developers/tooling/web.tsx
@@ -51,17 +51,19 @@ export default function ToolingPage() {
       <PageHeader name="Web tooling" type="guidelines" />
       <MainSection name="Core design system">
         <List label="The core Gestalt Design System consists of:">
-          {[
-            ['Gestalt Design Libraries', 'http://go/gestaltFigma'],
-            ['Reusable component library in Github', 'https://github.com/pinterest/gestalt'],
-            ['Gestalt component extensions in Pinboard', 'http://go/gestaltExtensions'],
-
-            ['Gestalt Flow types library in Pinboard', 'http://go/gestaltExtensionsTypes'],
+          {(
             [
-              'Documentation site in gestalt.pinterest.systems',
-              'https://gestalt.pinterest.systems/',
-            ],
-          ].map((item) => (
+              ['Gestalt Design Libraries', 'http://go/gestaltFigma'],
+              ['Reusable component library in Github', 'https://github.com/pinterest/gestalt'],
+              ['Gestalt component extensions in Pinboard', 'http://go/gestaltExtensions'],
+
+              ['Gestalt Flow types library in Pinboard', 'http://go/gestaltExtensionsTypes'],
+              [
+                'Documentation site in gestalt.pinterest.systems',
+                'https://gestalt.pinterest.systems/',
+              ],
+            ] as const
+          ).map((item) => (
             <List.Item
               key={item[0]}
               text={
@@ -338,88 +340,90 @@ The following table lists the currently available metrics to track Gestalt adopt
               </Table.Row>
             </Table.Header>
             <Table.Body>
-              {[
+              {(
                 [
-                  '% Gestalt components over HTML ',
-                  '# total Gestalt components / (# native DOM elements + # total Gestalt component); % per site',
-                  'https://statsboard.pinadmin.com/share/jh3g8',
-                ],
-                [
-                  '% HTML coverage',
-                  '# total Gestalt components with HTML equivalent/ (# native DOM elements with Gestalt equivalent + # total Gestalt components with HTML equivalent);',
-                  'https://statsboard.pinadmin.com/share/j68ut',
-                ],
-                [
-                  '% HTML coverage',
-                  '# total Gestalt components with HTML equivalent/ (# native DOM elements with Gestalt equivalent + # total Gestalt components with HTML equivalent); per HTML tag',
-                  'https://statsboard.pinadmin.com/share/cbaju',
-                ],
-                [
-                  'HTML detailed coverage',
-                  '# total Gestalt components with HTML equivalent, # total HTML components with Gestalt equivalent',
-                  'https://statsboard.pinadmin.com/share/mt37a',
-                ],
-                [
-                  'Gestalt Components: component level',
-                  '# total Gestalt components; # per component',
-                  'https://statsboard.pinadmin.com/share/9z982',
-                ],
-                [
-                  'Gestalt Components: prop level',
-                  '# total Gestalt components; # per prop & component',
-                  'https://statsboard.pinadmin.com/share/nfjae',
-                ],
-                [
-                  'Gestalt Components: prop value level',
-                  '# total Gestalt components; # per prop value & prop & component',
-                  'https://statsboard.pinadmin.com/share/4w3rk',
-                ],
-                [
-                  'Native DOM Elements: tag level',
-                  '# total native DOM elements; # per tag',
-                  'https://statsboard.pinadmin.com/share/g8jn6',
-                ],
-                [
-                  'Native DOM Elements: attribute level',
-                  '# total native DOM elements; # per attribute & tag',
-                  'https://statsboard.pinadmin.com/share/zxkz4',
-                ],
-                [
-                  'Native DOM Elements: attribute value level',
-                  '# total native DOM elements; # per attribute value & attribute & tag',
-                  'https://statsboard.pinadmin.com/share/87dua',
-                ],
-                [
-                  'Boxes with dangerouslySetInlineStyle',
-                  '# Gestalt Box with dangerouslySetInlineStyle prop / (# total Gestalt Box); % per site',
-                  'https://statsboard.pinadmin.com/share/6t565',
-                ],
-                [
-                  'Top dangerouslySetInlineStyle style attribute keys',
-                  '# most used CSS attributes passed to dangerouslySetInlineStyle; # per site',
-                  'https://statsboard.pinadmin.com/d/gestalt/dangerouslyInlineStyle/Top%20dangerous%20style%20keys',
-                ],
-                [
-                  'Usage by import source (direct import, subcomponent, Pinboard extension)',
-                  '# total Gestalt components; # per source',
-                  'https://statsboard.pinadmin.com/share/rb87s',
-                ],
-                [
-                  'Usage by component category (Html equivalent, industry standard, Pinterest specific)',
-                  '# total Gestalt components; # per category',
-                  'https://statsboard.pinadmin.com/share/ns8f9',
-                ],
-                [
-                  'Usage by component type (utility, building block, UI)',
-                  '# total Gestalt components; # per type',
-                  'https://statsboard.pinadmin.com/share/44jwh',
-                ],
-                [
-                  'Component impressions',
-                  '# component impressions; # per component',
-                  'https://statsboard.pinadmin.com/share/j3a4z',
-                ],
-              ].map((item) => (
+                  [
+                    '% Gestalt components over HTML ',
+                    '# total Gestalt components / (# native DOM elements + # total Gestalt component); % per site',
+                    'https://statsboard.pinadmin.com/share/jh3g8',
+                  ],
+                  [
+                    '% HTML coverage',
+                    '# total Gestalt components with HTML equivalent/ (# native DOM elements with Gestalt equivalent + # total Gestalt components with HTML equivalent);',
+                    'https://statsboard.pinadmin.com/share/j68ut',
+                  ],
+                  [
+                    '% HTML coverage',
+                    '# total Gestalt components with HTML equivalent/ (# native DOM elements with Gestalt equivalent + # total Gestalt components with HTML equivalent); per HTML tag',
+                    'https://statsboard.pinadmin.com/share/cbaju',
+                  ],
+                  [
+                    'HTML detailed coverage',
+                    '# total Gestalt components with HTML equivalent, # total HTML components with Gestalt equivalent',
+                    'https://statsboard.pinadmin.com/share/mt37a',
+                  ],
+                  [
+                    'Gestalt Components: component level',
+                    '# total Gestalt components; # per component',
+                    'https://statsboard.pinadmin.com/share/9z982',
+                  ],
+                  [
+                    'Gestalt Components: prop level',
+                    '# total Gestalt components; # per prop & component',
+                    'https://statsboard.pinadmin.com/share/nfjae',
+                  ],
+                  [
+                    'Gestalt Components: prop value level',
+                    '# total Gestalt components; # per prop value & prop & component',
+                    'https://statsboard.pinadmin.com/share/4w3rk',
+                  ],
+                  [
+                    'Native DOM Elements: tag level',
+                    '# total native DOM elements; # per tag',
+                    'https://statsboard.pinadmin.com/share/g8jn6',
+                  ],
+                  [
+                    'Native DOM Elements: attribute level',
+                    '# total native DOM elements; # per attribute & tag',
+                    'https://statsboard.pinadmin.com/share/zxkz4',
+                  ],
+                  [
+                    'Native DOM Elements: attribute value level',
+                    '# total native DOM elements; # per attribute value & attribute & tag',
+                    'https://statsboard.pinadmin.com/share/87dua',
+                  ],
+                  [
+                    'Boxes with dangerouslySetInlineStyle',
+                    '# Gestalt Box with dangerouslySetInlineStyle prop / (# total Gestalt Box); % per site',
+                    'https://statsboard.pinadmin.com/share/6t565',
+                  ],
+                  [
+                    'Top dangerouslySetInlineStyle style attribute keys',
+                    '# most used CSS attributes passed to dangerouslySetInlineStyle; # per site',
+                    'https://statsboard.pinadmin.com/d/gestalt/dangerouslyInlineStyle/Top%20dangerous%20style%20keys',
+                  ],
+                  [
+                    'Usage by import source (direct import, subcomponent, Pinboard extension)',
+                    '# total Gestalt components; # per source',
+                    'https://statsboard.pinadmin.com/share/rb87s',
+                  ],
+                  [
+                    'Usage by component category (Html equivalent, industry standard, Pinterest specific)',
+                    '# total Gestalt components; # per category',
+                    'https://statsboard.pinadmin.com/share/ns8f9',
+                  ],
+                  [
+                    'Usage by component type (utility, building block, UI)',
+                    '# total Gestalt components; # per type',
+                    'https://statsboard.pinadmin.com/share/44jwh',
+                  ],
+                  [
+                    'Component impressions',
+                    '# component impressions; # per component',
+                    'https://statsboard.pinadmin.com/share/j3a4z',
+                  ],
+                ] as const
+              ).map((item) => (
                 <TableEntry
                   key={`table_entry: ${item[0]}`}
                   description={item[1]}

--- a/docs/pages/visual-test/Collage-dark.tsx
+++ b/docs/pages/visual-test/Collage-dark.tsx
@@ -46,7 +46,7 @@ export default function Snapshot() {
                 src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
               },
             ];
-            const image = images[index] || {};
+            const image = images[index];
             return (
               <Mask height={height} wash width={width}>
                 {image ? (

--- a/docs/pages/visual-test/Collage.tsx
+++ b/docs/pages/visual-test/Collage.tsx
@@ -45,7 +45,7 @@ export default function Snapshot() {
               src: 'https://i.ibb.co/FY2MKr5/stock6.jpg',
             },
           ];
-          const image = images[index] || {};
+          const image = images[index];
           return (
             <Mask height={height} wash width={width}>
               {image ? (

--- a/docs/pages/web/accordion.tsx
+++ b/docs/pages/web/accordion.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -21,13 +21,10 @@ import staticWithErrorType from '../../examples/accordion/staticWithErrorType';
 import staticWithIcon from '../../examples/accordion/staticWithIcon';
 import staticWithIconButton from '../../examples/accordion/staticWithIconButton';
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['Accordion', 'AccordionExpandable'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen.Accordion?.description}>
       <PageHeader
@@ -229,20 +226,20 @@ export default function DocsPage({
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
-  const docGen = await multipleDocGen(['Accordion', 'AccordionExpandable']);
+  const docGen = await multipleDocGen(DOC_NAMES);
 
-  docGen.Accordion.props.icon = {
-    ...docGen.Accordion.props.icon,
-    tsType: {
-      name: 'string',
-      raw: 'Icon[icon]',
-    },
-  };
+  if (docGen.Accordion.props.icon) {
+    docGen.Accordion.props.icon = {
+      ...docGen.Accordion.props.icon,
+      tsType: {
+        name: 'string',
+        raw: 'Icon[icon]',
+      },
+    };
+  }
 
   return {
     props: { generatedDocGen: docGen },

--- a/docs/pages/web/bannerupsell.tsx
+++ b/docs/pages/web/bannerupsell.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -24,13 +24,10 @@ import singleTextField from '../../examples/bannerupsell/singleTextField';
 import textVariant from '../../examples/bannerupsell/textVariant';
 import useForMarketing from '../../examples/bannerupsell/useForMarketing';
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['BannerUpsell', 'BannerUpsellForm'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.BannerUpsell?.displayName}>
       <PageHeader
@@ -372,12 +369,10 @@ If the \`message\` text requires more complex style, such as bold text or inline
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
-    props: { generatedDocGen: await multipleDocGen(['BannerUpsell', 'BannerUpsellForm']) },
+    props: { generatedDocGen: await multipleDocGen(DOC_NAMES) },
   };
 }

--- a/docs/pages/web/chartgraph.tsx
+++ b/docs/pages/web/chartgraph.tsx
@@ -15,7 +15,7 @@ import {
 } from 'gestalt-design-tokens';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
 import CombinationNew from '../../docs-components/CombinationNew';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -57,13 +57,10 @@ import timeseries from '../../examples/chartgraph/timeseries';
 import title from '../../examples/chartgraph/title';
 import tooltip from '../../examples/chartgraph/tooltip';
 
-export default function ComponentPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['ChartGraph', 'LegendIcon'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function ComponentPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   const MEDIUM_HEIGHT = 300;
   const SMALL_HEIGHT = 250;
   const LARGE_HEIGHT = 400;
@@ -723,14 +720,12 @@ Tables show data that's more complex and granular.      `}
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen(['ChartGraph', 'LegendIcon']),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/dropdown.tsx
+++ b/docs/pages/web/dropdown.tsx
@@ -1,6 +1,6 @@
 import { BannerSlim } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -27,13 +27,10 @@ import mobile from '../../examples/dropdown/mobile';
 import sections from '../../examples/dropdown/sections';
 import subtext from '../../examples/dropdown/subtext';
 
-export default function ComponentPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['Dropdown', 'DropdownItem', 'DropdownLink', 'DropdownSection'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function ComponentPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen.Dropdown?.displayName}>
       <PageHeader
@@ -365,17 +362,10 @@ If users need the ability to choose an option by typing in an input and filterin
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
-  const docGen = await multipleDocGen([
-    'Dropdown',
-    'DropdownItem',
-    'DropdownLink',
-    'DropdownSection',
-  ]);
+  const docGen = await multipleDocGen(DOC_NAMES);
 
   docGen.Dropdown.props.children.tsType.raw = 'React.ChildrenArray<React.ReactElement>';
   docGen.DropdownSection.props.children.tsType.raw = 'React.ChildrenArray<React.ReactElement>';

--- a/docs/pages/web/flex.tsx
+++ b/docs/pages/web/flex.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
 import CombinationNew from '../../docs-components/CombinationNew';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -16,15 +16,12 @@ import main from '../../examples/flex/main';
 import menu from '../../examples/flex/menu';
 import overflowing from '../../examples/flex/overflowing';
 
+const DOC_NAMES = ['Flex', 'FlexItem'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
 const ignoredProps = ['smAlignItems', 'mdAlignItems', 'lgAlignItems'];
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.Flex?.displayName}>
       <PageHeader
@@ -175,9 +172,7 @@ export default function DocsPage({
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {

--- a/docs/pages/web/iconbuttonfloating.tsx
+++ b/docs/pages/web/iconbuttonfloating.tsx
@@ -224,13 +224,15 @@ export async function getServerSideProps(): Promise<{
 }> {
   const generatedDocGen = await docGen('IconButtonFloating');
 
-  generatedDocGen.props.icon = {
-    ...generatedDocGen.props.icon,
-    tsType: {
-      name: 'string',
-      raw: 'Icon[icon]',
-    },
-  };
+  if (generatedDocGen.props.icon) {
+    generatedDocGen.props.icon = {
+      ...generatedDocGen.props.icon,
+      tsType: {
+        name: 'string',
+        raw: 'Icon[icon]',
+      },
+    };
+  }
 
   return {
     props: { generatedDocGen },

--- a/docs/pages/web/list.tsx
+++ b/docs/pages/web/list.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import MainSection from '../../docs-components/MainSection';
 import Page from '../../docs-components/Page';
@@ -27,13 +27,10 @@ import typeExample1 from '../../examples/list/typeExample1';
 import typeExample2 from '../../examples/list/typeExample2';
 import useWhenDisplayingMoreThanTwo from '../../examples/list/useWhenDisplayingMoreThanTwo';
 
-export default function ListPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['List', 'ListItem'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function ListPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.List.displayName}>
       <PageHeader
@@ -372,9 +369,7 @@ Fieldset creates a fieldset and legend for a group of related form items, like [
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   const docGen = await multipleDocGen(['List', 'ListItem']);

--- a/docs/pages/web/masonry.tsx
+++ b/docs/pages/web/masonry.tsx
@@ -159,18 +159,22 @@ export async function getServerSideProps(): Promise<{
 }> {
   const generatedDocGen = await docGen('Masonry');
 
-  generatedDocGen.props.loadItems = {
-    ...generatedDocGen.props.loadItems,
-    defaultValue: null,
-  };
+  if (generatedDocGen.props.loadItems) {
+    generatedDocGen.props.loadItems = {
+      ...generatedDocGen.props.loadItems,
+      defaultValue: null,
+    };
+  }
 
-  generatedDocGen.props.measurementStore = {
-    ...generatedDocGen.props.measurementStore,
-    tsType: {
-      name: 'string',
-      raw: 'typeof MeasurementStore',
-    },
-  };
+  if (generatedDocGen.props.measurementStore) {
+    generatedDocGen.props.measurementStore = {
+      ...generatedDocGen.props.measurementStore,
+      tsType: {
+        name: 'string',
+        raw: 'typeof MeasurementStore',
+      },
+    };
+  }
 
   return {
     props: { generatedDocGen },

--- a/docs/pages/web/overlaypanel.tsx
+++ b/docs/pages/web/overlaypanel.tsx
@@ -1,6 +1,6 @@
 import { BannerSlim, Link, Text } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -18,13 +18,10 @@ import quickEditsExample from '../../examples/overlaypanel/quickEditsExample';
 import sizesExample from '../../examples/overlaypanel/sizesExample';
 import subheadingExample from '../../examples/overlaypanel/subHeadingExample';
 
-export default function SheetPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['OverlayPanel', 'DismissingElement'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function SheetPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   const PREVIEW_HEIGHT = 800;
 
   return (
@@ -355,14 +352,12 @@ Toast provides feedback on an interaction. Toasts appear at the bottom of a desk
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen(['OverlayPanel', 'DismissingElement']),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/pog.tsx
+++ b/docs/pages/web/pog.tsx
@@ -136,13 +136,15 @@ export async function getServerSideProps(): Promise<{
 }> {
   const generatedDocGen = await docGen('Pog');
 
-  generatedDocGen.props.icon = {
-    ...generatedDocGen.props.icon,
-    tsType: {
-      name: 'string',
-      raw: 'Icon[icon]',
-    },
-  };
+  if (generatedDocGen.props.icon) {
+    generatedDocGen.props.icon = {
+      ...generatedDocGen.props.icon,
+      tsType: {
+        name: 'string',
+        raw: 'Icon[icon]',
+      },
+    };
+  }
 
   return {
     props: { generatedDocGen },

--- a/docs/pages/web/popover.tsx
+++ b/docs/pages/web/popover.tsx
@@ -290,7 +290,9 @@ export async function getServerSideProps(): Promise<{
   };
 }> {
   const generatedDocGen = await docGen('Popover');
-  generatedDocGen.props.color.tsType.raw = '"white" | "darkGray"';
+  if (generatedDocGen.props.color) {
+    generatedDocGen.props.color.tsType.raw = '"white" | "darkGray"';
+  }
 
   return {
     props: {

--- a/docs/pages/web/radiogroup.tsx
+++ b/docs/pages/web/radiogroup.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -24,13 +24,10 @@ import withCustomLabelsExample from '../../examples/radiogroup/withCustomLabelsE
 import withHelperTextExample from '../../examples/radiogroup/withHelperTextExample';
 import withImageExample from '../../examples/radiogroup/withImageExample';
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['RadioGroup', 'RadioGroupButton'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.RadioGroup?.displayName}>
       <PageHeader
@@ -345,14 +342,12 @@ export default function DocsPage({
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen(['RadioGroup', 'RadioGroupButton']),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/selectlist.tsx
+++ b/docs/pages/web/selectlist.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { DocGen, multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import MainSection from '../../docs-components/MainSection';
 import Page from '../../docs-components/Page';
@@ -24,13 +24,10 @@ import labelVisible from '../../examples/selectlist/labelVisible';
 import main from '../../examples/selectlist/main';
 import size from '../../examples/selectlist/size';
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['SelectList', 'SelectListOption', 'SelectListGroup'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.SelectList?.displayName}>
       <PageHeader
@@ -354,7 +351,7 @@ export async function getServerSideProps(): Promise<{
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen(['SelectList', 'SelectListOption', 'SelectListGroup']),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/sheetmobile.tsx
+++ b/docs/pages/web/sheetmobile.tsx
@@ -1,6 +1,6 @@
 import { BannerSlim } from 'gestalt';
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import InternalDocumentationSection from '../../docs-components/InternalDocumentationSection';
 import LocalizationSection from '../../docs-components/LocalizationSection';
@@ -24,13 +24,10 @@ import outsideClick from '../../examples/sheetmobile/outsideClick';
 import textOnlyHeader from '../../examples/sheetmobile/textOnlyHeader';
 import withPrimaryActionHeader from '../../examples/sheetmobile/withPrimaryActionHeader';
 
-export default function SheetMobilePage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = ['SheetMobile', 'DismissingElement'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function SheetMobilePage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen?.SheetMobile.displayName}>
       <PageHeader
@@ -398,14 +395,12 @@ OverlayPanels are surfaces that allow users to view optional information or comp
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen(['SheetMobile', 'DismissingElement']),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/sidenavigation.tsx
+++ b/docs/pages/web/sidenavigation.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -41,12 +41,20 @@ import primaryAction from '../../examples/sidenavigation/primaryAction';
 import sectionsExample from '../../examples/sidenavigation/sectionsExample';
 import subcomponent from '../../examples/sidenavigation/subcomponent';
 
+const DOC_NAMES = [
+  'SideNavigation',
+  'SideNavigationSection',
+  'SideNavigationTopItem',
+  'SideNavigationNestedItem',
+  'SideNavigationGroup',
+  'SideNavigationNestedGroup',
+] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
 export default function SideNavigationPage({
   generatedDocGen,
 }: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
+  generatedDocGen: GeneratedDocGen;
 }) {
   return (
     <Page title={generatedDocGen.SideNavigation?.displayName ?? ''}>
@@ -619,21 +627,12 @@ For pages with a main top nav bar, every SideNav should have a PageHeader to ann
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
   return {
     props: {
-      generatedDocGen: await multipleDocGen([
-        'SideNavigation',
-        'SideNavigationSection',
-        'SideNavigationTopItem',
-        'SideNavigationNestedItem',
-        'SideNavigationGroup',
-        'SideNavigationNestedGroup',
-      ]),
+      generatedDocGen: await multipleDocGen(DOC_NAMES),
     },
   };
 }

--- a/docs/pages/web/table.tsx
+++ b/docs/pages/web/table.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -32,13 +32,21 @@ import stickyHeaderFooterExample from '../../examples/table/stickyHeaderFooterEx
 import topCaptionExample from '../../examples/table/topCaptionExample';
 import uncontrolledExpandable from '../../examples/table/uncontrolledExpandable';
 
-export default function DocsPage({
-  generatedDocGen,
-}: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
-}) {
+const DOC_NAMES = [
+  'Table',
+  'TableHeader',
+  'TableBody',
+  'TableFooter',
+  'TableCell',
+  'TableHeaderCell',
+  'TableSortableHeaderCell',
+  'TableRow',
+  'TableRowExpandable',
+  'TableRowDrawer',
+] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
+export default function DocsPage({ generatedDocGen }: { generatedDocGen: GeneratedDocGen }) {
   return (
     <Page title={generatedDocGen.Table?.displayName}>
       <PageHeader
@@ -576,23 +584,10 @@ Checkboxes are often used in tables to allow for selecting and editing of multip
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
-  const docGen = await multipleDocGen([
-    'Table',
-    'TableHeader',
-    'TableBody',
-    'TableFooter',
-    'TableCell',
-    'TableHeaderCell',
-    'TableSortableHeaderCell',
-    'TableRow',
-    'TableRowExpandable',
-    'TableRowDrawer',
-  ]);
+  const docGen = await multipleDocGen(DOC_NAMES);
 
   docGen.Table.props.children.tsType.raw = 'React.ChildrenArray<ReactElement>';
   docGen.TableHeader.props.children.tsType.raw = 'ReactElement';

--- a/docs/pages/web/tableofcontents.tsx
+++ b/docs/pages/web/tableofcontents.tsx
@@ -1,5 +1,5 @@
 import AccessibilitySection from '../../docs-components/AccessibilitySection';
-import { DocGen, multipleDocGen } from '../../docs-components/docgen';
+import { multipleDocGen, MultipleDocGenType } from '../../docs-components/docgen';
 import GeneratedPropTable from '../../docs-components/GeneratedPropTable';
 import LocalizationSection from '../../docs-components/LocalizationSection';
 import MainSection from '../../docs-components/MainSection';
@@ -14,12 +14,13 @@ import nestedItemsExample from '../../examples/tableofcontents/nestedItemsExampl
 import topAlignWithContetnTitle from '../../examples/tableofcontents/topAlignWithContentTitle';
 import withHeaderExample from '../../examples/tableofcontents/withHeaderExample';
 
+const DOC_NAMES = ['TableOfContents', 'TableOfContentsItem'] as const;
+type GeneratedDocGen = MultipleDocGenType<typeof DOC_NAMES[number]>;
+
 export default function TableOfContentsPage({
   generatedDocGen,
 }: {
-  generatedDocGen: {
-    [key: string]: DocGen;
-  };
+  generatedDocGen: GeneratedDocGen;
 }) {
   return (
     <Page title={generatedDocGen?.TableOfContents.displayName}>
@@ -181,12 +182,10 @@ Tabs may be used navigate between multiple URLs. Tabs are intended as page-level
 
 export async function getServerSideProps(): Promise<{
   props: {
-    generatedDocGen: {
-      [key: string]: DocGen;
-    };
+    generatedDocGen: GeneratedDocGen;
   };
 }> {
-  const docGen = await multipleDocGen(['TableOfContents', 'TableOfContentsItem']);
+  const docGen = await multipleDocGen(DOC_NAMES);
 
   docGen.TableOfContents.props.children.tsType.raw = '<ReactElement>';
   docGen.TableOfContentsItem.props.children.tsType.raw = '<ReactElement>';

--- a/docs/pages/web/textfield.tsx
+++ b/docs/pages/web/textfield.tsx
@@ -523,7 +523,9 @@ export async function getServerSideProps(): Promise<{
 }> {
   const generatedDocGen = await docGen('TextField');
 
-  generatedDocGen.props.autoComplete.tsType.raw = `'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username' | 52 more ...`;
+  if (generatedDocGen.props.autoComplete) {
+    generatedDocGen.props.autoComplete.tsType.raw = `'bday' | 'current-password' | 'email' | 'new-password' | 'on' | 'off' | 'username' | 52 more ...`;
+  }
 
   return {
     props: { generatedDocGen: await docGen('TextField') },

--- a/packages/eslint-plugin-gestalt/src/helpers/eslintASTFixers.ts
+++ b/packages/eslint-plugin-gestalt/src/helpers/eslintASTFixers.ts
@@ -49,7 +49,7 @@ export const updateGestaltImportFixer: updateGestaltImportFixerType = ({
   }
 
   const filteredImportComponents = importsToRemove
-    ? importsComponentsArray.filter((component) => !importsToRemove.includes(component[0]))
+    ? importsComponentsArray.filter((component) => !importsToRemove.includes(component[0]!))
     : importsComponentsArray;
 
   const sortedImports = filteredImportComponents

--- a/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.ts
+++ b/packages/eslint-plugin-gestalt/src/prefer-box-inline-style.ts
@@ -114,7 +114,7 @@ const rule: ESLintRule = {
           const matched = attr.name && attr.name.name === 'style';
           if (matched) {
             // If we have style properties here, this is an object declared inline
-            let styleProperties: null | ReadonlyArray<Record<any, any>>;
+            let styleProperties: null | undefined | ReadonlyArray<Record<any, any>>;
             styleProperties = getInlineDefinedStyles(attr);
 
             // Not declared inline? Check to see if there's a variable matching the name defined

--- a/packages/gestalt-charts/src/ChartGraph.jsdom.test.tsx
+++ b/packages/gestalt-charts/src/ChartGraph.jsdom.test.tsx
@@ -336,7 +336,7 @@ describe('ChartGraph', () => {
     expect(screen.getByLabelText('Visual pattern view')).toBeVisible();
 
     act(() => {
-      screen.getAllByRole('button')[1].click();
+      screen.getAllByRole('button')[1]?.click();
     });
     expect(mockonVisualPatternChange).toHaveBeenCalled();
   });

--- a/packages/gestalt-datepicker/src/DateField/InternalDateField.tsx
+++ b/packages/gestalt-datepicker/src/DateField/InternalDateField.tsx
@@ -201,7 +201,7 @@ const getTranslationsFromMUIJS: (arg1?: Locale | null | undefined) =>
     const split = localeData.code.split('-');
     if (split.length === 1) {
       // turns 'es' into 'enES'
-      split.push(split[0].toUpperCase());
+      split.push((split[0] ?? '').toUpperCase());
     }
     const code = split.join('');
 

--- a/packages/gestalt-datepicker/src/DateRange.jsdom.test.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.jsdom.test.tsx
@@ -85,9 +85,10 @@ describe('DateRange', () => {
 
     const startSelectedDay = screen.getAllByText('13')[0];
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {
-      fireEvent.click(startSelectedDay);
+      if (startSelectedDay) {
+        fireEvent.click(startSelectedDay);
+      }
     });
 
     expect(screen.getByDisplayValue('12 / 13 / 1995')).toBeInTheDocument();
@@ -95,9 +96,10 @@ describe('DateRange', () => {
 
     const endSelectedDay = screen.getAllByText('13')[1];
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {
-      fireEvent.click(endSelectedDay);
+      if (endSelectedDay) {
+        fireEvent.click(endSelectedDay);
+      }
     });
 
     expect(screen.getByDisplayValue('12 / 13 / 1995')).toBeInTheDocument();
@@ -140,16 +142,18 @@ describe('DateRange', () => {
 
     const startSelectedDay = screen.getAllByText('13')[0];
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {
-      fireEvent.click(startSelectedDay);
+      if (startSelectedDay) {
+        fireEvent.click(startSelectedDay);
+      }
     });
 
     const endSelectedDay = screen.getAllByText('13')[1];
 
-    // eslint-disable-next-line testing-library/no-unnecessary-act -- We have to wrap the focus event in `act` since it does change the component's internal state
     await act(async () => {
-      fireEvent.click(endSelectedDay);
+      if (endSelectedDay) {
+        fireEvent.click(endSelectedDay);
+      }
     });
 
     expect(onStartDateChangeMock).toHaveBeenNthCalledWith(

--- a/packages/gestalt/src/AccordionExpandable.jsdom.test.tsx
+++ b/packages/gestalt/src/AccordionExpandable.jsdom.test.tsx
@@ -88,21 +88,27 @@ describe('AccordionExpandable', () => {
       name: /Expand section/i,
     });
 
-    fireEvent.click(expandButtons[0]);
+    if (expandButtons[0]) {
+      fireEvent.click(expandButtons[0]);
+    }
     expect(screen.getByText(/Children1/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.queryByText(/Children3/i)).toBeNull();
     expect(screen.queryByText(/Children4/i)).toBeNull();
     expect(screen.queryByText(/Children5/i)).toBeNull();
 
-    fireEvent.click(expandButtons[1]);
+    if (expandButtons[1]) {
+      fireEvent.click(expandButtons[1]);
+    }
     expect(screen.queryByText(/Children1/i)).toBeNull();
     expect(screen.getByText(/Children2/i)).toBeInTheDocument();
     expect(screen.queryByText(/Children3/i)).toBeNull();
     expect(screen.queryByText(/Children4/i)).toBeNull();
     expect(screen.queryByText(/Children5/i)).toBeNull();
 
-    fireEvent.click(expandButtons[2]);
+    if (expandButtons[2]) {
+      fireEvent.click(expandButtons[2]);
+    }
     expect(screen.queryByText(/Children1/i)).toBeNull();
     expect(screen.queryByText(/Children2/i)).toBeNull();
     expect(screen.getByText(/Children3/i)).toBeInTheDocument();
@@ -138,7 +144,9 @@ describe('AccordionExpandable', () => {
       name: /Expand section/i,
     });
     expect(expandButtons).toHaveLength(5);
-    fireEvent.click(expandButtons[1]);
+    if (expandButtons[1]) {
+      fireEvent.click(expandButtons[1]);
+    }
     expect(newProps.onExpandedChange).toHaveBeenCalledWith(1);
   });
 });

--- a/packages/gestalt/src/Avatar/DefaultAvatar.tsx
+++ b/packages/gestalt/src/Avatar/DefaultAvatar.tsx
@@ -6,7 +6,7 @@ type Props = {
 };
 
 export default function DefaultAvatar({ accessibilityLabel, name }: Props) {
-  const firstInitial = name ? Array.from(name)[0].toUpperCase() : '';
+  const firstInitial = (name && Array.from(name)[0]?.toUpperCase()) || '';
   const title = accessibilityLabel ?? name;
 
   return (

--- a/packages/gestalt/src/Button.test.tsx
+++ b/packages/gestalt/src/Button.test.tsx
@@ -31,16 +31,16 @@ describe('<Button />', () => {
 
   test('Custom white text color on transparent background', () => {
     const instance = create(<Button color="transparentWhiteText" text="Hello World" />).root;
-    expect(instance.findAll((element: any) => element.type === 'div')[1].props.className).toContain(
-      'inverse',
-    );
+    expect(
+      instance.findAll((element: any) => element.type === 'div')[1]?.props.className,
+    ).toContain('inverse');
   });
 
   test('Default darkGray text color on transparent background', () => {
     const instance = create(<Button color="transparent" text="Hello World" />).root;
-    expect(instance.findAll((element: any) => element.type === 'div')[1].props.className).toContain(
-      'default',
-    );
+    expect(
+      instance.findAll((element: any) => element.type === 'div')[1]?.props.className,
+    ).toContain('default');
   });
 
   test('accessibilityControls', () => {

--- a/packages/gestalt/src/ButtonToggle.test.tsx
+++ b/packages/gestalt/src/ButtonToggle.test.tsx
@@ -34,9 +34,9 @@ describe('<ButtonToggle />', () => {
     const instance = create(
       <ButtonToggle color="transparent" selected={false} text="Hello World" />,
     ).root;
-    expect(instance.findAll((element: any) => element.type === 'div')[3].props.className).toContain(
-      'default',
-    );
+    expect(
+      instance.findAll((element: any) => element.type === 'div')[3]?.props.className,
+    ).toContain('default');
   });
 
   test('accessibilityControls', () => {

--- a/packages/gestalt/src/Collage.tsx
+++ b/packages/gestalt/src/Collage.tsx
@@ -65,8 +65,7 @@ const paddingAll = (
     height: height - gutter,
   }));
 
-const mindex = (arr: ReadonlyArray<number>) =>
-  arr.reduce((minIndex, item, i) => (item < arr[minIndex] ? i : minIndex), 0);
+const mindex = (arr: ReadonlyArray<number>) => (arr.length ? arr.indexOf(Math.min(...arr)) : 0);
 
 const columnsForCollageWithCover = (numOfColumns: Column) => (numOfColumns === 4 ? 2 : 1);
 
@@ -112,17 +111,17 @@ function getCollageLayout({
   for (let i = 0; i < 2 * gridCols; i += 1) {
     const col = mindex(colHeights);
     const colIdx = colCounts[col];
-    const itemHeight = layout[col][colIdx] * height;
+    const itemHeight = layout![col]![colIdx!]! * height;
 
     positions.push({
-      top: colHeights[col],
+      top: colHeights[col]!,
       left: col * (width / numCols),
       width: width / numCols,
       height: itemHeight,
     });
 
-    colHeights[col] += itemHeight;
-    colCounts[col] += 1;
+    colHeights[col] = colHeights[col]! + itemHeight;
+    colCounts[col] = colCounts[col]! + 1;
   }
 
   // If we have a cover image, figure out how big it is, then move all the
@@ -200,8 +199,8 @@ export default function Collage(props: Props) {
       renderItem={({ idx: index }) =>
         renderImage({
           index,
-          width: positions[index].width,
-          height: positions[index].height,
+          width: positions[index]!.width,
+          height: positions[index]!.height,
         })
       }
     />

--- a/packages/gestalt/src/ComboBox.jsdom.test.tsx
+++ b/packages/gestalt/src/ComboBox.jsdom.test.tsx
@@ -15,7 +15,7 @@ describe('ComboBox', () => {
     'xe / xem',
     'xie / xem',
     'zie / zem',
-  ];
+  ] as const;
 
   const defaultOptions = PRONOUNS.map((pronoun: any, index: any) => ({
     label: pronoun,
@@ -337,7 +337,7 @@ describe('ComboBox', () => {
     });
 
     it('shows selected option in textfield', () => {
-      const input1 = controlledOptions[0].label;
+      const input1 = controlledOptions[0]?.label;
 
       renderComboBox({
         inputValue: input1,
@@ -350,7 +350,7 @@ describe('ComboBox', () => {
     });
 
     it('shows selected option in dropdown', async () => {
-      const input1 = controlledOptions[0].label;
+      const input1 = controlledOptions[0]?.label;
 
       renderComboBox({
         inputValue: input1,

--- a/packages/gestalt/src/HelpButton.test.tsx
+++ b/packages/gestalt/src/HelpButton.test.tsx
@@ -81,7 +81,7 @@ describe('HelpButton', () => {
     ).root;
 
     expect(
-      instance.findAll((element: any) => element.type === 'div')[3].props['aria-controls'],
+      instance.findAll((element: any) => element.type === 'div')[3]?.props['aria-controls'],
     ).toBeTruthy();
   });
 
@@ -94,7 +94,7 @@ describe('HelpButton', () => {
       />,
     ).root;
     expect(
-      instance.findAll((element: any) => element.type === 'div')[3].props['aria-expanded'],
+      instance.findAll((element: any) => element.type === 'div')[3]?.props['aria-expanded'],
     ).toBe(false);
   });
 
@@ -107,7 +107,7 @@ describe('HelpButton', () => {
       />,
     ).root;
     expect(
-      instance.findAll((element: any) => element.type === 'div')[3].props['aria-label'],
+      instance.findAll((element: any) => element.type === 'div')[3]?.props['aria-label'],
     ).toContain('Click to learn more');
   });
 });

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -210,12 +210,11 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       props._dynamicHeights && typeof window !== 'undefined' && this.positionStore
         ? new ResizeObserver((entries) => {
             let triggerUpdate = false;
-            for (let i = 0; i < entries.length; i += 1) {
-              const { target, contentRect } = entries[i];
+            entries.forEach(({ target, contentRect }) => {
               const idx = Number(target.getAttribute('data-grid-item-idx'));
 
               if (typeof idx === 'number') {
-                const changedItem: T = this.state.items[idx];
+                const changedItem: T = this.state.items[idx]!;
                 const newHeight = contentRect.height;
 
                 triggerUpdate =
@@ -227,7 +226,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                     measurementStore: this.state.measurementStore,
                   }) || triggerUpdate;
               }
-            }
+            });
             if (triggerUpdate) {
               this.forceUpdate();
             }
@@ -708,7 +707,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
               this.renderLoadingStateComponent({
                 itemData,
                 idx,
-                position: positions[idx],
+                position: positions[idx]!,
               }),
             )}
           </div>
@@ -747,7 +746,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
                 i,
                 // If we have items in the positionStore (newer way of tracking positions used for 2-col support), use that. Otherwise fall back to the classic way of tracking positions
                 // this is only required atm because the two column layout doesn't not return positions in their original item order
-                positionStore.get(item) ?? positions[i],
+                positionStore.get(item) ?? positions[i]!,
               ),
             )}
           </div>
@@ -757,7 +756,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
               // we normalize the index here relative to the item list as a whole so that itemIdx is correct
               // and so that React doesnt reuse the measurement nodes
               const measurementIndex = itemsToRender.length + i;
-              const position = measuringPositions[i];
+              const position = measuringPositions[i]!;
               return (
                 <div
                   key={`measuring-${measurementIndex}`}

--- a/packages/gestalt/src/Masonry/defaultLayout.test.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.ts
@@ -279,10 +279,10 @@ describe.each([undefined, getColumnSpanConfig])('default layout tests', (_getCol
     const pin2Position = positions[2];
     const pin3Position = positions[3];
 
-    expect(pin2Position.height).toBe(0);
-    expect(pin2Position.top).toBe(0);
-    expect(pin3Position.top).toBe(0);
-    expect(pin2Position.left).toBe(pin3Position.left);
+    expect(pin2Position?.height).toBe(0);
+    expect(pin2Position?.top).toBe(0);
+    expect(pin3Position?.top).toBe(0);
+    expect(pin2Position?.left).toBe(pin3Position?.left);
   });
 });
 

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -94,28 +94,22 @@ const defaultLayout =
           _getColumnSpanConfig,
           ...otherProps,
         })
-      : items.reduce<Array<any>>((acc, item) => {
-          let position;
-
-          const positions = acc;
+      : items.map((item) => {
           const height = isLoadingStateItem(item, renderLoadingState)
             ? item.height
             : measurementCache.get(item);
 
           if (height == null) {
-            position = offscreen(columnWidth);
-          } else {
-            const heightAndGutter = getHeightAndGutter(height, gutter);
-            const col = mindex(heights);
-            const top = heights[col];
-            const left = col * columnWidthAndGutter + centerOffset;
-
-            heights[col] += heightAndGutter;
-            position = { top, left, width: columnWidth, height };
+            return offscreen(columnWidth);
           }
-          positions.push(position);
-          return positions;
-        }, []);
+          const heightAndGutter = getHeightAndGutter(height, gutter);
+          const col = mindex(heights);
+          const top = heights[col]!;
+          const left = col * columnWidthAndGutter + centerOffset;
+
+          heights[col] = heights[col]! + heightAndGutter;
+          return { top, left, width: columnWidth, height };
+        });
   };
 
 export default defaultLayout;

--- a/packages/gestalt/src/Masonry/dynamicHeightsUtils.test.ts
+++ b/packages/gestalt/src/Masonry/dynamicHeightsUtils.test.ts
@@ -16,7 +16,7 @@ describe('dynamic heights on masonry', () => {
   test('one column first item increase', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items = [
+    const items: readonly [Item, ...Item[]] = [
       { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
       { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
       { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
@@ -59,7 +59,7 @@ describe('dynamic heights on masonry', () => {
     });
 
     items.forEach((item, index) => {
-      const originalPos = positions[index];
+      const originalPos = positions[index]!;
       const newPos = positionCache.get(item);
 
       const expectedPos = {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -108,10 +108,10 @@ describe.each([undefined, getColumnSpanConfig])(
       const pin2Position = positions[2];
       const pin3Position = positions[3];
 
-      expect(pin2Position.height).toBe(0);
-      expect(pin2Position.top).toBe(0);
-      expect(pin3Position.top).toBe(0);
-      expect(pin2Position.left).toBe(pin3Position.left);
+      expect(pin2Position?.height).toBe(0);
+      expect(pin2Position?.top).toBe(0);
+      expect(pin3Position?.top).toBe(0);
+      expect(pin2Position?.left).toBe(pin3Position?.left);
     });
   },
 );

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -78,7 +78,7 @@ const fullWidthLayout = <T>({
             const top = heights[col];
             const left = col * columnWidthAndGutter + centerOffset;
 
-            heights[col] += heightAndGutter;
+            heights[col] = (heights[col] ?? 0) + heightAndGutter;
             position = {
               top,
               left,

--- a/packages/gestalt/src/Masonry/mindex.ts
+++ b/packages/gestalt/src/Masonry/mindex.ts
@@ -1,9 +1,3 @@
 export default function mindex(arr: ReadonlyArray<number>): number {
-  let idx = 0;
-  for (let i = 0; i < arr.length; i += 1) {
-    if (arr[i] < arr[idx]) {
-      idx = i;
-    }
-  }
-  return idx;
+  return arr.length ? arr.indexOf(Math.min(...arr)) : 0;
 }

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -108,10 +108,10 @@ describe('one column layout test cases', () => {
     const pin2Position = positions[2];
     const pin3Position = positions[3];
 
-    expect(pin2Position.height).toBe(0);
-    expect(pin2Position.top).toBe(0);
-    expect(pin3Position.top).toBe(0);
-    expect(pin2Position.left).toBe(pin3Position.left);
+    expect(pin2Position?.height).toBe(0);
+    expect(pin2Position?.top).toBe(0);
+    expect(pin3Position?.top).toBe(0);
+    expect(pin2Position?.left).toBe(pin3Position?.left);
   });
 });
 
@@ -149,7 +149,7 @@ describe('multi column layout test cases', () => {
     // perform single column layout first since we expect two column items on second page+ currently
     layout(items);
 
-    let newItems = [
+    const newItems = [
       { name: 'Pin 10', height: 210, color: '#30BAF6' },
       { name: 'Pin 11', height: 211, color: '#7076FA' },
       { name: 'Pin 12', height: 212, color: '#B032ED' },
@@ -164,17 +164,17 @@ describe('multi column layout test cases', () => {
     // perform positioning of batch with two column item
     layout(updatedItems);
 
-    newItems = [
+    const newItems2 = [
       { name: 'Pin 15', height: 210, color: '#30BAF6' },
       { name: 'Pin 16', height: 211, color: '#7076FA' },
       { name: 'Pin 17', height: 212, color: '#B032ED' },
       { name: 'Pin 18', height: 213, color: '#F21DCF', columnSpan: 3 },
       { name: 'Pin 19', height: 214, color: '#45098F' },
     ];
-    newItems.forEach((item: any) => {
+    newItems2.forEach((item: any) => {
       measurementStore.set(item, item.height);
     });
-    updatedItems = updatedItems.concat(newItems);
+    updatedItems = updatedItems.concat(newItems2);
 
     // perform positioning of batch with multi column item
     layout(updatedItems);
@@ -316,7 +316,7 @@ describe('multi column layout test cases', () => {
 
     // Placing the first one col item after first line we have a whitespace of 10
     // so we break early although the next combination has 0 whitespace
-    const items = [
+    const items: readonly [Item, Item, Item, Item, Item, ...Item[]] = [
       { 'name': 'Pin 0', 'height': 300, 'color': '#E230BA' },
       { 'name': 'Pin 1', 'height': 150, 'color': '#F67076' },
       { 'name': 'Pin 2', 'height': 350, 'color': '#FAB032' },
@@ -332,7 +332,7 @@ describe('multi column layout test cases', () => {
       measurementStore.set(item, item.height);
     });
 
-    const layout = (itemsToLayout: Item[]) =>
+    const layout = (itemsToLayout: readonly Item[]) =>
       multiColumnLayout({
         items: itemsToLayout,
         gutter: 0,
@@ -531,7 +531,7 @@ describe('multi column layout test cases', () => {
     // Correct position when two column module is on the start of the batch
     const positions = layout(items);
 
-    expect(positions[multiColumnModuleIndex].width).toEqual(1002);
+    expect(positions[multiColumnModuleIndex]?.width).toEqual(1002);
   });
 
   test('set correct width for multi col item that is scaled to fit', () => {
@@ -599,7 +599,7 @@ describe('multi column layout test cases', () => {
   test('correctly position multiple multi column items', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items = [
+    const items: readonly [Item, Item, Item, Item, Item, ...Item[]] = [
       { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
       { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
       { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032', columnSpan: 2 },
@@ -618,7 +618,7 @@ describe('multi column layout test cases', () => {
       measurementStore.set(item, item.height);
     });
 
-    const layout = (itemsToLayout: Item[]) =>
+    const layout = (itemsToLayout: readonly Item[]) =>
       multiColumnLayout({
         items: itemsToLayout,
         columnWidth: 240,
@@ -671,7 +671,7 @@ describe('multi column layout test cases', () => {
 
       const mockItems = [
         ...items.slice(0, multiColumnModuleIndex),
-        { ...items[multiColumnModuleIndex], columnSpan },
+        { ...items[multiColumnModuleIndex]!, columnSpan },
         ...items.slice(multiColumnModuleIndex + 1),
       ];
       mockItems.forEach((item: any) => {
@@ -729,7 +729,7 @@ describe('multi column layout test cases', () => {
 
       const mockItems = [
         ...items.slice(0, multiColumnModuleIndex),
-        { ...items[multiColumnModuleIndex], columnSpan },
+        { ...items[multiColumnModuleIndex]!, columnSpan },
         ...items.slice(multiColumnModuleIndex + 1),
       ];
       mockItems.forEach((item: any) => {
@@ -797,7 +797,7 @@ describe('multi column layout test cases', () => {
 
       const mockItems = [
         ...items.slice(0, multiColumnModuleIndex),
-        { ...items[multiColumnModuleIndex], columnSpan },
+        { ...items[multiColumnModuleIndex]!, columnSpan },
         ...items.slice(multiColumnModuleIndex + 1),
       ];
       mockItems.forEach((item: any) => {
@@ -832,7 +832,7 @@ describe('responsive module layout test cases', () => {
   test('sets the correct column width for fixed column span', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items = [
+    const items: readonly [Item, Item, Item, Item, Item, Item, Item, Item, Item, Item, Item] = [
       { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
       { 'name': 'Pin 1', 'height': 200, 'color': '#F67076' },
       { 'name': 'Pin 2', 'height': 200, 'color': '#FAB032' },
@@ -871,7 +871,7 @@ describe('responsive module layout test cases', () => {
   test('sets the correct column width for responsive column span', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
-    const items = [
+    const items: readonly [Item, Item, Item, Item, Item, Item, Item, Item, Item, Item, Item] = [
       { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
       { 'name': 'Pin 1', 'height': 200, 'color': '#F67076' },
       { 'name': 'Pin 2', 'height': 200, 'color': '#FAB032' },

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -69,7 +69,7 @@ function getAdjacentColumnHeightDeltas(
 ): ReadonlyArray<number> {
   const adjacentHeightDeltas = [];
   for (let i = 0; i < heights.length - 1; i += 1) {
-    adjacentHeightDeltas.push(Math.abs(heights[i] - heights[i + 1]));
+    adjacentHeightDeltas.push(Math.abs(heights[i]! - heights[i + 1]!));
   }
 
   if (columnSpan === 2) {
@@ -161,7 +161,7 @@ export function initializeHeightsArray<T>({
         // for each column the module spans -
         // if we've already set a taller height, we don't want to override it
         // otherwise, override the height of the column
-        if (absoluteHeight > heights[i]) {
+        if (absoluteHeight > heights[i]!) {
           heights[i] = absoluteHeight;
         }
       }
@@ -219,9 +219,9 @@ function getOneColumnItemPositions<T>({
       if (height != null) {
         const heightAndGutter = getHeightAndGutter(height, gutter);
         const col = mindex(heights);
-        const top = heights[col];
+        const top = heights[col]!;
         const left = col * columnWidthAndGutter + centerOffset;
-        heights[col] += heightAndGutter;
+        heights[col] = heights[col]! + heightAndGutter;
 
         return [
           ...positionsSoFar,
@@ -300,11 +300,11 @@ function getMultiColItemPosition<T>({
     lowestAdjacentColumnHeightDeltaIndex +
     lowestAdjacentColumnHeights.indexOf(Math.max(...lowestAdjacentColumnHeights));
 
-  const top = heights[tallestColumn];
+  const top = heights[tallestColumn]!;
   const left = lowestAdjacentColumnHeightDeltaIndex * columnWidthAndGutter + centerOffset;
 
   // Increase the heights of both adjacent columns
-  const tallestColumnFinalHeight = heights[tallestColumn] + heightAndGutter;
+  const tallestColumnFinalHeight = heights[tallestColumn]! + heightAndGutter;
 
   const additionalWhitespace = getAdjacentWhitespaceOnIndex(
     heights,
@@ -676,11 +676,11 @@ const multiColumnLayout = <T>({
     const batchSize = multiColumnItems.length;
     const batches = Array.from({ length: batchSize }, (): ReadonlyArray<T> => []).map(
       (batch, i) => {
-        const startIndex = i === 0 ? 0 : itemsWithoutPositions.indexOf(multiColumnItems[i]);
+        const startIndex = i === 0 ? 0 : itemsWithoutPositions.indexOf(multiColumnItems[i]!);
         const endIndex =
           i + 1 === multiColumnItems.length
             ? itemsWithoutPositions.length
-            : itemsWithoutPositions.indexOf(multiColumnItems[i + 1]);
+            : itemsWithoutPositions.indexOf(multiColumnItems[i + 1]!);
         return itemsWithoutPositions.slice(startIndex, endIndex);
       },
     );
@@ -702,7 +702,7 @@ const multiColumnLayout = <T>({
     } = batches.reduce(
       (acc, itemsToPosition, i) =>
         getPositionsWithMultiColumnItem({
-          multiColumnItem: multiColumnItems[i],
+          multiColumnItem: multiColumnItems[i]!,
           itemsToPosition,
           heights: acc.heights,
           prevPositions: acc.positions,

--- a/packages/gestalt/src/Masonry/uniformRowLayout.ts
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.ts
@@ -33,36 +33,29 @@ const uniformRowLayout =
     const columnWidthAndGutter = columnWidth + gutter;
     const columnCount = Math.max(Math.floor((width + gutter) / columnWidthAndGutter), minCols);
 
-    const positions = [];
-    const heights = [];
-
-    for (let i = 0; i < items.length; i += 1) {
-      let position;
-      const item = items[i];
+    const heights: Array<number> = [];
+    return items.map((item, i) => {
       const height = isLoadingStateItem(item, renderLoadingState) ? item.height : cache.get(item);
 
       if (height == null) {
-        position = offscreen(columnWidth);
-      } else {
-        const column = i % columnCount;
-        const row = Math.floor(i / columnCount);
-
-        if (column === 0 || height > heights[row]) {
-          heights[row] = height;
-        }
-
-        const top = row > 0 ? heights.slice(0, row).reduce((sum, y) => sum + y + gutter, 0) : 0;
-
-        position = {
-          top,
-          left: column * columnWidthAndGutter,
-          width: columnWidth,
-          height,
-        };
+        return offscreen(columnWidth);
       }
-      positions.push(position);
-    }
-    return positions;
+      const column = i % columnCount;
+      const row = Math.floor(i / columnCount);
+
+      if (column === 0 || height > heights[row]!) {
+        heights[row] = height;
+      }
+
+      const top = row > 0 ? heights.slice(0, row).reduce((sum, y) => sum + y + gutter, 0) : 0;
+
+      return {
+        top,
+        left: column * columnWidthAndGutter,
+        width: columnWidth,
+        height,
+      };
+    });
   };
 
 export default uniformRowLayout;

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -697,12 +697,11 @@ function Masonry<T>(
       _dynamicHeights && typeof window !== 'undefined' && positionStore
         ? new ResizeObserver((entries) => {
             let triggerUpdate = false;
-            for (let i = 0; i < entries.length; i += 1) {
-              const { target, contentRect } = entries[i];
+            entries.forEach(({ target, contentRect }) => {
               const idx = Number(target.getAttribute('data-grid-item-idx'));
 
               if (typeof idx === 'number') {
-                const changedItem: T = items[idx];
+                const changedItem: T = items[idx]!;
 
                 triggerUpdate =
                   recalcHeights({
@@ -713,7 +712,7 @@ function Masonry<T>(
                     measurementStore,
                   }) || triggerUpdate;
               }
-            }
+            });
             if (triggerUpdate) {
               setHeightUpdateTrigger((prev) => prev + 1);
             }

--- a/packages/gestalt/src/OverlayPanel.jsdom.test.tsx
+++ b/packages/gestalt/src/OverlayPanel.jsdom.test.tsx
@@ -330,7 +330,10 @@ describe('OverlayPanel', () => {
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
     if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
-    fireEvent.animationEnd(screen.getAllByRole('dialog')[0]);
+    const dialog = screen.getAllByRole('dialog')[0];
+    if (dialog) {
+      fireEvent.animationEnd(dialog);
+    }
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(0);
   });
@@ -405,7 +408,10 @@ describe('OverlayPanel', () => {
     const backDrop = screen.getByRole('dialog').parentElement?.firstElementChild;
     if (backDrop instanceof HTMLElement) fireEvent.click(backDrop);
 
-    fireEvent.animationEnd(screen.getAllByRole('dialog')[0]);
+    const dialog = screen.getAllByRole('dialog')[0];
+    if (dialog) {
+      fireEvent.animationEnd(dialog);
+    }
 
     expect(container).toMatchSnapshot();
   });

--- a/packages/gestalt/src/contexts/ExperimentProvider.ts
+++ b/packages/gestalt/src/contexts/ExperimentProvider.ts
@@ -19,5 +19,10 @@ export default ExperimentProvider;
 
 export function useExperimentContext(experimentName: string): Experiment {
   const experiments = useContext(ExperimentContext) ?? {};
-  return experiments[experimentName] ?? {};
+  return (
+    experiments[experimentName] ?? {
+      anyEnabled: false,
+      group: '',
+    }
+  );
 }

--- a/packages/gestalt/src/style.ts
+++ b/packages/gestalt/src/style.ts
@@ -55,7 +55,7 @@ export const concat = (styles: ReadonlyArray<Style>): Style =>
 export const mapClassName =
   (fn: (x: string) => string): ((arg1: Style) => Style) =>
   ({ className, inlineStyle }: Style): Style => ({
-    className: new Set(Array.from(className).map(fn)),
+    className: new Set(Array.from(className).map((n) => fn(n))),
     inlineStyle,
   });
 

--- a/packages/gestalt/src/transforms.ts
+++ b/packages/gestalt/src/transforms.ts
@@ -22,7 +22,9 @@ export const toggle =
 export const mapping =
   (map: { [key: string]: string }): ((val: string) => Style) =>
   (val) =>
-    Object.prototype.hasOwnProperty.call(map, val) ? fromClassName(map[val]) : identity();
+    Object.prototype.hasOwnProperty.call(map, val) && typeof map[val] === 'string'
+      ? fromClassName(map[val])
+      : identity();
 
 // Maps a range of integers to a range of classnames
 //     <Box padding={1} />
@@ -45,7 +47,7 @@ export function bind<T>(
     readonly [key: string]: string;
   },
 ): (val: T) => Style {
-  const map = mapClassName((name) => scope[name]);
+  const map = mapClassName((name) => scope[name]!);
   return (val: T): Style => map(fn(val));
 }
 

--- a/packages/gestalt/src/utils/keyboardNavigation.ts
+++ b/packages/gestalt/src/utils/keyboardNavigation.ts
@@ -31,7 +31,7 @@ const handleContainerScrolling = ({ direction, containerRef, currentHoveredOptio
   // If one of these nodes is missing, exit early
   if (!container || !nextSelectedOption) return;
 
-  const containerHeight = container.getClientRects()[0].height;
+  const containerHeight = container.getClientRects()[0]?.height ?? 0;
   const overScroll =
     nextSelectedOption instanceof HTMLElement && nextSelectedOption?.offsetHeight
       ? nextSelectedOption.offsetHeight / 3

--- a/packages/gestalt/src/utils/positioningUtils.ts
+++ b/packages/gestalt/src/utils/positioningUtils.ts
@@ -183,7 +183,7 @@ export function getPopoverDir({
     idealDirection &&
     // @ts-expect-error - TS2367 - This condition will always return 'true' since the types '"left" | "right" | "down" | "up"' and '"forceDown"' have no overlap.
     idealDirection !== 'forceDown' &&
-    spaces[DIR_INDEX_MAP[idealDirection]] > 0
+    (spaces[DIR_INDEX_MAP[idealDirection]] ?? 0) > 0
   ) {
     // user pref
     return idealDirection;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strictFunctionTypes": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "plugins": [


### PR DESCRIPTION
## What changed?

Make accessing objects safer by enabling the `noUncheckedIndexedAccess` option. See [this](https://www.totaltypescript.com/tips/make-accessing-objects-safer-by-enabling-nouncheckedindexedaccess-in-tsconfig) for more details.

## Problem

Consider the following code:
```ts
type User = { id: string; name: string };

const users: Array<User> = [];
console.log(users[0].name); // 🔴 TS does _not_ catch this runtime error

const userMap: { [id: string]: User } = {};
console.log(users['2a'].name); // 🔴 TS does _not_ catch this runtime error
```

By default, TypeScript does not raise an error here because it just assumes `users[index]` and `usersMap[key]` would be evaluated to be `User` rather than `User | undefined`. The rationale for TypeScript is that it strikes for a [balance between correctness and productivity](https://github.com/Microsoft/TypeScript/wiki/TypeScript-Design-Goals#non-goals). While this does reduce false errors in many cases, this is really dangerous and I would argue that the correctness is more important here.

## Solution

Luckily, TypeScript offers `noUncheckedIndexedAccess` option where we can opt-in so that objects/array index access is inferred as possibly `undefined`. 

After we turn the `noUncheckedIndexedAccess` option on, we now get TS errors on the sample code above, as expected, and we may fix like this:

```diff
const users: Array<User> = [];
-console.log(users[0].name); // TS now raises an error
+console.log(users[0]?.name); // fixed!

const userMap: { [id: string]: User } = {};
-console.log(users['2a'].name); // TS now raises an error
+console.log(users['2a']?.name); // fixed!
```

## Difficult Cases

Consider the following code:
```ts
const xArray = [1, 2] as const;
const yArray = [3, 4] as const;
const coordinates: ReadonlyArray<[number, number]> = xArray.map((x, i) => [x, yArray[i]]);
```

The annotation of `coordinate`, `ReadonlyArray<[number, number]>` is correct but now TypeScript is complaining. Is `noUncheckedIndexedAccess` option too sensitive?

It may appear to be, but what if `yArray` has fewer elements than `xArray`?
```diff
const xArray = [1, 2] as const;
-const yArray = [3, 4] as const;
+const yArray = [3] as const;
```
Now `coordinates` would be `[[1, 3], [2, undefined]]`, and our annotation `ReadonlyArray<[number, number]>` is no longer correct.

So how do we fix the error above?

**Solution 1**: Change `coordinates` to take into account that `yArray` may have fewer elements than `xArray`.
```diff
const xArray = [1, 2] as const;
const yArray = [3, 4] as const;
-const coordinates: ReadonlyArray<[number, number]> = xArray.map((x, i) => [x, yArray[i]]);
+const coordinates: ReadonlyArray<[number, number | undefined]> = xArray.map((x, i) => [x, yArray[i]]);
```

**Solution 2**: Tell TS that not to worry about out-of-bound case with [non-null assertion](https://www.totaltypescript.com/books/total-typescript-essentials/annotations-and-assertions#the-non-null-assertion)
```diff
const xArray = [1, 2] as const;
const yArray = [3, 4] as const;
-const coordinates: ReadonlyArray<[number, number]> = xArray.map((x, i) => [x, yArray[i]]);
+const coordinates: ReadonlyArray<[number, number]> = xArray.map((x, i) => [x, yArray[i]!]);
```

## Why?

Failing to check for indexed access for safety index access is a common source of bugs. Turning the `noUncheckedIndexedAccess` option would require developers to always explicitly check for indexed access, avoiding a big class of potential bugs. See [this](https://www.totaltypescript.com/tips/make-accessing-objects-safer-by-enabling-nouncheckedindexedaccess-in-tsconfig) for more details.
