### PR TITLE
TapArea: support to VR visible focus style

### DIFF
--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -3,18 +3,111 @@ import { Box, Flex, TapArea } from 'gestalt';
 export default function TapAreaExample() {
   return (
     <Box padding={8} width="100%">
-      <Flex direction="column" gap={6} width="100%">
-        <Box alignItems='center' borderStyle="sm" display='flex' height={100} justifyContent='center' width={100}>
-          <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
-            <Box height={50} width={50} />
-          </TapArea>
-        </Box>
+      <Flex gap={6} width="100%">
+        <Flex direction="column" gap={6} width="100%">
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
 
-        <Box alignItems='center' borderStyle="sm" color="selected" display='flex' height={100} justifyContent='center' width={100}>
-          <TapArea focusColor="darkBackground" fullHeight={false} fullWidth={false}>
-            <Box height={50} width={50} />
-          </TapArea>
-        </Box>
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color="selected"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea focusColor="darkBackground" fullHeight={false} fullWidth={false}>
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+        </Flex>
+        <Flex direction="column" gap={6} width="100%">
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea
+              focusColor="lightBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="default"
+            >
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color="selected"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea
+              focusColor="darkBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="default"
+            >
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+        </Flex>
+        <Flex direction="column" gap={6} width="100%">
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea
+              focusColor="lightBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="inverse"
+            >
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color="selected"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
+          >
+            <TapArea
+              focusColor="darkBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="inverse"
+            >
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+        </Flex>{' '}
       </Flex>
     </Box>
   );

--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -36,18 +36,13 @@ export default function TapAreaExample() {
           <Box
             alignItems="center"
             borderStyle="sm"
-            color="successBase"
+            color="successWeak"
             display="flex"
             height={100}
             justifyContent="center"
             width={100}
           >
-            <TapArea
-              focusColor="darkBackground"
-              fullHeight={false}
-              fullWidth={false}
-              innerFocusColor="default"
-            >
+            <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false} innerFocusColor='default'>
               <Box height={50} width={50} />
             </TapArea>
           </Box>
@@ -61,53 +56,40 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={100}
           >
-            <TapArea
-              focusColor="darkBackground"
-              fullHeight={false}
-              fullWidth={false}
-              innerFocusColor="default"
-            >
+            <TapArea focusColor="darkBackground"  fullHeight={false} fullWidth={false} innerFocusColor='default'>
               <Box height={50} width={50} />
             </TapArea>
           </Box>
         </Flex>
-        <Box
-          alignItems="center"
-          borderStyle="sm"
-          color="successBase"
-          display="flex"
-          height={100}
-          justifyContent="center"
-          width={100}
-        >
-          <TapArea
-            focusColor="darkBackground"
-            fullHeight={false}
-            fullWidth={false}
-            innerFocusColor="inverse"
+        <Flex direction="column" gap={6} width="100%">
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color="successWeak"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
           >
-            <Box height={50} width={50} />
-          </TapArea>
-        </Box>
+            <TapArea  focusColor="lightBackground"   fullHeight={false} fullWidth={false} innerFocusColor='inverse'>
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
 
-        <Box
-          alignItems="center"
-          borderStyle="sm"
-          color="successBase"
-          display="flex"
-          height={100}
-          justifyContent="center"
-          width={100}
-        >
-          <TapArea
-            focusColor="darkBackground"
-            fullHeight={false}
-            fullWidth={false}
-            innerFocusColor="inverse"
+          <Box
+            alignItems="center"
+            borderStyle="sm"
+            color="successBase"
+            display="flex"
+            height={100}
+            justifyContent="center"
+            width={100}
           >
-            <Box height={50} width={50} />
-          </TapArea>
-        </Box>
+            <TapArea focusColor="darkBackground"  fullHeight={false} fullWidth={false} innerFocusColor='inverse'>
+              <Box height={50} width={50} />
+            </TapArea>
+          </Box>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -1,0 +1,21 @@
+import { Box, Flex, TapArea } from 'gestalt';
+
+export default function TapAreaExample() {
+  return (
+    <Box padding={8} width="100%">
+      <Flex direction="column" gap={6} width="100%">
+        <Box alignItems='center' borderStyle="sm" display='flex' height={100} justifyContent='center' width={100}>
+          <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
+            <Box height={50} width={50} />
+          </TapArea>
+        </Box>
+
+        <Box alignItems='center' borderStyle="sm" color="selected" display='flex' height={100} justifyContent='center' width={100}>
+          <TapArea focusColor="darkBackground" fullHeight={false} fullWidth={false}>
+            <Box height={50} width={50} />
+          </TapArea>
+        </Box>
+      </Flex>
+    </Box>
+  );
+}

--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -36,13 +36,14 @@ export default function TapAreaExample() {
           <Box
             alignItems="center"
             borderStyle="sm"
+            color="successBase"
             display="flex"
             height={100}
             justifyContent="center"
             width={100}
           >
             <TapArea
-              focusColor="lightBackground"
+              focusColor="darkBackground"
               fullHeight={false}
               fullWidth={false}
               innerFocusColor="default"
@@ -54,7 +55,7 @@ export default function TapAreaExample() {
           <Box
             alignItems="center"
             borderStyle="sm"
-            color="selected"
+            color="successBase"
             display="flex"
             height={100}
             justifyContent="center"
@@ -70,44 +71,43 @@ export default function TapAreaExample() {
             </TapArea>
           </Box>
         </Flex>
-        <Flex direction="column" gap={6} width="100%">
-          <Box
-            alignItems="center"
-            borderStyle="sm"
-            display="flex"
-            height={100}
-            justifyContent="center"
-            width={100}
+        <Box
+          alignItems="center"
+          borderStyle="sm"
+          color="successBase"
+          display="flex"
+          height={100}
+          justifyContent="center"
+          width={100}
+        >
+          <TapArea
+            focusColor="darkBackground"
+            fullHeight={false}
+            fullWidth={false}
+            innerFocusColor="inverse"
           >
-            <TapArea
-              focusColor="lightBackground"
-              fullHeight={false}
-              fullWidth={false}
-              innerFocusColor="inverse"
-            >
-              <Box height={50} width={50} />
-            </TapArea>
-          </Box>
+            <Box height={50} width={50} />
+          </TapArea>
+        </Box>
 
-          <Box
-            alignItems="center"
-            borderStyle="sm"
-            color="selected"
-            display="flex"
-            height={100}
-            justifyContent="center"
-            width={100}
+        <Box
+          alignItems="center"
+          borderStyle="sm"
+          color="successBase"
+          display="flex"
+          height={100}
+          justifyContent="center"
+          width={100}
+        >
+          <TapArea
+            focusColor="darkBackground"
+            fullHeight={false}
+            fullWidth={false}
+            innerFocusColor="inverse"
           >
-            <TapArea
-              focusColor="darkBackground"
-              fullHeight={false}
-              fullWidth={false}
-              innerFocusColor="inverse"
-            >
-              <Box height={50} width={50} />
-            </TapArea>
-          </Box>
-        </Flex>{' '}
+            <Box height={50} width={50} />
+          </TapArea>
+        </Box>
       </Flex>
     </Box>
   );

--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, TapArea } from 'gestalt';
+import { Box, Flex, TapArea, Text } from 'gestalt';
 
 export default function TapAreaExample() {
   return (
@@ -9,12 +9,16 @@ export default function TapAreaExample() {
             alignItems="center"
             borderStyle="sm"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
             <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
-              <Box height={50} width={50} />
+              <Box height={100} width={100}>
+                <Text size="100">
+                  focusColor=lightBackground
+                </Text>
+              </Box>
             </TapArea>
           </Box>
 
@@ -23,12 +27,16 @@ export default function TapAreaExample() {
             borderStyle="sm"
             color="selected"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
             <TapArea focusColor="darkBackground" fullHeight={false} fullWidth={false}>
-              <Box height={50} width={50} />
+              <Box height={100} width={100}>
+                <Text color="inverse" size="100">
+                  focusColor=darkBackground
+                </Text>
+              </Box>
             </TapArea>
           </Box>
         </Flex>
@@ -38,12 +46,21 @@ export default function TapAreaExample() {
             borderStyle="sm"
             color="successWeak"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
-            <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false} innerFocusColor='default'>
-              <Box height={50} width={50} />
+            <TapArea
+              focusColor="lightBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="default"
+            >
+              <Box height={100} width={100}>
+                <Text size="100">
+                  focusColor=lightBackground & innerFocusColor=default
+                </Text>
+              </Box>
             </TapArea>
           </Box>
 
@@ -52,12 +69,21 @@ export default function TapAreaExample() {
             borderStyle="sm"
             color="successBase"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
-            <TapArea focusColor="darkBackground"  fullHeight={false} fullWidth={false} innerFocusColor='default'>
-              <Box height={50} width={50} />
+            <TapArea
+              focusColor="darkBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="default"
+            >
+              <Box height={100} width={100}>
+                <Text size="100">
+                  focusColor=darkBackground & innerFocusColor=default
+                </Text>
+              </Box>
             </TapArea>
           </Box>
         </Flex>
@@ -67,12 +93,21 @@ export default function TapAreaExample() {
             borderStyle="sm"
             color="successWeak"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
-            <TapArea  focusColor="lightBackground"   fullHeight={false} fullWidth={false} innerFocusColor='inverse'>
-              <Box height={50} width={50} />
+            <TapArea
+              focusColor="lightBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="inverse"
+            >
+              <Box height={100} width={100}>
+                <Text size="100">
+                  focusColor=lightBackground & innerFocusColor=inverse
+                </Text>
+              </Box>
             </TapArea>
           </Box>
 
@@ -81,12 +116,21 @@ export default function TapAreaExample() {
             borderStyle="sm"
             color="successBase"
             display="flex"
-            height={100}
+            height={150}
             justifyContent="center"
-            width={100}
+            width={150}
           >
-            <TapArea focusColor="darkBackground"  fullHeight={false} fullWidth={false} innerFocusColor='inverse'>
-              <Box height={50} width={50} />
+            <TapArea
+              focusColor="darkBackground"
+              fullHeight={false}
+              fullWidth={false}
+              innerFocusColor="inverse"
+            >
+              <Box height={100} width={100}>
+                <Text size="100">
+                  focusColor=darkBackground & innerFocusColor=inverse
+                </Text>
+              </Box>
             </TapArea>
           </Box>
         </Flex>

--- a/docs/examples/taparea/focus.tsx
+++ b/docs/examples/taparea/focus.tsx
@@ -15,9 +15,7 @@ export default function TapAreaExample() {
           >
             <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
               <Box height={100} width={100}>
-                <Text size="100">
-                  focusColor=lightBackground
-                </Text>
+                <Text size="100">focusColor=lightBackground</Text>
               </Box>
             </TapArea>
           </Box>
@@ -57,9 +55,7 @@ export default function TapAreaExample() {
               innerFocusColor="default"
             >
               <Box height={100} width={100}>
-                <Text size="100">
-                  focusColor=lightBackground & innerFocusColor=default
-                </Text>
+                <Text size="100">focusColor=lightBackground & innerFocusColor=default</Text>
               </Box>
             </TapArea>
           </Box>
@@ -80,9 +76,7 @@ export default function TapAreaExample() {
               innerFocusColor="default"
             >
               <Box height={100} width={100}>
-                <Text size="100">
-                  focusColor=darkBackground & innerFocusColor=default
-                </Text>
+                <Text size="100">focusColor=darkBackground & innerFocusColor=default</Text>
               </Box>
             </TapArea>
           </Box>
@@ -104,9 +98,7 @@ export default function TapAreaExample() {
               innerFocusColor="inverse"
             >
               <Box height={100} width={100}>
-                <Text size="100">
-                  focusColor=lightBackground & innerFocusColor=inverse
-                </Text>
+                <Text size="100">focusColor=lightBackground & innerFocusColor=inverse</Text>
               </Box>
             </TapArea>
           </Box>
@@ -127,9 +119,7 @@ export default function TapAreaExample() {
               innerFocusColor="inverse"
             >
               <Box height={100} width={100}>
-                <Text size="100">
-                  focusColor=darkBackground & innerFocusColor=inverse
-                </Text>
+                <Text size="100">focusColor=darkBackground & innerFocusColor=inverse</Text>
               </Box>
             </TapArea>
           </Box>

--- a/docs/pages/web/taparea.tsx
+++ b/docs/pages/web/taparea.tsx
@@ -12,6 +12,7 @@ import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
 import accessibility from '../../examples/taparea/accessibility';
 import compressBehavior from '../../examples/taparea/compressBehavior';
+import focus from '../../examples/taparea/focus';
 import fullSpace from '../../examples/taparea/fullSpace';
 import heightWidth from '../../examples/taparea/heightWidth';
 import inlineUsage from '../../examples/taparea/inlineUsage';
@@ -67,6 +68,12 @@ TapArea with link interaction can be paired with GlobalEventsHandlerProvider. Se
                 previewHeight={400}
               />
             }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Focus state">
+          <MainSection.Card
+            sandpackExample={<SandpackExample code={focus} name="Focus example" />}
           />
         </MainSection.Subsection>
 

--- a/packages/gestalt/src/ButtonToggle.css
+++ b/packages/gestalt/src/ButtonToggle.css
@@ -144,7 +144,7 @@
   margin: calc(var(--g-border-width-lg) / 2 * -1);
 }
 
-.accessibilityOutlineVr {
+.accessibilityOutlineLightBackground {
   border-color: var(--sema-color-border-focus-inner-default);
   outline: 2px solid var(--sema-color-border-focus-outer-default);
   outline-offset: 2px;

--- a/packages/gestalt/src/ButtonToggle.tsx
+++ b/packages/gestalt/src/ButtonToggle.tsx
@@ -207,7 +207,7 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
     {
       [focusStyles.hideOutline]: !disabled && !isFocusVisible,
       [focusStyles.accessibilityOutline]: !disabled && isFocusVisible && !isInVRExperiment,
-      [styles.accessibilityOutlineVr]: !disabled && isFocused && isFocusVisible && isInVRExperiment,
+      [styles.accessibilityOutlineLightBackground]: !disabled && isFocused && isFocusVisible && isInVRExperiment,
     },
   );
 

--- a/packages/gestalt/src/ButtonToggle.tsx
+++ b/packages/gestalt/src/ButtonToggle.tsx
@@ -207,7 +207,8 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
     {
       [focusStyles.hideOutline]: !disabled && !isFocusVisible,
       [focusStyles.accessibilityOutline]: !disabled && isFocusVisible && !isInVRExperiment,
-      [styles.accessibilityOutlineLightBackground]: !disabled && isFocused && isFocusVisible && isInVRExperiment,
+      [styles.accessibilityOutlineLightBackground]:
+        !disabled && isFocused && isFocusVisible && isInVRExperiment,
     },
   );
 

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -22,6 +22,10 @@
   border: 2px solid var(--sema-color-border-focus-inner-light);
 }
 
+.accessibilityOutlineBorder {
+  border: 2px solid var(--base-color-transparent);
+}
+
 .accessibilityOutlineBorderInverse:focus {
   border: 2px solid var(--sema-color-border-focus-inner-dark);
 }

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -3,9 +3,15 @@
   outline-offset: 0;
 }
 
-.accessibilityOutlineVR:focus {
-  outline: 2px solid var(--color-border-focus);
+.accessibilityOutlineLightBackground:focus {
+  outline: 2px solid var(--sema-color-border-focus-outer-default);
   outline-offset: 0;
+}
+
+.accessibilityOutlineDarkBackground:focus {
+  outline: 2px solid var(--sema-color-border-focus-outer-light);
+  outline-offset: 0;
+
 }
 
 .accessibilityOutlineFocusWithin .accessibilityOutline:focus-within {

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -11,12 +11,19 @@
 .accessibilityOutlineDarkBackground:focus {
   outline: 2px solid var(--sema-color-border-focus-outer-light);
   outline-offset: 0;
-
 }
 
 .accessibilityOutlineFocusWithin .accessibilityOutline:focus-within {
   outline: 4px solid var(--color-border-focus);
   outline-offset: 0;
+}
+
+.accessibilityOutlineBorderDefault {
+  border: 2px solid var(--sema-color-border-focus-inner-light);
+}
+
+.accessibilityOutlineBorderInverse {
+  border: 2px solid var(--sema-color-border-focus-inner-dark);
 }
 
 .accessibilityOutlineFocusWithin .accessibilityOutline:focus {

--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -18,11 +18,11 @@
   outline-offset: 0;
 }
 
-.accessibilityOutlineBorderDefault {
+.accessibilityOutlineBorderDefault:focus {
   border: 2px solid var(--sema-color-border-focus-inner-light);
 }
 
-.accessibilityOutlineBorderInverse {
+.accessibilityOutlineBorderInverse:focus {
   border: 2px solid var(--sema-color-border-focus-inner-dark);
 }
 

--- a/packages/gestalt/src/TapArea.tsx
+++ b/packages/gestalt/src/TapArea.tsx
@@ -229,6 +229,8 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
       isInVRExperiment && focusColor === 'lightBackground' && !disabled && isFocusVisible,
     [focusStyles.accessibilityOutlineDarkBackground]:
       isInVRExperiment && focusColor === 'darkBackground' && !disabled && isFocusVisible,
+    [focusStyles.accessibilityOutlineBorder]:
+      isInVRExperiment && innerFocusColor === 'default' && !disabled && !isFocusVisible,
     [focusStyles.accessibilityOutlineBorderDefault]:
       isInVRExperiment && innerFocusColor === 'default' && !disabled && isFocusVisible,
     [focusStyles.accessibilityOutlineBorderInverse]:

--- a/packages/gestalt/src/TapArea.tsx
+++ b/packages/gestalt/src/TapArea.tsx
@@ -66,6 +66,8 @@ type Props = {
    * Used for improving focus ring color contrast.
    */
   focusColor?: 'lightBackground' | 'darkBackground';
+
+  innerFocusColor?: 'transparent' | 'default' | 'inverse';
   /**
    * Set the TapArea height to expand to the full height of the parent.
    */
@@ -172,6 +174,7 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
     focusColor = 'lightBackground',
     fullHeight,
     fullWidth = true,
+    innerFocusColor = 'transparent',
     mouseCursor = 'pointer',
     onBlur,
     onKeyDown,
@@ -223,7 +226,10 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
       isInVRExperiment && focusColor === 'lightBackground' && !disabled && isFocusVisible,
     [focusStyles.accessibilityOutlineDarkBackground]:
       isInVRExperiment && focusColor === 'darkBackground' && !disabled && isFocusVisible,
-
+    [focusStyles.accessibilityOutlineBorderDefault]:
+      isInVRExperiment && innerFocusColor === 'default' && !disabled && isFocusVisible,
+    [focusStyles.accessibilityOutlineBorderInverse]:
+      isInVRExperiment && innerFocusColor === 'inverse' && !disabled && isFocusVisible,
     [styles.fullHeight]: fullHeight,
     [styles.fullWidth]: fullWidth,
     [styles.copy]: mouseCursor === 'copy' && !disabled,

--- a/packages/gestalt/src/TapArea.tsx
+++ b/packages/gestalt/src/TapArea.tsx
@@ -62,6 +62,11 @@ type Props = {
    */
   disabled?: boolean;
   /**
+   * Indicates whether this component is hosted in a light or dark container.
+   * Used for improving focus ring color contrast.
+   */
+  focusColor?: 'lightBackground' | 'darkBackground';
+  /**
    * Set the TapArea height to expand to the full height of the parent.
    */
   fullHeight?: boolean;
@@ -164,6 +169,7 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
     children,
     dataTestId,
     disabled = false,
+    focusColor = 'lightBackground',
     fullHeight,
     fullWidth = true,
     mouseCursor = 'pointer',
@@ -213,7 +219,11 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
   const buttonRoleClasses = classnames(styles.tapTransition, getRoundingClassName(rounding), {
     [focusStyles.hideOutline]: !disabled && !isFocusVisible,
     [focusStyles.accessibilityOutline]: !isInVRExperiment && !disabled && isFocusVisible,
-    [focusStyles.accessibilityOutlineVR]: isInVRExperiment && !disabled && isFocusVisible,
+    [focusStyles.accessibilityOutlineLightBackground]:
+      isInVRExperiment && focusColor === 'lightBackground' && !disabled && isFocusVisible,
+    [focusStyles.accessibilityOutlineDarkBackground]:
+      isInVRExperiment && focusColor === 'darkBackground' && !disabled && isFocusVisible,
+
     [styles.fullHeight]: fullHeight,
     [styles.fullWidth]: fullWidth,
     [styles.copy]: mouseCursor === 'copy' && !disabled,

--- a/packages/gestalt/src/TapArea.tsx
+++ b/packages/gestalt/src/TapArea.tsx
@@ -66,8 +66,11 @@ type Props = {
    * Used for improving focus ring color contrast.
    */
   focusColor?: 'lightBackground' | 'darkBackground';
-
-  innerFocusColor?: 'transparent' | 'default' | 'inverse';
+  /**
+   * Indicates whether this component presents a light ('default') or dark ('inverse') inner focus border when focused.
+   * Used for improving focus ring color contrast.
+   */
+  innerFocusColor?: 'default' | 'inverse';
   /**
    * Set the TapArea height to expand to the full height of the parent.
    */
@@ -174,7 +177,7 @@ const TapAreaWithForwardRef = forwardRef<HTMLDivElement, Props>(function TapArea
     focusColor = 'lightBackground',
     fullHeight,
     fullWidth = true,
-    innerFocusColor = 'transparent',
+    innerFocusColor,
     mouseCursor = 'pointer',
     onBlur,
     onKeyDown,


### PR DESCRIPTION
TapArea: support to VR visible focus style
## classic
![Brave Browser - TapArea - Gestalt 2024-09-27 at 2 50 07 AM](https://github.com/user-attachments/assets/59acc56e-1db8-4663-971c-904c63631797) 
## VR 
![Brave Browser - TapArea - Gestalt 2024-09-27 at 2 49 23 AM](https://github.com/user-attachments/assets/e71b3537-f392-4b91-8607-b46edaf09242)