### PR TITLE
TAI-5041

### DIFF
--- a/docs/examples/sidenavigation/disablePreviewExample.tsx
+++ b/docs/examples/sidenavigation/disablePreviewExample.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Box, Heading, SideNavigation } from 'gestalt';
+
+export default function Example() {
+  const [page, setPage] = useState('');
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <Box display="flex" height="100%" overflow="auto">
+      {/* It is recommended the wrapper to be sticky. */}
+      <div style={{ position: 'sticky', top: 0 }}>
+        <SideNavigation
+          accessibilityLabel="Collapsible example"
+          collapsed={collapsed}
+          disablePreview
+          onCollapse={() => setCollapsed(!collapsed)}
+          showBorder
+        >
+          <SideNavigation.TopItem
+            active={page === '1' ? 'page' : undefined}
+            href="#"
+            icon="trending"
+            label="Trends"
+            notificationAccessibilityLabel="New data available"
+            onClick={({ event }) => {
+              event.preventDefault();
+              setPage('1');
+            }}
+            primaryAction={{ icon: 'ellipsis', tooltip: { text: 'Mark as read' } }}
+          />
+
+          <SideNavigation.TopItem
+            active={page === '2' ? 'page' : undefined}
+            badge={{ text: 'New', type: 'success' }}
+            counter={{ number: '10', accessibilityLabel: 'New details' }}
+            href="#"
+            icon="business-hierarchy"
+            label="Business Details"
+            onClick={({ event }) => {
+              event.preventDefault();
+              setPage('2');
+            }}
+          />
+
+          <SideNavigation.Section label="Public Holidays">
+            <SideNavigation.Group icon="people" label="Christmas">
+              <SideNavigation.NestedItem
+                active={page === '3' ? 'page' : undefined}
+                href="#"
+                label="Luxury Christmas"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                  setPage('3');
+                }}
+              />
+              <SideNavigation.NestedItem
+                active={page === '4' ? 'page' : undefined}
+                href="#"
+                label="Luxury Christmas"
+                onClick={({ event }) => {
+                  event.preventDefault();
+                  setPage('4');
+                }}
+              />
+              <SideNavigation.NestedGroup label="Classic Christmas">
+                <SideNavigation.NestedItem
+                  active={page === '5' ? 'page' : undefined}
+                  href="#"
+                  label="West Coast"
+                  onClick={({ event }) => {
+                    event.preventDefault();
+                    setPage('5');
+                  }}
+                />
+              </SideNavigation.NestedGroup>
+            </SideNavigation.Group>
+
+            <SideNavigation.TopItem
+              active={page === '6' ? 'page' : undefined}
+              href="#"
+              icon="overview"
+              label="Public profile"
+              notificationAccessibilityLabel="Needs your attention"
+              onClick={({ event }) => {
+                event.preventDefault();
+                setPage('6');
+              }}
+            />
+
+            <SideNavigation.TopItem
+              active={page === '7' ? 'page' : undefined}
+              href="#"
+              icon="workflow-status-unstarted"
+              label="Personal information"
+              onClick={({ event }) => {
+                event.preventDefault();
+                setPage('7');
+              }}
+            />
+          </SideNavigation.Section>
+
+          <SideNavigation.Section label="Contacts">
+            <SideNavigation.TopItem
+              active={page === '8' ? 'page' : undefined}
+              href="#"
+              icon="phone"
+              label="Contact Information"
+              onClick={({ event }) => {
+                event.preventDefault();
+                setPage('8');
+              }}
+            />
+            <SideNavigation.TopItem
+              active={page === '9' ? 'page' : undefined}
+              href="#"
+              icon="history"
+              label="Other Details"
+              onClick={({ event }) => {
+                event.preventDefault();
+                setPage('9');
+              }}
+            />
+          </SideNavigation.Section>
+        </SideNavigation>
+      </div>
+
+      <Box height={800} padding={4}>
+        <Heading size="500">Page main content</Heading>
+      </Box>
+    </Box>
+  );
+}

--- a/docs/pages/web/sidenavigation.tsx
+++ b/docs/pages/web/sidenavigation.tsx
@@ -20,6 +20,7 @@ import correctIconExample from '../../examples/sidenavigation/correctIconExample
 import correctLengthExample from '../../examples/sidenavigation/correctLengthExample';
 import counterExample from '../../examples/sidenavigation/counterExample';
 import customIconsExample from '../../examples/sidenavigation/customIconsExample';
+import disablePreviewExample from '../../examples/sidenavigation/disablePreviewExample';
 import displayExpandable from '../../examples/sidenavigation/displayExpandable';
 import displayExpanded from '../../examples/sidenavigation/displayExpanded';
 import displayStatic from '../../examples/sidenavigation/displayStatic';
@@ -555,6 +556,18 @@ It is recommended the wrapper to be \`sticky\` (not \`fixed\`) so that it stays 
               />
             }
             title="Items without icons"
+          />
+          <MainSection.Card
+            cardSize="lg"
+            description="If none of the SideNavigation items have icons, the component is collapsed only with expand icon button."
+            sandpackExample={
+              <SandpackExample
+                code={disablePreviewExample}
+                name="Collapsible without preview mode"
+                previewHeight={500}
+              />
+            }
+            title="Disable preview mode"
           />
         </MainSection.Subsection>
 

--- a/packages/gestalt/src/SideNavigation.tsx
+++ b/packages/gestalt/src/SideNavigation.tsx
@@ -36,6 +36,10 @@ export type Props = {
     onDismiss: () => void;
   };
   /**
+   * When passed SideNavigation will have no preview when mouse over the component. If not passed, it stays with the preview mode. See the [disablePreview variant](https://gestalt.pinterest.systems/web/sidenavigation#DisablePreview) to learn more. This functionality is not supported in mobile.
+   */
+  disablePreview?: boolean;
+  /**
    * Displays a border in SideNavigation. See the [Border](https://gestalt.pinterest.systems/web/sidenavigation#Border) variant for more info.
    */
   showBorder?: boolean;
@@ -75,6 +79,7 @@ export default function SideNavigation({
   showBorder,
   mobileTitle,
   collapsed,
+  disablePreview,
   onCollapse,
   onPreview,
 }: Props) {
@@ -120,6 +125,7 @@ export default function SideNavigation({
     <SideNavigationProvider
       collapsed={collapsed}
       collapsible={collapsible}
+      disablePreview={disablePreview}
       onCollapse={onCollapse}
       onPreview={onPreview}
     >

--- a/packages/gestalt/src/SideNavigation/NavigationContent.tsx
+++ b/packages/gestalt/src/SideNavigation/NavigationContent.tsx
@@ -39,6 +39,7 @@ export default function NavigationContent({
     setOverlayPreview,
     transitioning,
     setTransitioning,
+    disablePreview,
   } = useSideNavigation();
 
   const mainContainer = useRef<HTMLElement | null>(null);
@@ -65,7 +66,7 @@ export default function NavigationContent({
     const scrollHandler = () => setIsScrolled(!!element?.scrollTop);
 
     const mouseEnterHandler = () => {
-      if (sideNavigationCollapsed && !transitioning) {
+      if (sideNavigationCollapsed && !transitioning && !disablePreview) {
         // @ts-expect-error - TS2769 - No overload matches this call.
         clearTimeout(previewTimeoutRef.current);
         setCollapsedContainerWidth(mainContainer.current?.offsetWidth);
@@ -90,7 +91,7 @@ export default function NavigationContent({
       element?.removeEventListener('mouseenter', mouseEnterHandler);
       element?.removeEventListener('mouseleave', mouseLeaveHandler);
     };
-  }, [sideNavigationCollapsed, onCollapse, setOverlayPreview, transitioning]);
+  }, [sideNavigationCollapsed, onCollapse, setOverlayPreview, transitioning, disablePreview]);
 
   const isCollapsed = sideNavigationCollapsed && !overlayPreview;
 

--- a/packages/gestalt/src/contexts/SideNavigationProvider.tsx
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.tsx
@@ -15,6 +15,7 @@ type SideNavigationContextType = {
   setOverlayPreview: (arg1: boolean) => void;
   collapsible?: boolean;
   collapsed?: boolean;
+  disablePreview?: boolean;
   onCollapse?: (arg1: boolean) => void;
   transitioning?: boolean;
   setTransitioning: (arg1: boolean) => void;
@@ -34,6 +35,7 @@ type Props = {
   };
   collapsible?: boolean;
   collapsed?: boolean;
+  disablePreview?: boolean;
   onCollapse?: (arg1: boolean) => void;
   onPreview?: (arg1: boolean) => void;
 };
@@ -58,6 +60,7 @@ function SideNavigationProvider({
   dismissButton,
   collapsible,
   collapsed,
+  disablePreview,
   onCollapse: onCollapseProp,
   onPreview,
 }: Props) {
@@ -73,6 +76,8 @@ function SideNavigationProvider({
   };
 
   const setOverlayPreview = (state: boolean) => {
+    console.log('# overlayPreview: ', overlayPreview);
+    console.log('# state: ', state);
     if (overlayPreview !== state) setTransitioning(true);
     setOverlayPreviewCb(state);
     onPreview?.(state);
@@ -93,6 +98,7 @@ function SideNavigationProvider({
     onCollapse,
     transitioning,
     setTransitioning,
+    disablePreview,
   } as const;
 
   return <Provider value={sideNavigationContext}>{children}</Provider>;

--- a/packages/gestalt/src/contexts/SideNavigationProvider.tsx
+++ b/packages/gestalt/src/contexts/SideNavigationProvider.tsx
@@ -76,8 +76,6 @@ function SideNavigationProvider({
   };
 
   const setOverlayPreview = (state: boolean) => {
-    console.log('# overlayPreview: ', overlayPreview);
-    console.log('# state: ', state);
     if (overlayPreview !== state) setTransitioning(true);
     setOverlayPreviewCb(state);
     onPreview?.(state);


### PR DESCRIPTION
### Summary

This PR allow users to use the SideNavigation in the collapsed mode, without having a preview to interact with the icons.

#### What changed?

Added a new property to SideNavigation to allow user disable the preview.

#### Why?

Not be able to use the SideNavigation was pointed as an issue for users that are using the new Media Planner tool of Pinterest, so in order to have the user a better experience we created the option to disable the preview when it is collapsed

### Links

- [Jira](https://jira.pinadmin.com/browse/TAI-5041)


### Checklist

- [X] Added unit tests
- [X] Added documentation + accessibility tests
- [X] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
