### PR TITLE
DateRange: make onCancel and onSubmit events optional (web)

### DIFF
--- a/packages/gestalt-datepicker/src/DateRange.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.tsx
@@ -35,7 +35,7 @@ type Props = {
   /**
    * Callback triggered when the user clicks the Cancel button to not persist the selected dates. It should be used to close DateRange. See the [controlled component variant](https://gestalt.pinterest.systems/web/daterange#Controlled-component) to learn more.
    */
-  onCancel: () => void;
+  onCancel?: () => void;
   /**
    * Callback triggered when the end date input loses focus. See the [error messaging variant](https://gestalt.pinterest.systems/web/daterange#Error-messaging) to learn more.
    */
@@ -92,7 +92,7 @@ type Props = {
   /**
    * Callback triggered when the user clicks the Apply button to persist the selected dates. It should be used to persist the dates selected and close the DateRange. See the [controlled component variant](https://gestalt.pinterest.systems/web/daterange#Controlled-component) to learn more.
    */
-  onSubmit: () => void;
+  onSubmit?: () => void;
   /**
    * An optional RadioGroup to provide preestablished date range options. See the [with RadioGroup variant](https://gestalt.pinterest.systems/web/daterange#With-RadioGroup) to learn more.
    */
@@ -364,25 +364,27 @@ function DateRange({
                 }
               />
             </Box>
-            <Flex.Item alignSelf={isMobile ? 'center' : 'end'}>
-              <Box marginBottom={4} marginEnd={4}>
-                <ButtonGroup>
-                  <Button color="gray" onClick={() => onCancel()} text={cancelText} />
+            {onSubmit && onCancel ? (
+              <Flex.Item alignSelf={isMobile ? 'center' : 'end'}>
+                <Box marginBottom={4} marginEnd={4}>
+                  <ButtonGroup>
+                    <Button color="gray" onClick={() => onCancel()} text={cancelText} />
 
-                  <Button
-                    color="red"
-                    disabled={
-                      !!dateErrorMessage?.startDate ||
-                      !!dateErrorMessage?.endDate ||
-                      !dateValue.startDate ||
-                      !dateValue.endDate
-                    }
-                    onClick={() => onSubmit()}
-                    text={applyText}
-                  />
-                </ButtonGroup>
-              </Box>
-            </Flex.Item>
+                    <Button
+                      color="red"
+                      disabled={
+                        !!dateErrorMessage?.startDate ||
+                        !!dateErrorMessage?.endDate ||
+                        !dateValue.startDate ||
+                        !dateValue.endDate
+                      }
+                      onClick={() => onSubmit()}
+                      text={applyText}
+                    />
+                  </ButtonGroup>
+                </Box>
+              </Flex.Item>
+            ) : null}
           </Flex>
         </Box>
       </Flex>


### PR DESCRIPTION
### Summary

Makes `onCancel` and `onSubmit` events optional props. This will also hide cancel and submit buttons.

#### What changed?

Makes `onCancel` and `onSubmit` events optional props. If those props are not passed then the component is going to hide the cancel and submit buttons.

#### Why?

The current DatePicker used in analytics doesn't have an apply button, the user is accustomed to an action to occur when the endDate is selected, the data fetching occurs currently on the endDateChange event. There is no onCancel or onSubmit business logic on our side. For accomplish this we don't need to change the logic of the component, we just need to conditionally render those buttons if the props are present.

### Screenshots
<img width="1904" alt="Screenshot 2024-10-18 at 2 12 38 p m" src="https://github.com/user-attachments/assets/d3b91129-9dc1-4db0-8a2a-55977d072a70">
<img width="1904" alt="Screenshot 2024-10-18 at 2 12 26 p m" src="https://github.com/user-attachments/assets/2ffebe4d-fe8d-46d8-b022-7784f00c87ac">


### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
