### PR TITLE
Tabs: fix padding

### DIFF
--- a/packages/gestalt/src/Tabs.css
+++ b/packages/gestalt/src/Tabs.css
@@ -1,6 +1,5 @@
 .paddingY {
-  padding-left: var(--space-300);
-  padding-right: var(--space-300);
+  composes: paddingY3 from "./boxWhitespace.css";
 }
 
 .focused {


### PR DESCRIPTION
Tabs: fix padding


Padding needed to position the underline border