### PR TITLE
IconButton: refactor to prevent snapshot change

### DIFF
--- a/packages/gestalt/src/Accordion/__snapshots__/ExpandableItem.test.tsx.snap
+++ b/packages/gestalt/src/Accordion/__snapshots__/ExpandableItem.test.tsx.snap
@@ -526,55 +526,51 @@ exports[`AccordionExpandableItem renders correctly with icon button 1`] = `
                     }
                   }
                 >
-                  <div
-                    className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+                  <button
+                    aria-label="Get help"
+                    className="parentButton"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchCancel={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    type="button"
                   >
-                    <button
-                      aria-label="Get help"
-                      className="parentButton"
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onFocus={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseEnter={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchCancel={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
+                    <div
+                      className="button tapTransition enabled"
                     >
                       <div
-                        className="button tapTransition enabled"
-                      >
-                        <div
-                          className="pog lightGray"
-                          style={
-                            Object {
-                              "height": 24,
-                              "width": 24,
-                            }
+                        className="pog lightGray"
+                        style={
+                          Object {
+                            "height": 24,
+                            "width": 24,
                           }
+                        }
+                      >
+                        <svg
+                          aria-hidden={true}
+                          aria-label=""
+                          className="default icon iconBlock"
+                          height={12}
+                          role="img"
+                          viewBox="0 0 24 24"
+                          width={12}
                         >
-                          <svg
-                            aria-hidden={true}
-                            aria-label=""
-                            className="default icon iconBlock"
-                            height={12}
-                            role="img"
-                            viewBox="0 0 24 24"
-                            width={12}
-                          >
-                            <path
-                              d="test-file-stub"
-                            />
-                          </svg>
-                        </div>
+                          <path
+                            d="test-file-stub"
+                          />
+                        </svg>
                       </div>
-                    </button>
-                  </div>
+                    </div>
+                  </button>
                 </div>
               </div>
             </div>

--- a/packages/gestalt/src/IconButton.tsx
+++ b/packages/gestalt/src/IconButton.tsx
@@ -195,7 +195,7 @@ const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function I
     [styles.hoverText]: isHovered && !isActive,
   });
 
-  const divStyles = classnames(styles.button, touchableStyles.tapTransition, compressStyle, {
+  const divStyles = classnames(styles.button, touchableStyles.tapTransition, {
     [styles.disabled]: disabled,
     [styles.enabled]: !disabled,
     [touchableStyles.tapCompress]: !disabled && isTapping,
@@ -268,23 +268,27 @@ const IconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function I
     </div>
   );
 
-  return (
+  const buttonWithTooltip = tooltip?.text ? (
+    <Tooltip
+      accessibilityLabel={tooltip.accessibilityLabel}
+      idealDirection={tooltip.idealDirection}
+      inline={tooltip.inline}
+      text={tooltip.text}
+      zIndex={tooltip.zIndex}
+    >
+      {buttonComponent}
+    </Tooltip>
+  ) : (
+    buttonComponent
+  );
+
+  return label && size === 'xl' ? (
     <Flex alignItems="center" direction="column">
-      {tooltip?.text ? (
-        <Tooltip
-          accessibilityLabel={tooltip.accessibilityLabel}
-          idealDirection={tooltip.idealDirection}
-          inline={tooltip.inline}
-          text={tooltip.text}
-          zIndex={tooltip.zIndex}
-        >
-          {buttonComponent}
-        </Tooltip>
-      ) : (
-        buttonComponent
-      )}
-      {label && size === 'xl' && labelComponent}
+      {buttonWithTooltip}
+      {labelComponent}
     </Flex>
+  ) : (
+    buttonWithTooltip
   );
 });
 

--- a/packages/gestalt/src/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Accordion.test.tsx.snap
@@ -245,55 +245,51 @@ exports[`Accordion renders an icon button correctly 1`] = `
             }
           }
         >
-          <div
-            className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+          <button
+            aria-label="Get help"
+            className="parentButton"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
           >
-            <button
-              aria-label="Get help"
-              className="parentButton"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <div
+              className="button tapTransition enabled"
             >
               <div
-                className="button tapTransition enabled"
-              >
-                <div
-                  className="pog lightGray"
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
+                className="pog lightGray"
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
                   }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="default icon iconBlock"
+                  height={12}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={12}
                 >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="default icon iconBlock"
-                    height={12}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={12}
-                  >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
-                </div>
+                  <path
+                    d="test-file-stub"
+                  />
+                </svg>
               </div>
-            </button>
-          </div>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/packages/gestalt/src/__snapshots__/ActivationCard.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/ActivationCard.test.tsx.snap
@@ -354,55 +354,51 @@ exports[`<ActivationCard /> message + title + link + dismissButton 1`] = `
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss card"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss card"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="subtle icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="subtle icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/BannerCallout.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/BannerCallout.test.tsx.snap
@@ -299,55 +299,51 @@ exports[`<BannerCallout /> bannercallout with rich text message 1`] = `
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss this banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss this banner"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -458,55 +454,51 @@ exports[`<BannerCallout /> message + title + primaryAction + dismissButton 1`] =
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss banner"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/BannerSlim.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/BannerSlim.test.tsx.snap
@@ -279,55 +279,51 @@ exports[`BannerSlim renders primary action and dismiss button 1`] = `
         <div
           className="FlexItem"
         >
-          <div
-            className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+          <button
+            aria-label="Dismiss banner"
+            className="parentButton"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchCancel={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
           >
-            <button
-              aria-label="Dismiss banner"
-              className="parentButton"
-              onBlur={[Function]}
-              onClick={[Function]}
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchCancel={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <div
+              className="button tapTransition enabled"
             >
               <div
-                className="button tapTransition enabled"
-              >
-                <div
-                  className="pog transparent"
-                  style={
-                    Object {
-                      "height": 24,
-                      "width": 24,
-                    }
+                className="pog transparent"
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
                   }
+                }
+              >
+                <svg
+                  aria-hidden={true}
+                  aria-label=""
+                  className="default icon iconBlock"
+                  height={12}
+                  role="img"
+                  viewBox="0 0 24 24"
+                  width={12}
                 >
-                  <svg
-                    aria-hidden={true}
-                    aria-label=""
-                    className="default icon iconBlock"
-                    height={12}
-                    role="img"
-                    viewBox="0 0 24 24"
-                    width={12}
-                  >
-                    <path
-                      d="test-file-stub"
-                    />
-                  </svg>
-                </div>
+                  <path
+                    d="test-file-stub"
+                  />
+                </svg>
               </div>
-            </button>
-          </div>
+            </div>
+          </button>
         </div>
       </div>
     </div>

--- a/packages/gestalt/src/__snapshots__/BannerUpsell.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/BannerUpsell.test.tsx.snap
@@ -200,55 +200,51 @@ exports[`<BannerUpsell /> message + title + dismissButton + image + form 1`] = `
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss banner"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -374,55 +370,51 @@ exports[`<BannerUpsell /> message + title + primaryAction + dismissButton + imag
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss banner"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;
@@ -516,55 +508,51 @@ exports[`<BannerUpsell /> message + title + primaryAction + dismissButton 1`] = 
   <div
     className="rtlPos"
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-label="Dismiss banner"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-label="Dismiss banner"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 48,
-                "width": 48,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 48,
+              "width": 48,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={16}
+            role="img"
+            viewBox="0 0 24 24"
+            width={16}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={16}
-              role="img"
-              viewBox="0 0 24 24"
-              width={16}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </div>
 </div>
 `;

--- a/packages/gestalt/src/__snapshots__/IconButton.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/IconButton.jsdom.test.tsx.snap
@@ -2,160 +2,144 @@
 
 exports[`IconButton renders with disabled state 1`] = `
 <div>
-  <div
-    class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+  <button
+    aria-label="Pinterest"
+    class="parentButton"
+    disabled=""
+    type="button"
   >
-    <button
-      aria-label="Pinterest"
-      class="parentButton"
-      disabled=""
-      type="button"
+    <div
+      class="button tapTransition disabled"
     >
       <div
-        class="button tapTransition disabled"
+        class="pog transparent"
+        style="height: 48px; width: 48px;"
       >
-        <div
-          class="pog transparent"
-          style="height: 48px; width: 48px;"
+        <svg
+          aria-hidden="true"
+          aria-label=""
+          class="default icon iconBlock"
+          height="20"
+          role="img"
+          viewBox="0 0 24 24"
+          width="20"
         >
-          <svg
-            aria-hidden="true"
-            aria-label=""
-            class="default icon iconBlock"
-            height="20"
-            role="img"
-            viewBox="0 0 24 24"
-            width="20"
-          >
-            <path
-              d="test-file-stub"
-            />
-          </svg>
-        </div>
+          <path
+            d="test-file-stub"
+          />
+        </svg>
       </div>
-    </button>
-  </div>
+    </div>
+  </button>
 </div>
 `;
 
 exports[`IconButton renders with icon 1`] = `
 <div>
-  <div
-    class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+  <button
+    aria-label="Pinterest"
+    class="parentButton"
+    tabindex="0"
+    type="button"
   >
-    <button
-      aria-label="Pinterest"
-      class="parentButton"
-      tabindex="0"
-      type="button"
+    <div
+      class="button tapTransition enabled"
     >
       <div
-        class="button tapTransition enabled"
+        class="pog transparent"
+        style="height: 48px; width: 48px;"
       >
-        <div
-          class="pog transparent"
-          style="height: 48px; width: 48px;"
+        <svg
+          aria-hidden="true"
+          aria-label=""
+          class="default icon iconBlock"
+          height="20"
+          role="img"
+          viewBox="0 0 24 24"
+          width="20"
         >
-          <svg
-            aria-hidden="true"
-            aria-label=""
-            class="default icon iconBlock"
-            height="20"
-            role="img"
-            viewBox="0 0 24 24"
-            width="20"
-          >
-            <path
-              d="test-file-stub"
-            />
-          </svg>
-        </div>
+          <path
+            d="test-file-stub"
+          />
+        </svg>
       </div>
-    </button>
-  </div>
+    </div>
+  </button>
 </div>
 `;
 
 exports[`IconButton renders with svg 1`] = `
 <div>
-  <div
-    class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+  <button
+    aria-label="Pinterest"
+    class="parentButton"
+    tabindex="0"
+    type="button"
   >
-    <button
-      aria-label="Pinterest"
-      class="parentButton"
-      tabindex="0"
-      type="button"
+    <div
+      class="button tapTransition enabled"
     >
       <div
-        class="button tapTransition enabled"
+        class="pog transparent"
+        style="height: 48px; width: 48px;"
       >
-        <div
-          class="pog transparent"
-          style="height: 48px; width: 48px;"
+        <svg
+          aria-hidden="true"
+          aria-label=""
+          class="default icon iconBlock"
+          height="20"
+          role="img"
+          viewBox="0 0 24 24"
+          width="20"
         >
-          <svg
-            aria-hidden="true"
-            aria-label=""
-            class="default icon iconBlock"
-            height="20"
-            role="img"
-            viewBox="0 0 24 24"
-            width="20"
-          >
-            <path
-              d="M13.00,20.00"
-            />
-          </svg>
-        </div>
+          <path
+            d="M13.00,20.00"
+          />
+        </svg>
       </div>
-    </button>
-  </div>
+    </div>
+  </button>
 </div>
 `;
 
 exports[`IconButton renders with tooltip 1`] = `
 <div>
   <div
-    class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    class="box xsDisplayBlock"
   >
     <div
-      class="box xsDisplayBlock"
+      aria-label="This Pin is private unless you share it with others."
+      class="box"
     >
-      <div
-        aria-label="This Pin is private unless you share it with others."
-        class="box"
+      <button
+        aria-label="Share"
+        class="parentButton"
+        tabindex="0"
+        type="button"
       >
-        <button
-          aria-label="Share"
-          class="parentButton"
-          tabindex="0"
-          type="button"
+        <div
+          class="button tapTransition enabled"
         >
           <div
-            class="button tapTransition enabled"
+            class="pog transparent"
+            style="height: 48px; width: 48px;"
           >
-            <div
-              class="pog transparent"
-              style="height: 48px; width: 48px;"
+            <svg
+              aria-hidden="true"
+              aria-label=""
+              class="default icon iconBlock"
+              height="20"
+              role="img"
+              viewBox="0 0 24 24"
+              width="20"
             >
-              <svg
-                aria-hidden="true"
-                aria-label=""
-                class="default icon iconBlock"
-                height="20"
-                role="img"
-                viewBox="0 0 24 24"
-                width="20"
-              >
-                <path
-                  d="test-file-stub"
-                />
-              </svg>
-            </div>
+              <path
+                d="test-file-stub"
+              />
+            </svg>
           </div>
-        </button>
-      </div>
+        </div>
+      </button>
     </div>
   </div>
 </div>
@@ -164,45 +148,41 @@ exports[`IconButton renders with tooltip 1`] = `
 exports[`IconButton renders with tooltip and no accessibilityLabel 1`] = `
 <div>
   <div
-    class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    class="box xsDisplayBlock"
   >
     <div
-      class="box xsDisplayBlock"
+      aria-label=""
+      class="box"
     >
-      <div
-        aria-label=""
-        class="box"
+      <button
+        aria-label="Share"
+        class="parentButton"
+        tabindex="0"
+        type="button"
       >
-        <button
-          aria-label="Share"
-          class="parentButton"
-          tabindex="0"
-          type="button"
+        <div
+          class="button tapTransition enabled"
         >
           <div
-            class="button tapTransition enabled"
+            class="pog transparent"
+            style="height: 48px; width: 48px;"
           >
-            <div
-              class="pog transparent"
-              style="height: 48px; width: 48px;"
+            <svg
+              aria-hidden="true"
+              aria-label=""
+              class="default icon iconBlock"
+              height="20"
+              role="img"
+              viewBox="0 0 24 24"
+              width="20"
             >
-              <svg
-                aria-hidden="true"
-                aria-label=""
-                class="default icon iconBlock"
-                height="20"
-                role="img"
-                viewBox="0 0 24 24"
-                width="20"
-              >
-                <path
-                  d="test-file-stub"
-                />
-              </svg>
-            </div>
+              <path
+                d="test-file-stub"
+              />
+            </svg>
           </div>
-        </button>
-      </div>
+        </div>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/ModalAlert.jsdom.test.tsx.snap
@@ -50,39 +50,35 @@ exports[`ModalAlert Desktop ModalAlert renders (default) 1`] = `
                     <div
                       class="box marginStart2"
                     >
-                      <div
-                        class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+                      <button
+                        aria-label="Dismiss modal"
+                        class="parentButton"
+                        tabindex="0"
+                        type="button"
                       >
-                        <button
-                          aria-label="Dismiss modal"
-                          class="parentButton"
-                          tabindex="0"
-                          type="button"
+                        <div
+                          class="button tapTransition enabled"
                         >
                           <div
-                            class="button tapTransition enabled"
+                            class="pog white"
+                            style="height: 32px; width: 32px;"
                           >
-                            <div
-                              class="pog white"
-                              style="height: 32px; width: 32px;"
+                            <svg
+                              aria-hidden="true"
+                              aria-label=""
+                              class="default icon iconBlock"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width="16"
                             >
-                              <svg
-                                aria-hidden="true"
-                                aria-label=""
-                                class="default icon iconBlock"
-                                height="16"
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width="16"
-                              >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
-                            </div>
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
                           </div>
-                        </button>
-                      </div>
+                        </div>
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -413,39 +409,35 @@ exports[`ModalAlert Mobile Desktop ModalAlert renders 1`] = `
                     <div
                       class="box marginStart2"
                     >
-                      <div
-                        class="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+                      <button
+                        aria-label="Dismiss modal"
+                        class="parentButton"
+                        tabindex="0"
+                        type="button"
                       >
-                        <button
-                          aria-label="Dismiss modal"
-                          class="parentButton"
-                          tabindex="0"
-                          type="button"
+                        <div
+                          class="button tapTransition enabled"
                         >
                           <div
-                            class="button tapTransition enabled"
+                            class="pog white"
+                            style="height: 32px; width: 32px;"
                           >
-                            <div
-                              class="pog white"
-                              style="height: 32px; width: 32px;"
+                            <svg
+                              aria-hidden="true"
+                              aria-label=""
+                              class="default icon iconBlock"
+                              height="16"
+                              role="img"
+                              viewBox="0 0 24 24"
+                              width="16"
                             >
-                              <svg
-                                aria-hidden="true"
-                                aria-label=""
-                                class="default icon iconBlock"
-                                height="16"
-                                role="img"
-                                viewBox="0 0 24 24"
-                                width="16"
-                              >
-                                <path
-                                  d="test-file-stub"
-                                />
-                              </svg>
-                            </div>
+                              <path
+                                d="test-file-stub"
+                              />
+                            </svg>
                           </div>
-                        </button>
-                      </div>
+                        </div>
+                      </button>
                     </div>
                   </div>
                 </div>

--- a/packages/gestalt/src/__snapshots__/PageHeader.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/PageHeader.test.tsx.snap
@@ -434,58 +434,54 @@ exports[`PageHeader renders primary action 1`] = `
               <div
                 className="box mdDisplayNone xsDisplayBlock"
               >
-                <div
-                  className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+                <button
+                  aria-controls="pageheader-dropdown"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="test"
+                  className="parentButton"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <button
-                    aria-controls="pageheader-dropdown"
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    aria-label="test"
-                    className="parentButton"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    type="button"
+                  <div
+                    className="button tapTransition enabled"
                   >
                     <div
-                      className="button tapTransition enabled"
-                    >
-                      <div
-                        className="pog transparent"
-                        style={
-                          Object {
-                            "height": 48,
-                            "width": 48,
-                          }
+                      className="pog transparent"
+                      style={
+                        Object {
+                          "height": 48,
+                          "width": 48,
                         }
+                      }
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="default icon iconBlock"
+                        height={20}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={20}
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-label=""
-                          className="default icon iconBlock"
-                          height={20}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={20}
-                        >
-                          <path
-                            d="test-file-stub"
-                          />
-                        </svg>
-                      </div>
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
                     </div>
-                  </button>
-                </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>
@@ -691,58 +687,54 @@ exports[`PageHeader renders secondary action 1`] = `
               <div
                 className="box mdDisplayNone xsDisplayBlock"
               >
-                <div
-                  className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+                <button
+                  aria-controls="pageheader-dropdown"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="test"
+                  className="parentButton"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchCancel={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <button
-                    aria-controls="pageheader-dropdown"
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    aria-label="test"
-                    className="parentButton"
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onFocus={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchCancel={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    type="button"
+                  <div
+                    className="button tapTransition enabled"
                   >
                     <div
-                      className="button tapTransition enabled"
-                    >
-                      <div
-                        className="pog transparent"
-                        style={
-                          Object {
-                            "height": 48,
-                            "width": 48,
-                          }
+                      className="pog transparent"
+                      style={
+                        Object {
+                          "height": 48,
+                          "width": 48,
                         }
+                      }
+                    >
+                      <svg
+                        aria-hidden={true}
+                        aria-label=""
+                        className="default icon iconBlock"
+                        height={20}
+                        role="img"
+                        viewBox="0 0 24 24"
+                        width={20}
                       >
-                        <svg
-                          aria-hidden={true}
-                          aria-label=""
-                          className="default icon iconBlock"
-                          height={20}
-                          role="img"
-                          viewBox="0 0 24 24"
-                          width={20}
-                        >
-                          <path
-                            d="test-file-stub"
-                          />
-                        </svg>
-                      </div>
+                        <path
+                          d="test-file-stub"
+                        />
+                      </svg>
                     </div>
-                  </button>
-                </div>
+                  </div>
+                </button>
               </div>
             </div>
           </div>

--- a/packages/gestalt/src/__snapshots__/TableRowExpandable.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/TableRowExpandable.test.tsx.snap
@@ -13,57 +13,53 @@ exports[`renders correctly 1`] = `
       }
     }
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-controls="expandableRow"
+      aria-expanded={false}
+      aria-label="Expand"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-controls="expandableRow"
-        aria-expanded={false}
-        aria-label="Expand"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 24,
-                "width": 24,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={12}
-              role="img"
-              viewBox="0 0 24 24"
-              width={12}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </td>
   <div>
     row cells
@@ -84,57 +80,53 @@ exports[`renders correctly with explicit hover 1`] = `
       }
     }
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-controls="expandableRow"
+      aria-expanded={false}
+      aria-label="Expand"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-controls="expandableRow"
-        aria-expanded={false}
-        aria-label="Expand"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 24,
-                "width": 24,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={12}
-              role="img"
-              viewBox="0 0 24 24"
-              width={12}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </td>
   <div>
     row cells
@@ -155,57 +147,53 @@ exports[`renders correctly without hover 1`] = `
       }
     }
   >
-    <div
-      className="Flex rowGap0 columnGap0 xsDirectionColumn xsItemsCenter"
+    <button
+      aria-controls="expandableRow"
+      aria-expanded={false}
+      aria-label="Expand"
+      className="parentButton"
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
     >
-      <button
-        aria-controls="expandableRow"
-        aria-expanded={false}
-        aria-label="Expand"
-        className="parentButton"
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={0}
-        type="button"
+      <div
+        className="button tapTransition enabled"
       >
         <div
-          className="button tapTransition enabled"
-        >
-          <div
-            className="pog transparent"
-            style={
-              Object {
-                "height": 24,
-                "width": 24,
-              }
+          className="pog transparent"
+          style={
+            Object {
+              "height": 24,
+              "width": 24,
             }
+          }
+        >
+          <svg
+            aria-hidden={true}
+            aria-label=""
+            className="default icon iconBlock"
+            height={12}
+            role="img"
+            viewBox="0 0 24 24"
+            width={12}
           >
-            <svg
-              aria-hidden={true}
-              aria-label=""
-              className="default icon iconBlock"
-              height={12}
-              role="img"
-              viewBox="0 0 24 24"
-              width={12}
-            >
-              <path
-                d="test-file-stub"
-              />
-            </svg>
-          </div>
+            <path
+              d="test-file-stub"
+            />
+          </svg>
         </div>
-      </button>
-    </div>
+      </div>
+    </button>
   </td>
   <div>
     row cells


### PR DESCRIPTION
### Summary

#### What changed?

The wrapping flex around IconButton now renders conditionally

#### Why?

To reduce the number of snapshot changes necessary on Pinboard when bumping #3720