### PR TITLE
Masonry: Log number of iterations it takes to find optimal whitespace

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -114,11 +114,11 @@ type Props<T> = {
    */
   virtualize?: boolean;
   /**
-   * Experimental prop to log the additional whitespace shown above two-column items.
+   * Experimental prop to log the additional whitespace shown above multicolumn items and the number of iterations it took to position it.
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
+  _logTwoColWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
   /**
    * Experimental prop to define how many columns a module should span. This is also used to enable multi-column support
    * _getColumnSpanConfig is a function that takes an individual grid item as an input and returns a ColumnSpanConfig. ColumnSpanConfig can be one of two things:

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -118,7 +118,11 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _logTwoColWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
+  _logTwoColWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   /**
    * Experimental prop to define how many columns a module should span. This is also used to enable multi-column support
    * _getColumnSpanConfig is a function that takes an individual grid item as an input and returns a ColumnSpanConfig. ColumnSpanConfig can be one of two things:

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -60,7 +60,7 @@ const defaultLayout =
     measurementCache: Cache<T, number>;
     _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
     whitespaceThreshold?: number;
-    logWhitespace?: (arg1: ReadonlyArray<number>) => void;
+    logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
     renderLoadingState?: boolean;
   }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) =>
   (items): ReadonlyArray<Position> => {

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -60,7 +60,11 @@ const defaultLayout =
     measurementCache: Cache<T, number>;
     _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
     whitespaceThreshold?: number;
-    logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
+    logWhitespace?: (
+      additionalWhitespace: ReadonlyArray<number>,
+      numberOfIterations: number,
+      columnSpan: number,
+    ) => void;
     renderLoadingState?: boolean;
   }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) =>
   (items): ReadonlyArray<Position> => {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -23,7 +23,11 @@ const fullWidthLayout = <T>({
   measurementCache: Cache<T, number>;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
-  logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
+  logWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   renderLoadingState?: boolean;
 }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) => {
   if (width == null) {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -23,7 +23,7 @@ const fullWidthLayout = <T>({
   measurementCache: Cache<T, number>;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   whitespaceThreshold?: number;
-  logWhitespace?: (arg1: ReadonlyArray<number>) => void;
+  logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
   renderLoadingState?: boolean;
 }): ((items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position>) => {
   if (width == null) {

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -28,7 +28,11 @@ export default function getLayoutAlgorithm<T>({
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
+  _logTwoColWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
 }): (forItems: ReadonlyArray<T>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
     return fullWidthLayout({

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -488,7 +488,11 @@ function getPositionsWithMultiColumnItem<T>({
     position: Position;
   }>;
   whitespaceThreshold?: number;
-  logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
+  logWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   columnCount: number;
   centerOffset: number;
   columnWidth: number;
@@ -604,7 +608,7 @@ function getPositionsWithMultiColumnItem<T>({
   // Log additional whitespace shown above the multi column module
   // This may need to be tweaked or removed if pin leveling is implemented
   if (additionalWhitespace) {
-    logWhitespace?.(additionalWhitespace, numberOfIterations);
+    logWhitespace?.(additionalWhitespace, numberOfIterations, multiColumnItemColumnSpan);
   }
 
   finalPositions.forEach(({ item, position }) => {
@@ -636,7 +640,11 @@ const multiColumnLayout = <T>({
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
   whitespaceThreshold?: number;
-  logWhitespace?: (additionalWhitespace: ReadonlyArray<number>, numberOfIterations: number) => void;
+  logWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   _getColumnSpanConfig: (item: T) => ColumnSpanConfig;
 }): ReadonlyArray<Position> => {
   if (!items.every((item) => measurementCache.has(item))) {

--- a/packages/gestalt/src/Masonry/types.ts
+++ b/packages/gestalt/src/Masonry/types.ts
@@ -17,7 +17,7 @@ export type NodeData<T> = {
 export type GetGraphPositionsReturn<T> = {
   winningNode: NodeData<T>;
   numberOfIterations: number;
-}
+};
 
 export type Align = 'start' | 'center' | 'end';
 

--- a/packages/gestalt/src/Masonry/types.ts
+++ b/packages/gestalt/src/Masonry/types.ts
@@ -14,6 +14,11 @@ export type NodeData<T> = {
   }>;
 };
 
+export type GetGraphPositionsReturn<T> = {
+  winningNode: NodeData<T>;
+  numberOfIterations: number;
+}
+
 export type Align = 'start' | 'center' | 'end';
 
 export type Layout =

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -118,11 +118,15 @@ type Props<T> = {
    */
   virtualize?: boolean;
   /**
-   * Experimental prop to log the additional whitespace shown above two-column items.
+   * Experimental prop to log the additional whitespace shown above multicolumn items and the number of iterations it took to position it.
    *
    * This is an experimental prop and may be removed in the future.
    */
-  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
+  _logTwoColWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   /**
    * Experimental prop to measure all items in one batch
    */

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -366,7 +366,11 @@ function useLayout<T>({
   positionStore: Cache<T, Position>;
   width: number | null | undefined;
   heightUpdateTrigger: number;
-  _logTwoColWhitespace?: (arg1: ReadonlyArray<number>) => void;
+  _logTwoColWhitespace?: (
+    additionalWhitespace: ReadonlyArray<number>,
+    numberOfIterations: number,
+    columnSpan: number,
+  ) => void;
   _measureAll?: boolean;
   _useRAF?: boolean;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;


### PR DESCRIPTION
### Summary

We want to add Masonry metrics to Statsboard. We want to have insights on how many iterations we make each time we position a multicolumn module.

#### What changed?

- logWhitespace now includes number of iterations to be used when logging
- Changed getGraphPositions to return winningNode and this new metric

https://github.com/user-attachments/assets/30b69a3c-3620-4337-9268-3053133abf27

Added the columnspan so we can use it as a tag when logging and potentially segment the data.

Enabling whitespace threshold to 16:

https://github.com/user-attachments/assets/62c2efd5-6add-47d4-95d9-6bf6a1c612dc




