### PR TITLE
Button: Fixing transparentwhitetext interactive colors

### DIFF
--- a/packages/gestalt/src/Button.css
+++ b/packages/gestalt/src/Button.css
@@ -138,6 +138,18 @@
   background-color: var(--color-background-button-tertiary-active);
 }
 
+.transparentWhiteText {
+  background-color: var(--color-background-button-tertiary-default);
+}
+
+.transparentWhiteText:hover {
+  background-color: var(--color-background-button-semitransparentdark-hover);
+}
+
+.transparentWhiteText:active {
+  background-color: var(--color-background-button-semitransparentdark-active);
+}
+
 .blue {
   background-color: var(--color-background-button-shopping-default);
 }

--- a/packages/gestalt/src/Button.tsx
+++ b/packages/gestalt/src/Button.tsx
@@ -241,7 +241,7 @@ const ButtonWithForwardRef = forwardRef<HTMLButtonElement, Props>(function Butto
   const isDarkMode = colorSchemeName === 'darkMode';
   const isDarkModeRed = isDarkMode && color === 'red';
 
-  const colorClass = color === 'transparentWhiteText' ? 'transparent' : color;
+  const colorClass = color === 'transparentWhiteText' && !isInVRExperiment ? 'transparent' : color;
 
   const { isFocusVisible } = useFocusVisible();
 


### PR DESCRIPTION
### Summary

#### What changed?

Changed the tokens for the hover+pressed states of the white text transparent Button
Before:
![image](https://github.com/user-attachments/assets/55a5bd75-4548-4004-a4b8-0109b4cb7326)

After:
![image](https://github.com/user-attachments/assets/bf3f4673-33b4-473a-82b5-13af4fc71e2d)


#### Why?

To fix the issue with contrast on hover+pressed

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
