### PR TITLE
ButtonGroup: VR Implementation

### DIFF
--- a/packages/gestalt/src/ButtonGroup.tsx
+++ b/packages/gestalt/src/ButtonGroup.tsx
@@ -1,5 +1,7 @@
 import { Children, ReactNode } from 'react';
+import { Flex } from '.';
 import Box from './Box';
+import useInExperiment from './useInExperiment';
 
 type Props = {
   /**
@@ -16,10 +18,21 @@ type Props = {
  *
  */
 function ButtonGroup({ children }: Props) {
+  const isInVRExperiment = useInExperiment({
+    webExperimentName: 'web_gestalt_visualRefresh',
+    mwebExperimentName: 'web_gestalt_visualRefresh',
+  });
+
   if (Children.count(children) === 0) {
     return null;
   }
-
+  if (isInVRExperiment) {
+    return (
+      <Flex gap={1} wrap>
+        {children}
+      </Flex>
+    );
+  }
   return (
     <Box display="flex" margin={-1} wrap>
       {Children.map(children, (child) =>


### PR DESCRIPTION
### Summary

#### What changed?

Implemented changes to ButtonGroup in VR. Specifically, the spacing between buttons was reduced by 2px.

Classic:
<img width="169" alt="Screenshot 2024-10-30 at 01 45 28" src="https://github.com/user-attachments/assets/b090c3a6-0eb2-4ee6-aa4e-91502f1763e8">

VR:
<img width="163" alt="Screenshot 2024-10-30 at 01 45 32" src="https://github.com/user-attachments/assets/e5f28f08-5f4d-4b83-a459-af1aef837bd0">

#### Why?

To conform to new VR designs.

### Links

- [Jira](https://jira.pinadmin.com/browse/CPW-7193)
- [Figma](https://www.figma.com/design/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-Web?node-id=2508-17905&node-type=canvas&m=dev)