### PR TITLE
Masonry: Add fixed early bailout depending on column span

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -150,11 +150,11 @@ type Props<T> = {
    */
   _dynamicHeights?: boolean;
   /**
-   * Experimental prop to define how much whitespace is good enough to position multicolumn modules
+   * Experimental prop to enable early bailout when positioning multicolumn modules
    *
    * This is an experimental prop and may be removed or changed in the future
    */
-  _whitespaceThreshold?: number;
+  _earlyBailout?: boolean;
 };
 
 type State<T> = {
@@ -591,7 +591,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
       _getColumnSpanConfig,
       _loadingStateItems = [],
       _renderLoadingStateItems,
-      _whitespaceThreshold,
+      _earlyBailout,
     } = this.props;
     const { hasPendingMeasurements, measurementStore, width } = this.state;
     const { positionStore } = this;
@@ -614,7 +614,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         logWhitespace: _logTwoColWhitespace,
         _getColumnSpanConfig,
         renderLoadingState,
-        whitespaceThreshold: _whitespaceThreshold,
+        earlyBailout: _earlyBailout,
       });
     } else if (layout === 'uniformRow') {
       getPositions = uniformRowLayout({
@@ -639,7 +639,7 @@ export default class Masonry<T> extends ReactComponent<Props<T>, State<T>> {
         logWhitespace: _logTwoColWhitespace,
         _getColumnSpanConfig,
         renderLoadingState,
-        whitespaceThreshold: _whitespaceThreshold,
+        earlyBailout: _earlyBailout,
       });
     }
 

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -59,7 +59,7 @@ const defaultLayout =
     positionCache: Cache<T, Position>;
     measurementCache: Cache<T, number>;
     _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-    whitespaceThreshold?: number;
+    earlyBailout?: boolean;
     logWhitespace?: (
       additionalWhitespace: ReadonlyArray<number>,
       numberOfIterations: number,

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -22,7 +22,7 @@ const fullWidthLayout = <T>({
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-  whitespaceThreshold?: number;
+  earlyBailout?: boolean;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -19,7 +19,7 @@ export default function getLayoutAlgorithm<T>({
   _logTwoColWhitespace,
   _loadingStateItems = [],
   renderLoadingState,
-  _whitespaceThreshold,
+  _earlyBailout,
 }: {
   align: Align;
   columnWidth: number;
@@ -38,7 +38,7 @@ export default function getLayoutAlgorithm<T>({
   ) => void;
   _loadingStateItems?: ReadonlyArray<LoadingStateItem>;
   renderLoadingState?: boolean;
-  _whitespaceThreshold?: number;
+  _earlyBailout?: boolean;
 }): (items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
     return fullWidthLayout({
@@ -51,7 +51,7 @@ export default function getLayoutAlgorithm<T>({
       logWhitespace: _logTwoColWhitespace,
       _getColumnSpanConfig,
       renderLoadingState,
-      whitespaceThreshold: _whitespaceThreshold,
+      earlyBailout: _earlyBailout,
     });
   }
   if (layout === 'uniformRow') {
@@ -77,6 +77,6 @@ export default function getLayoutAlgorithm<T>({
     width,
     _getColumnSpanConfig,
     renderLoadingState,
-    whitespaceThreshold: _whitespaceThreshold,
+    earlyBailout: _earlyBailout,
   });
 }

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -310,7 +310,7 @@ describe('multi column layout test cases', () => {
     });
   });
 
-  test('bails out graph when whitespace threshold is found', () => {
+  test('bails out graph when prop is found', () => {
     const measurementStore = new MeasurementStore<Record<any, any>, number>();
     const positionCache = new MeasurementStore<Record<any, any>, Position>();
 
@@ -335,13 +335,13 @@ describe('multi column layout test cases', () => {
     const layout = (itemsToLayout: readonly Item[]) =>
       multiColumnLayout({
         items: itemsToLayout,
-        gutter: 0,
+        gutter: 5,
         columnWidth: 240,
         columnCount: 4,
         centerOffset: 20,
         measurementCache: measurementStore,
         positionCache,
-        whitespaceThreshold: 11,
+        earlyBailout: true,
         _getColumnSpanConfig: getColumnSpanConfig,
       });
 
@@ -352,9 +352,9 @@ describe('multi column layout test cases', () => {
 
     expect(positionCache.get(items[4])).toEqual({
       height: 200,
-      left: 500,
-      top: 350,
-      width: 480,
+      left: 510,
+      top: 355,
+      width: 485,
     });
   });
 

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -474,7 +474,7 @@ function getPositionsWithMultiColumnItem<T>({
   itemsToPosition,
   heights,
   prevPositions,
-  whitespaceThreshold,
+  earlyBailout,
   columnCount,
   logWhitespace,
   _getColumnSpanConfig,
@@ -487,7 +487,7 @@ function getPositionsWithMultiColumnItem<T>({
     item: T;
     position: Position;
   }>;
-  whitespaceThreshold?: number;
+  earlyBailout?: boolean;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,
@@ -508,7 +508,7 @@ function getPositionsWithMultiColumnItem<T>({
   }>;
   heights: ReadonlyArray<number>;
 } {
-  const { positionCache } = commonGetPositionArgs;
+  const { positionCache, gutter } = commonGetPositionArgs;
 
   // This is the index inside the items to position array
   const multiColumnIndex = itemsToPosition.indexOf(multiColumnItem);
@@ -562,6 +562,13 @@ function getPositionsWithMultiColumnItem<T>({
   paintedItemPositions.forEach(({ item, position }) => {
     positionCache.set(item, position);
   });
+
+  let whitespaceThreshold;
+  if (earlyBailout && multiColumnItemColumnSpan <= 3) {
+    whitespaceThreshold = 2 * gutter;
+  } else if (earlyBailout && multiColumnItemColumnSpan > 3) {
+    whitespaceThreshold = 3 * gutter;
+  }
 
   // Get a node with the required whitespace
   const { winningNode, numberOfIterations } = getGraphPositions({
@@ -629,7 +636,7 @@ const multiColumnLayout = <T>({
   logWhitespace,
   measurementCache,
   positionCache,
-  whitespaceThreshold,
+  earlyBailout,
   _getColumnSpanConfig,
 }: {
   items: ReadonlyArray<T>;
@@ -639,7 +646,7 @@ const multiColumnLayout = <T>({
   centerOffset?: number;
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
-  whitespaceThreshold?: number;
+  earlyBailout?: boolean;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,
@@ -721,7 +728,7 @@ const multiColumnLayout = <T>({
           itemsToPosition,
           heights: acc.heights,
           prevPositions: acc.positions,
-          whitespaceThreshold,
+          earlyBailout,
           logWhitespace,
           columnCount,
           _getColumnSpanConfig,

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -162,11 +162,11 @@ type Props<T> = {
    */
   _dynamicHeights?: boolean;
   /**
-   * Experimental prop to define how much whitespace is good enough to position multicolumn modules
+   * Experimental prop to enable early bailout when positioning multicolumn modules
    *
    * This is an experimental prop and may be removed or changed in the future
    */
-  _whitespaceThreshold?: number;
+  _earlyBailout?: boolean;
 };
 
 type MasonryRef = {
@@ -376,7 +376,7 @@ function useLayout<T>({
   _getColumnSpanConfig,
   _loadingStateItems = [],
   _renderLoadingStateItems,
-  _whitespaceThreshold,
+  _earlyBailout,
 }: {
   align: Align;
   columnWidth: number;
@@ -398,7 +398,7 @@ function useLayout<T>({
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   _loadingStateItems?: ReadonlyArray<LoadingStateItem>;
   _renderLoadingStateItems?: Props<T>['_renderLoadingStateItems'];
-  _whitespaceThreshold?: number;
+  _earlyBailout?: boolean;
 }): {
   height: number;
   hasPendingMeasurements: boolean;
@@ -424,7 +424,7 @@ function useLayout<T>({
     _logTwoColWhitespace,
     _loadingStateItems,
     renderLoadingState,
-    _whitespaceThreshold,
+    _earlyBailout,
   });
 
   const hasMultiColumnItems =
@@ -701,7 +701,7 @@ function Masonry<T>(
     _dynamicHeights,
     _loadingStateItems = [],
     _renderLoadingStateItems,
-    _whitespaceThreshold,
+    _earlyBailout,
   }: Props<T>,
   ref:
     | {
@@ -825,7 +825,7 @@ function Masonry<T>(
       _getColumnSpanConfig,
       _loadingStateItems,
       _renderLoadingStateItems,
-      _whitespaceThreshold,
+      _earlyBailout,
     });
 
   useFetchOnScroll({


### PR DESCRIPTION
### Summary

After experimenting, we decided on two different values for early bailout. This PR exposes a prop to enable this functionality.

#### What changed?

- Removes whitespaceThreshold (We won't allow this value to be set from the outside)
- Adds earlyBailout prop
