### PR TITLE
DateRange: add example for secondary date errors (web)

### DIFF
--- a/docs/examples/daterange/secondaryErrorMessages.tsx
+++ b/docs/examples/daterange/secondaryErrorMessages.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import { DeviceTypeProvider, Flex } from 'gestalt';
+import { DateRange } from 'gestalt-datepicker';
+
+export default function Example() {
+  const year = new Date().getFullYear();
+  const startDate = new Date(year, 5, 30);
+  const endDate = null;
+  const secondaryStartDate = new Date(year, 7, 20);
+  const secondaryEndDate = new Date(year, 7, 21);
+
+  const minDate = new Date(year, 6, 1);
+  const maxDate = new Date(year, 6, 20);
+
+  const startDateError = 'Select a date after June 1st';
+  const endDateError = 'Select a date before June 20th';
+
+  const [primaryErrorMessage, setPrimaryErrorMessage] = useState<string | null>(null);
+  const [secondaryErrorMessage, setSecondaryErrorMessage] = useState<string | null>(null);
+  const [startErrorMessage, setStartErrorMessage] = useState<string | null>(null);
+  const [endErrorMessage, setEndErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (primaryErrorMessage) {
+      setStartErrorMessage(startDateError);
+    }
+    if (secondaryErrorMessage) {
+      setEndErrorMessage(endDateError);
+    }
+  }, [primaryErrorMessage, secondaryErrorMessage]);
+
+  return (
+    <DeviceTypeProvider deviceType="desktop">
+      <Flex alignItems="center" height="100%" justifyContent="center" width="100%">
+        <DateRange
+          dateErrorMessage={{ startDate: startErrorMessage, endDate: null }}
+          dateValue={{ startDate, endDate }}
+          maxDate={maxDate}
+          minDate={minDate}
+          onCancel={() => {}}
+          onDateChange={() => {}}
+          onDateError={{
+            startDate: ({ errorMessage }) => {
+              setPrimaryErrorMessage(errorMessage);
+            },
+            endDate: () => {},
+          }}
+          onSecondaryDateChange={() => {}}
+          onSecondaryDateError={{
+            startDate: () => {},
+            endDate: ({ errorMessage }) => {
+              setSecondaryErrorMessage(errorMessage);
+            },
+          }}
+          onSubmit={() => {}}
+          secondaryDateErrorMessage={{
+            startDate: null,
+            endDate: endErrorMessage,
+          }}
+          secondaryDateValue={{ startDate: secondaryStartDate, endDate: secondaryEndDate }}
+        />
+      </Flex>
+    </DeviceTypeProvider>
+  );
+}

--- a/docs/pages/web/daterange.tsx
+++ b/docs/pages/web/daterange.tsx
@@ -58,6 +58,7 @@ import main from '../../examples/daterange/main';
 import mobile from '../../examples/daterange/mobile';
 import pastRadiogroup from '../../examples/daterange/pastRadioGroup';
 import secondaryDateRange from '../../examples/daterange/secondaryDateRange';
+import secondaryErrorMessages from '../../examples/daterange/secondaryErrorMessages';
 
 const PREVIEW_HEIGHT = 600;
 
@@ -219,7 +220,7 @@ Use the SelectList to try out different locales by passing in the \`localeData\`
         <MainSection.Subsection
           description={`
 DateRange is a controlled component.
-Use \`endDateValue\`,  \`startDateValue\`,  \`onEndDateChange\`, \`onStartDateChange\`, \`onEndDateError\`, \`onStartDateError\`, \`onSubmit\` and \`onCancel\` to implement it correctly.
+Use \`dateValue\`, \`onDateChange\`, \`onDateError\`, \`onSubmit\` and \`onCancel\` to implement it correctly.
 
 Follow the implementation in the example to implement a controlled DateRange correctly.
 
@@ -273,16 +274,16 @@ When there’s not a date range selected, the call-to-action is disabled to prev
 
         <MainSection.Subsection
           description={`
-DateRange can communicate errors when the user selects an invalid date. Use \`startDateErrorMessage\`, \`endDateErrorMessage\`, \`onEndDateError\`, \`onStartDateError\`, \`onStartDateBlur\`, \`onStartDateFocus\`, \`onEndDateBlur\`, \`onEndDateFocus\` to implement error messaging correctly.
+DateRange can communicate errors when the user selects an invalid date. Use \`dateErrorMessage\`, \`onDateError\`, \`onDateBlur\`, \`onDateFocus\`, to implement error messaging correctly.
 
 The following implementation shows how to use all required props for error messaging.
 
-The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date fields are not pre-populated, leverage \`onStartDateBlur\` and \`onEndDateBlur\` to validate the error state after the date fields lose focus. If the date fields are pre-populated leverage React's useEffect to validate the error state.
+The \`onDateError\` event are very noisy. If the date fields are not pre-populated, leverage \`onDateBlur\` to validate the error state after the date fields lose focus. If the date fields are pre-populated leverage React's useEffect to validate the error state.
           `}
           title="Error messaging"
         >
           <MainSection.Card
-            cardSize="md"
+            cardSize="lg"
             sandpackExample={
               <SandpackExample
                 code={errorMessaging}
@@ -291,6 +292,19 @@ The \`onEndDateError\`, \`onStartDateError\` event are very noisy. If the date f
                 previewHeight={PREVIEW_HEIGHT}
               />
             }
+          />
+          <MainSection.Card
+            cardSize="lg"
+            description={`The secondary input fields also support error messages, you can control them with the \`secondaryDateErrorMessage\` prop.`}
+            sandpackExample={
+              <SandpackExample
+                code={secondaryErrorMessages}
+                layout="column"
+                name="secondary errors example"
+                previewHeight={PREVIEW_HEIGHT}
+              />
+            }
+            title="Secondary date errors"
           />
         </MainSection.Subsection>
         <MainSection.Subsection
@@ -354,7 +368,7 @@ On mobile devices, the \`radiogroup\` prop is not shown.
         </MainSection.Subsection>
         <MainSection.Subsection
           description={`
-DateRange supports a secondary date range in case you need to handle more that one range, in order to enable it you just need to pass the props \`secondaryDateValue\` and \`onSecondaryDateChange\`.`}
+DateRange supports a secondary date range in case you need to handle more that one range, in order to enable it you just need to pass the props \`secondaryDateValue\` and \`onSecondaryDateChange\`. One scenario for this could be if you need to compare/monitor metrics of two periods of time when creating campaigns.`}
           title="Secondary date range"
         >
           <MainSection.Card

--- a/packages/gestalt-datepicker/src/DateRange.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.tsx
@@ -102,7 +102,7 @@ type Props = {
    */
   dateValue: { startDate: Date | null; endDate: Date | null };
   /**
-   * DateRange is a controlled component. `dateValue` sets the value of the start date and end date.  See the [secondary date range variant](https://gestalt.pinterest.systems/web/daterange#Secondary-date-range) to learn more.
+   * DateRange is a controlled component. `secondaryDateValue` sets the value of the start date and end date.  See the [secondary date range variant](https://gestalt.pinterest.systems/web/daterange#Secondary-date-range) to learn more.
    */
   secondaryDateValue?: { startDate: Date | null; endDate: Date | null };
   /**


### PR DESCRIPTION
DateRange: add example for secondary date errors (web) #3806
