### PR TITLE
Masonry: Add early bailout to be configurable from the outside

### DIFF
--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -154,7 +154,7 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed or changed in the future
    */
-  _earlyBailout?: boolean;
+  _earlyBailout?: (columnSpan: number) => number;
 };
 
 type State<T> = {

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -59,7 +59,7 @@ const defaultLayout =
     positionCache: Cache<T, Position>;
     measurementCache: Cache<T, number>;
     _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-    earlyBailout?: boolean;
+    earlyBailout?: (columnSpan: number) => number;
     logWhitespace?: (
       additionalWhitespace: ReadonlyArray<number>,
       numberOfIterations: number,

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -22,7 +22,7 @@ const fullWidthLayout = <T>({
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
-  earlyBailout?: boolean;
+  earlyBailout?: (columnSpan: number) => number;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,

--- a/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
+++ b/packages/gestalt/src/Masonry/getLayoutAlgorithm.ts
@@ -38,7 +38,7 @@ export default function getLayoutAlgorithm<T>({
   ) => void;
   _loadingStateItems?: ReadonlyArray<LoadingStateItem>;
   renderLoadingState?: boolean;
-  _earlyBailout?: boolean;
+  _earlyBailout?: (columnSpan: number) => number;
 }): (items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => ReadonlyArray<Position> {
   if ((layout === 'flexible' || layout === 'serverRenderedFlexible') && width !== null) {
     return fullWidthLayout({

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -332,16 +332,25 @@ describe('multi column layout test cases', () => {
       measurementStore.set(item, item.height);
     });
 
+    const gutter = 5;
+
+    const earlyBailout = (columnSpan: number) => {
+      if (columnSpan <= 3) {
+        return 2 * gutter;
+      }
+      return 3 * gutter;
+    };
+
     const layout = (itemsToLayout: readonly Item[]) =>
       multiColumnLayout({
         items: itemsToLayout,
-        gutter: 5,
+        gutter,
         columnWidth: 240,
         columnCount: 4,
         centerOffset: 20,
         measurementCache: measurementStore,
         positionCache,
-        earlyBailout: true,
+        earlyBailout,
         _getColumnSpanConfig: getColumnSpanConfig,
       });
 

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -508,7 +508,7 @@ function getPositionsWithMultiColumnItem<T>({
   }>;
   heights: ReadonlyArray<number>;
 } {
-  const { positionCache, gutter } = commonGetPositionArgs;
+  const { positionCache } = commonGetPositionArgs;
 
   // This is the index inside the items to position array
   const multiColumnIndex = itemsToPosition.indexOf(multiColumnItem);

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -487,7 +487,7 @@ function getPositionsWithMultiColumnItem<T>({
     item: T;
     position: Position;
   }>;
-  earlyBailout?: boolean;
+  earlyBailout?: (columnSpan: number) => number;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,
@@ -563,12 +563,7 @@ function getPositionsWithMultiColumnItem<T>({
     positionCache.set(item, position);
   });
 
-  let whitespaceThreshold;
-  if (earlyBailout && multiColumnItemColumnSpan <= 3) {
-    whitespaceThreshold = 2 * gutter;
-  } else if (earlyBailout && multiColumnItemColumnSpan > 3) {
-    whitespaceThreshold = 3 * gutter;
-  }
+  const whitespaceThreshold = earlyBailout?.(multiColumnItemColumnSpan);
 
   // Get a node with the required whitespace
   const { winningNode, numberOfIterations } = getGraphPositions({
@@ -646,7 +641,7 @@ const multiColumnLayout = <T>({
   centerOffset?: number;
   positionCache: Cache<T, Position>;
   measurementCache: Cache<T, number>;
-  earlyBailout?: boolean;
+  earlyBailout?: (columnSpan: number) => number;
   logWhitespace?: (
     additionalWhitespace: ReadonlyArray<number>,
     numberOfIterations: number,

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -398,7 +398,7 @@ function useLayout<T>({
   _getColumnSpanConfig?: (item: T) => ColumnSpanConfig;
   _loadingStateItems?: ReadonlyArray<LoadingStateItem>;
   _renderLoadingStateItems?: Props<T>['_renderLoadingStateItems'];
-  _earlyBailout?: boolean;
+  _earlyBailout?: (columnSpan: number) => number;
 }): {
   height: number;
   hasPendingMeasurements: boolean;

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -166,7 +166,7 @@ type Props<T> = {
    *
    * This is an experimental prop and may be removed or changed in the future
    */
-  _earlyBailout?: boolean;
+  _earlyBailout?: (columnSpan: number) => number;
 };
 
 type MasonryRef = {


### PR DESCRIPTION
### Summary

Change earblyBailout prop to receive a function to define value using column span.

#### What changed?

- Changes earlyBailout from number to function

