### PR TITLE
PopoverEducational: Add Experimental Prop for Notification (background color change)

### DIFF
--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -24,7 +24,7 @@ type PrimaryActionType =
       role: 'link';
       target?: null | 'self' | 'blank';
       text: string;
-  }
+    }
   | {
       accessibilityLabel?: string;
       onClick?: (arg1: {
@@ -32,7 +32,7 @@ type PrimaryActionType =
       }) => void;
       role?: 'button';
       text: string;
-  };
+    };
 
 function PrimaryAction(props: PrimaryActionType) {
   if (props.role === 'link') {

--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -14,24 +14,24 @@ type Size = 'sm' | 'flexible';
 type Role = 'dialog' | 'tooltip';
 type PrimaryActionType =
   | {
-    accessibilityLabel?: string;
-    href: string;
-    onClick?: (arg1: {
-      event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
-      dangerouslyDisableOnNavigation: () => void;
-    }) => void;
-    rel?: 'none' | 'nofollow';
-    role: 'link';
-    target?: null | 'self' | 'blank';
-    text: string;
+      accessibilityLabel?: string;
+      href: string;
+      onClick?: (arg1: {
+        event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
+        dangerouslyDisableOnNavigation: () => void;
+      }) => void;
+      rel?: 'none' | 'nofollow';
+      role: 'link';
+      target?: null | 'self' | 'blank';
+      text: string;
   }
   | {
-    accessibilityLabel?: string;
-    onClick?: (arg1: {
-      event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>;
-    }) => void;
-    role?: 'button';
-    text: string;
+      accessibilityLabel?: string;
+      onClick?: (arg1: {
+        event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>;
+      }) => void;
+      role?: 'button';
+      text: string;
   };
 
 function PrimaryAction(props: PrimaryActionType) {
@@ -118,7 +118,7 @@ type Props = {
    */
   zIndex?: Indexable;
   /**
-   * This is an experimental prop that defines what background color is used for the popover. 
+   * This is an experimental prop that defines what background color is used for the popover.
    * If set to 'notification', the background color will be darkGray, and if set to 'education', background color will be blue.
    */
   _experimentalVariant?: 'notification' | 'education';

--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -176,7 +176,7 @@ export default function PopoverEducational({
       <InternalPopover
         accessibilityLabel={accessibilityLabel}
         anchor={anchor}
-        color={isInAddNotifVariantExperiment && _experimentalVariant === 'notification' ? 'darkGray' : 'blue'}
+        color={_experimentalVariant === 'notification' ? 'darkGray' : 'blue'}
         disableFocusTrap
         disablePortal
         forceDirection={forceDirection}

--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -8,7 +8,6 @@ import InternalPopover from './Popover/InternalPopover';
 import styles from './PopoverEducational.css';
 import Text from './Text';
 import { Indexable } from './zIndex';
-import useInExperiment from './useInExperiment';
 
 type Size = 'sm' | 'flexible';
 type Role = 'dialog' | 'tooltip';
@@ -171,11 +170,6 @@ export default function PopoverEducational({
 
     textElement = <span className={textColorOverrideStyles}>{message}</span>;
   }
-
-  const isInAddNotifVariantExperiment = _experimentalVariant ? useInExperiment({
-    webExperimentName: 'gestalt_popover_educational_dark_color',
-    mwebExperimentName: 'gestalt_popover_educational_dark_color',
-  }) : false;
 
   return (
     <Box position={zIndex ? 'relative' : undefined} zIndex={zIndex}>

--- a/packages/gestalt/src/PopoverEducational.tsx
+++ b/packages/gestalt/src/PopoverEducational.tsx
@@ -8,30 +8,31 @@ import InternalPopover from './Popover/InternalPopover';
 import styles from './PopoverEducational.css';
 import Text from './Text';
 import { Indexable } from './zIndex';
+import useInExperiment from './useInExperiment';
 
 type Size = 'sm' | 'flexible';
 type Role = 'dialog' | 'tooltip';
 type PrimaryActionType =
   | {
-      accessibilityLabel?: string;
-      href: string;
-      onClick?: (arg1: {
-        event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
-        dangerouslyDisableOnNavigation: () => void;
-      }) => void;
-      rel?: 'none' | 'nofollow';
-      role: 'link';
-      target?: null | 'self' | 'blank';
-      text: string;
-    }
+    accessibilityLabel?: string;
+    href: string;
+    onClick?: (arg1: {
+      event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
+      dangerouslyDisableOnNavigation: () => void;
+    }) => void;
+    rel?: 'none' | 'nofollow';
+    role: 'link';
+    target?: null | 'self' | 'blank';
+    text: string;
+  }
   | {
-      accessibilityLabel?: string;
-      onClick?: (arg1: {
-        event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>;
-      }) => void;
-      role?: 'button';
-      text: string;
-    };
+    accessibilityLabel?: string;
+    onClick?: (arg1: {
+      event: React.MouseEvent<HTMLButtonElement> | React.KeyboardEvent<HTMLButtonElement>;
+    }) => void;
+    role?: 'button';
+    text: string;
+  };
 
 function PrimaryAction(props: PrimaryActionType) {
   if (props.role === 'link') {
@@ -116,6 +117,11 @@ type Props = {
    * An object representing the zIndex value of PopoverEducational. Learn more about [zIndex classes](https://gestalt.pinterest.systems/web/zindex_classes)
    */
   zIndex?: Indexable;
+  /**
+   * This is an experimental prop that defines what background color is used for the popover. 
+   * If set to 'notification', the background color will be darkGray, and if set to 'education', background color will be blue.
+   */
+  _experimentalVariant?: 'notification' | 'education';
 };
 
 /**
@@ -137,6 +143,7 @@ export default function PopoverEducational({
   shouldFocus = false,
   size = 'sm',
   zIndex,
+  _experimentalVariant,
 }: Props) {
   const { colorSchemeName } = useColorScheme();
   const isDarkMode = colorSchemeName === 'darkMode';
@@ -165,12 +172,17 @@ export default function PopoverEducational({
     textElement = <span className={textColorOverrideStyles}>{message}</span>;
   }
 
+  const isInAddNotifVariantExperiment = _experimentalVariant ? useInExperiment({
+    webExperimentName: 'gestalt_popover_educational_dark_color',
+    mwebExperimentName: 'gestalt_popover_educational_dark_color',
+  }) : false;
+
   return (
     <Box position={zIndex ? 'relative' : undefined} zIndex={zIndex}>
       <InternalPopover
         accessibilityLabel={accessibilityLabel}
         anchor={anchor}
-        color="blue"
+        color={isInAddNotifVariantExperiment && _experimentalVariant === 'notification' ? 'darkGray' : 'blue'}
         disableFocusTrap
         disablePortal
         forceDirection={forceDirection}


### PR DESCRIPTION



### Summary
This PR adds an experimental prop to the component PopoverEducational so we can test out using it for notification purposes on web. This simply changes the background color of the current component.

#### light mode
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/8fa1e375-a51e-442a-a459-c9978ec2f1ba)

#### dark mode
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/cb9b20e1-3a17-4d5f-8785-a797bca863f9)

Approved contribution doc: https://docs.google.com/document/d/1uhpW2DmYsMWXMba0J0xkJrUyg8YnPrUdLTyNN2eergs/edit 

#### What changed?

Added prop: _experimentalVariant?: 'notification' | 'education'
If _experimentalVariant set to 'notification', set bgColor to be 'darkGray', otherwise default to 'blue'.

#### Why?

In August 2024, the Social Growth team shipped [this experiment ](https://helium.pinadmin.com/sg_dweb_app_start_msg_notif/)to show users a notification message on dWeb app start if they have unread messages and saw overall success on messaging engagement. At that time, we used a component that is not standard to Gestalt. For a long term solution, it would be ideal if we could have a standardized Gestalt component for use cases like this.

### Links

- doc: https://docs.google.com/document/d/1uhpW2DmYsMWXMba0J0xkJrUyg8YnPrUdLTyNN2eergs/edit  


