### PR TITLE
ButtonToggle: Fix VR scale animation

### DIFF
--- a/packages/gestalt/src/ButtonToggle.tsx
+++ b/packages/gestalt/src/ButtonToggle.tsx
@@ -308,30 +308,26 @@ const ButtonToggleWithForwardRef = forwardRef<HTMLButtonElement, Props>(function
     );
   }
 
-  const childrenDivClasses = classnames(
-    sharedTypeClasses,
-    touchableStyles.tapTransition,
-    sizeStyles,
-    styles.childrenDiv,
-    {
-      [styles.compact]: text.length === 0,
-      [styles.disabled]: disabled && (color !== 'red' || selected),
-      [styles.disabledRed]: disabled && color === 'red' && !selected,
-      [styles.disabledTransparent]: disabled && color === 'transparent' && !selected,
-      [styles.enabled]: !disabled,
-      [borderStyles.noBorder]: color === 'red' && !selected,
-      [styles.selected]: !disabled && selected,
-      [styles.selectedDisabled]: disabled && selected,
-      [styles.thumbnailDark]: graphicSrc && isDarkMode !== selected,
-      [styles.thumbnailDisabled]: graphicSrc && disabled,
-      [styles.thumbnailLg]: size === 'lg' && graphicSrc,
-      [styles.thumbnailMd]: size === 'md' && graphicSrc,
-      [styles.thumbnailSm]: size === 'sm' && graphicSrc,
-      [styles[color]]: !disabled && !selected,
-      [styles.interactiveBorder]:
-        !disabled && !selected && !isFocused && color === 'transparent' && isInVRExperiment,
-    },
-  );
+  const childrenDivClasses = classnames(sharedTypeClasses, sizeStyles, styles.childrenDiv, {
+    [buttonToggleAnimation.classes]: isInVRExperiment,
+    [touchableStyles.tapTransition]: !isInVRExperiment,
+    [styles.compact]: text.length === 0,
+    [styles.disabled]: disabled && (color !== 'red' || selected),
+    [styles.disabledRed]: disabled && color === 'red' && !selected,
+    [styles.disabledTransparent]: disabled && color === 'transparent' && !selected,
+    [styles.enabled]: !disabled,
+    [borderStyles.noBorder]: color === 'red' && !selected,
+    [styles.selected]: !disabled && selected,
+    [styles.selectedDisabled]: disabled && selected,
+    [styles.thumbnailDark]: graphicSrc && isDarkMode !== selected,
+    [styles.thumbnailDisabled]: graphicSrc && disabled,
+    [styles.thumbnailLg]: size === 'lg' && graphicSrc,
+    [styles.thumbnailMd]: size === 'md' && graphicSrc,
+    [styles.thumbnailSm]: size === 'sm' && graphicSrc,
+    [styles[color]]: !disabled && !selected,
+    [styles.interactiveBorder]:
+      !disabled && !selected && !isFocused && color === 'transparent' && isInVRExperiment,
+  });
 
   const textColor =
     (disabled && 'disabled') ||


### PR DESCRIPTION
### Summary

Reverted accidentally deleted lin of code that broke tap animation.

Reference: https://github.com/pinterest/gestalt/pull/3738/files#diff-687777f0ffbee69afb9f560b2c8602d3f68cb4844558ef9b76c5f159450285f2L223


**BEFORE**
![ezgif-1-7e543f1e09](https://github.com/user-attachments/assets/15612e2e-1d43-48b0-a838-af2528869fd6)


**AFTER**
![ezgif-1-1ce8dc860c](https://github.com/user-attachments/assets/6b3be54c-349a-41c4-aebc-8d759903f682)




### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
