### PR TITLE
TapAreaLink: support to VR visible focus style

### DIFF
--- a/docs/examples/taparealink/focus.tsx
+++ b/docs/examples/taparealink/focus.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex, TapArea, Text } from 'gestalt';
+import { Box, Flex, TapAreaLink, Text } from 'gestalt';
 
-export default function TapAreaExample() {
+export default function TapAreaLinkExample() {
   return (
     <Box padding={8} width="100%">
       <Flex gap={6} width="100%">
@@ -14,13 +14,19 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea focusColor="lightBackground" fullHeight={false} fullWidth={false}>
+            <TapAreaLink
+              focusColor="lightBackground"
+              fullHeight={false}
+              fullWidth={false}
+              href="www.pinterest.com"
+              onTap={({ event }) => event.preventDefault()}
+            >
               <Box height={100} width={100}>
                 <Text color="dark" size="100">
                   focusColor=lightBackground
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
 
           <Box
@@ -32,13 +38,19 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea focusColor="darkBackground" fullHeight={false} fullWidth={false}>
+            <TapAreaLink
+              focusColor="darkBackground"
+              fullHeight={false}
+              fullWidth={false}
+              href="www.pinterest.com"
+              onTap={({ event }) => event.preventDefault()}
+            >
               <Box height={100} width={100}>
                 <Text color="light" size="100">
                   focusColor=darkBackground
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
         </Flex>
         <Flex direction="column" gap={6} width="100%">
@@ -51,18 +63,20 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea
+            <TapAreaLink
               focusColor="lightBackground"
               fullHeight={false}
               fullWidth={false}
+              href="www.pinterest.com"
               innerFocusColor="default"
+              onTap={({ event }) => event.preventDefault()}
             >
               <Box height={100} width={100}>
                 <Text color="dark" size="100">
                   focusColor=lightBackground & innerFocusColor=default
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
 
           <Box
@@ -74,18 +88,20 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea
+            <TapAreaLink
               focusColor="darkBackground"
               fullHeight={false}
               fullWidth={false}
+              href="www.pinterest.com"
               innerFocusColor="default"
+              onTap={({ event }) => event.preventDefault()}
             >
               <Box height={100} width={100}>
                 <Text color="light" size="100">
                   focusColor=darkBackground & innerFocusColor=default
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
         </Flex>
         <Flex direction="column" gap={6} width="100%">
@@ -98,18 +114,20 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea
+            <TapAreaLink
               focusColor="lightBackground"
               fullHeight={false}
               fullWidth={false}
+              href="www.pinterest.com"
               innerFocusColor="inverse"
+              onTap={({ event }) => event.preventDefault()}
             >
               <Box height={100} width={100}>
                 <Text color="dark" size="100">
                   focusColor=lightBackground & innerFocusColor=inverse
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
 
           <Box
@@ -121,18 +139,20 @@ export default function TapAreaExample() {
             justifyContent="center"
             width={150}
           >
-            <TapArea
+            <TapAreaLink
               focusColor="darkBackground"
               fullHeight={false}
               fullWidth={false}
+              href="www.pinterest.com"
               innerFocusColor="inverse"
+              onTap={({ event }) => event.preventDefault()}
             >
               <Box height={100} width={100}>
                 <Text color="light" size="100">
                   focusColor=darkBackground & innerFocusColor=inverse
                 </Text>
               </Box>
-            </TapArea>
+            </TapAreaLink>
           </Box>
         </Flex>
       </Flex>

--- a/docs/pages/web/taparealink.tsx
+++ b/docs/pages/web/taparealink.tsx
@@ -10,6 +10,7 @@ import PageHeader from '../../docs-components/PageHeader';
 import QualityChecklist from '../../docs-components/QualityChecklist';
 import SandpackExample from '../../docs-components/SandpackExample';
 import compressBehavior from '../../examples/taparealink/compressBehavior';
+import focus from '../../examples/taparealink/focus';
 import heightWidth from '../../examples/taparealink/heightWidth';
 import inlineUsage from '../../examples/taparealink/inlineUsage';
 import localizationLabels from '../../examples/taparealink/localizationLabels';
@@ -44,6 +45,12 @@ export default function DocsPage({ generatedDocGen }: DocType) {
                 previewHeight={400}
               />
             }
+          />
+        </MainSection.Subsection>
+
+        <MainSection.Subsection title="Focus style">
+          <MainSection.Card
+            sandpackExample={<SandpackExample code={focus} name="Focus example" />}
           />
         </MainSection.Subsection>
 

--- a/packages/gestalt/src/Link/InternalLink.tsx
+++ b/packages/gestalt/src/Link/InternalLink.tsx
@@ -25,6 +25,7 @@ type Props = {
   fullWidth?: boolean;
   href: string;
   id?: string;
+  innerFocusColor?: 'default' | 'inverse';
   mouseCursor?: 'copy' | 'grab' | 'grabbing' | 'move' | 'noDrop' | 'pointer' | 'zoomIn' | 'zoomOut';
   onClick?: (arg1: {
     event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
@@ -68,6 +69,7 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
     fullWidth,
     href,
     id,
+    innerFocusColor,
     mouseCursor,
     onClick,
     onBlur,
@@ -176,6 +178,16 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
           [layoutStyles.block]: true,
           [touchableStyles.fullHeight]: fullHeight,
           [touchableStyles.fullWidth]: fullWidth,
+          [focusStyles.accessibilityOutlineLightBackground]:
+            isInVRExperiment && focusColor === 'lightBackground' && !disabled && isFocusVisible,
+          [focusStyles.accessibilityOutlineDarkBackground]:
+            isInVRExperiment && focusColor === 'darkBackground' && !disabled && isFocusVisible,
+          [focusStyles.accessibilityOutlineBorder]:
+            isInVRExperiment && innerFocusColor === 'default' && !disabled && !isFocusVisible,
+          [focusStyles.accessibilityOutlineBorderDefault]:
+            isInVRExperiment && innerFocusColor === 'default' && !disabled && isFocusVisible,
+          [focusStyles.accessibilityOutlineBorderInverse]:
+            isInVRExperiment && innerFocusColor === 'inverse' && !disabled && isFocusVisible,
         }
       : {},
     isTapArea && mouseCursor

--- a/packages/gestalt/src/TapAreaLink.tsx
+++ b/packages/gestalt/src/TapAreaLink.tsx
@@ -42,6 +42,17 @@ type Props = {
    */
   disabled?: boolean;
   /**
+   * Indicates whether this component is hosted in a light or dark container.
+   * Used for improving focus ring color contrast.
+   */
+  focusColor?: 'lightBackground' | 'darkBackground';
+  /**
+   * Indicates whether this component presents a light ('default') or dark ('inverse') inner focus border when focused.
+   * Used for improving focus ring color contrast.
+   */
+  innerFocusColor?: 'default' | 'inverse';
+
+  /**
    * Set the TapAreaLink height to expand to the full height of the parent.
    */
   fullHeight?: boolean;
@@ -132,9 +143,11 @@ const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function 
     children,
     dataTestId,
     disabled = false,
+    focusColor = 'lightBackground',
     fullHeight,
     fullWidth = true,
     href,
+    innerFocusColor,
     mouseCursor = 'pointer',
     onBlur,
     onKeyDown,
@@ -172,9 +185,11 @@ const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function 
       })}
       dataTestId={dataTestId}
       disabled={disabled}
+      focusColor={focusColor}
       fullHeight={fullHeight}
       fullWidth={fullWidth}
       href={href}
+      innerFocusColor={innerFocusColor}
       mouseCursor={mouseCursor}
       onBlur={({ event }) => {
         if (!disabled) onBlur?.({ event });


### PR DESCRIPTION
TapAreaLink: support to VR visible focus style

## classic
![Brave Browser - TapAreaLink - Gestalt 2024-10-02 at 3 17 13 AM](https://github.com/user-attachments/assets/5533dc4b-8e4b-458b-a3a4-2a959bf3a81b)

## VR 
![Brave Browser - TapAreaLink - Gestalt 2024-10-02 at 3 16 37 AM](https://github.com/user-attachments/assets/b6d17b58-0f65-40ec-9d55-da1b3aa8ecab)
