### PR TITLE
TapArea: fix focus token to support built-in darkmode

### DIFF
--- a/packages/gestalt/src/Focus.css
+++ b/packages/gestalt/src/Focus.css
@@ -19,7 +19,7 @@
 }
 
 .accessibilityOutlineBorderDefault:focus {
-  border: 2px solid var(--sema-color-border-focus-inner-light);
+  border: 2px solid var(--sema-color-border-focus-inner-default);
 }
 
 .accessibilityOutlineBorder {
@@ -27,7 +27,7 @@
 }
 
 .accessibilityOutlineBorderInverse:focus {
-  border: 2px solid var(--sema-color-border-focus-inner-dark);
+  border: 2px solid var(--sema-color-border-focus-inner-inverse);
 }
 
 .accessibilityOutlineFocusWithin .accessibilityOutline:focus {

--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -114,7 +114,7 @@
 }
 
 a.standalone {
-  color: var(--color-text-link);
+  color: var(--sema-color-text-default);
 }
 
 a.standalone:hover {


### PR DESCRIPTION
TapArea: fix focus token to support built-in darkmode### Checklist


## VR BEFORE fix 
![Brave Browser - TapArea - Gestalt 2024-10-02 at 11 00 35 PM](https://github.com/user-attachments/assets/1efc1e88-cc36-4215-bfc8-5ac6f58b89e0)

## VR AFTER fix 
![Brave Browser - TapAreaLink - Gestalt 2024-10-02 at 10 58 13 PM](https://github.com/user-attachments/assets/c113ce03-6b44-41ac-93c4-97143c458ad5)
