### PR TITLE
Masonry: Update fullWidthLayout to not floor column widths

### DIFF
--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -45,7 +45,7 @@ const fullWidthLayout = <T>({
   // original implementation takes with CSS.
   const colguess = Math.floor(width / idealColumnWidth);
   const columnCount = Math.max(Math.floor((width - colguess * gutter) / idealColumnWidth), minCols);
-  const columnWidth = Math.floor(width / columnCount) - gutter;
+  const columnWidth = (width / columnCount) - gutter;
   const columnWidthAndGutter = columnWidth + gutter;
   const centerOffset = gutter / 2;
 

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -45,7 +45,7 @@ const fullWidthLayout = <T>({
   // original implementation takes with CSS.
   const colguess = Math.floor(width / idealColumnWidth);
   const columnCount = Math.max(Math.floor((width - colguess * gutter) / idealColumnWidth), minCols);
-  const columnWidth = (width / columnCount) - gutter;
+  const columnWidth = width / columnCount - gutter;
   const columnWidthAndGutter = columnWidth + gutter;
   const centerOffset = gutter / 2;
 

--- a/playwright/masonry/flexible-resize.spec.ts
+++ b/playwright/masonry/flexible-resize.spec.ts
@@ -76,7 +76,7 @@ test.describe('Masonry: flexible resize', () => {
     const itemRectsAfter = await Promise.all(
       gridItemsAfter.map((gridItemAfter) => gridItemAfter.boundingBox()),
     );
-    expect(itemRectsAfter[0]?.width).toBe(273);
+    expect(Math.floor(itemRectsAfter[0]?.width)).toBe(273);
     expect(itemRectsAfter[0]?.height).toBe(216);
 
     // Get new sizes of grid items.


### PR DESCRIPTION
### Summary

Currently, when calculating column widths via `fullWidthLayout`, the values of the column widths are rounded down via Math.floor. 

Because we rely on CSS (specifically `calc`) for the initial server render, this can actually cause slight layout shifts when going from server render -> client render due to the slight difference in widths
![image](https://github.com/user-attachments/assets/3b8d3838-6800-4510-872e-add7bb149989) 
![image](https://github.com/user-attachments/assets/1ac62d54-d10f-411b-ab29-158aa81acd35)

While visually, this is not an issue (due to the shift being so tiny), this can actually result in LCP regressions since this results in a repaint.

This PR addresses the issue by removing the Math.floor. After this change, the column width will stay consistent between server and client render