### PR TITLE
IconButtonFloating: reverting circle to squircle 

### DIFF
--- a/packages/gestalt/src/IconButton/InternalIconButton.tsx
+++ b/packages/gestalt/src/IconButton/InternalIconButton.tsx
@@ -52,7 +52,6 @@ type Props = {
     zIndex?: Indexable;
   };
   type?: 'submit' | 'button';
-  variant?: 'floating' | 'default';
 };
 
 const InternalIconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function IconButton(
@@ -78,7 +77,6 @@ const InternalIconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(fu
     tabIndex = 0,
     tooltip,
     type,
-    variant,
   }: Props,
   ref,
 ) {

--- a/packages/gestalt/src/IconButton/InternalIconButton.tsx
+++ b/packages/gestalt/src/IconButton/InternalIconButton.tsx
@@ -179,7 +179,6 @@ const InternalIconButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(fu
           icon={icon}
           iconColor={iconColor}
           padding={padding}
-          rounding={variant === 'floating' ? 'circle' : undefined}
           selected={selected}
           size={size}
         />

--- a/packages/gestalt/src/IconButtonFloating.tsx
+++ b/packages/gestalt/src/IconButtonFloating.tsx
@@ -85,7 +85,7 @@ const IconButtonFloatingWithForwardRef = forwardRef<HTMLButtonElement, Props>(
     ref,
   ) {
     return (
-      <Box borderStyle="shadow" color="default" rounding="circle">
+      <Box borderStyle="shadow" color="default" rounding={4}>
         <InternalIconButton
           ref={ref}
           accessibilityControls={accessibilityControls}
@@ -100,7 +100,6 @@ const IconButtonFloatingWithForwardRef = forwardRef<HTMLButtonElement, Props>(
           selected={selected}
           size="xl"
           tooltip={tooltip}
-          variant="floating"
         />
       </Box>
     );

--- a/packages/gestalt/src/IconButtonFloating.tsx
+++ b/packages/gestalt/src/IconButtonFloating.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from 'react';
 import Box from './Box';
 import InternalIconButton from './IconButton/InternalIconButton';
 import icons from './icons/index';
+import useInExperiment from './useInExperiment';
 import { Indexable } from './zIndex';
 
 type Props = {
@@ -84,8 +85,13 @@ const IconButtonFloatingWithForwardRef = forwardRef<HTMLButtonElement, Props>(
     }: Props,
     ref,
   ) {
+    const isInVRExperiment = useInExperiment({
+      webExperimentName: 'web_gestalt_visualRefresh',
+      mwebExperimentName: 'web_gestalt_visualRefresh',
+    });
+
     return (
-      <Box borderStyle="shadow" color="default" rounding={4}>
+      <Box borderStyle="shadow" color="default" rounding={isInVRExperiment ? 4 : 'circle'}>
         <InternalIconButton
           ref={ref}
           accessibilityControls={accessibilityControls}


### PR DESCRIPTION
IconButtonFloating: reverting circle to squircle as per Gestalt design request


AFTER Classic
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/6086d138-d260-4a97-bb5c-e4825b2e2775)




BEFORE Classic
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/bb35e7d5-6921-4546-bcaf-6fdd70ed6729)



AFTER VR
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/441d35c8-9fd8-4050-b426-889414ced592)



BEFORE VR

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/61006412-414f-4b05-95f9-7d866070ddee)
 