### PR TITLE
Masonry: Add data-test-id for skeleton pins container

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -701,7 +701,11 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         : 0;
 
       gridBody = (
-        <div ref={this.setGridWrapperRef} style={{ width: '100%' }}>
+        <div
+          ref={this.setGridWrapperRef}
+          data-test-id="masonry--skeleton-pins-container"
+          style={{ width: '100%' }}
+        >
           <div className={styles.Masonry} role="list" style={{ height, width }}>
             {_loadingStateItems.map((itemData, idx) =>
               this.renderLoadingStateComponent({


### PR DESCRIPTION
### Summary

#### What changed?

- Adds `data-test-id="masonry--skeleton-pins-container"` to the loading state container

#### Why?

- The skeleton loading state experiment led to unexpected PWT abort regressions. Since the skeleton pins are rendered as divs with styling and no images, this caused the Masonry profiler to abort because although Masonry technically loaded, there were no images present.
  - We will get around this by having the Masonry profiler look for this data test id and then opt out of adding these metrics to the PWT aborts.

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
