### PR TITLE
Icon: vertical-align unset when within Text

### DIFF
--- a/packages/gestalt/src/Text.css
+++ b/packages/gestalt/src/Text.css
@@ -6,6 +6,11 @@
   composes: antialiased from "./Typography.css";
 }
 
+.Text svg,
+.TextBody svg {
+  vertical-align: unset;
+}
+
 .lg {
   font-family: var(--sema-font-family-body-lg);
   font-size: var(--sema-font-size-body-lg);


### PR DESCRIPTION
Icon: vertical-align unset (overriding vertical-align middle set by default in icons) when within Text

### BEFORE 

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/5334ceff-babe-4f88-a34b-3aebb376ab45)


### AFTER 

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/8726eb4a-e91c-45d3-9dcb-a8b90e3423cf)
