### PR TITLE
Masonry: Update container measurement logic for V2

### DIFF
--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -264,7 +264,6 @@ function useScrollContainer({
     }
   }, [gridWrapper, scrollContainer]);
 
-
   useEffect(() => {
     // measure the container whenever the gridWrapper or scrollContainer changes (we use the identity of the measureContainer function here as an indication of that)
     measureContainer();

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -480,6 +480,7 @@ function useLayout<T>({
     // - itemMeasurementsCount: if we have a change in the number of items we've measured, we should always recalculage
     // - canPerformLayout: if we don't have a width, we can't calculate positions yet. so recalculate once we're able to
 
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [itemMeasurementsCount, items, canPerformLayout, heightUpdateTrigger]);
 
@@ -777,6 +778,7 @@ function Masonry<T>(
       hasSetInitialWidth.current = true;
     }
 
+    // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width]);
 


### PR DESCRIPTION
### Summary
This PR fixes a bug with Masonry V2 which can cause a delay in items being rendered when unmounting/restoring scroll position.

### Problem
Currently, we initialize the `containerHeight` and `containerOffset` values during the initial render and then, subsequently, trigger async updates. However, this results in a delay during the initial render because `scrollContainer` is not set, which results in the order of operations being:
- render
- set containerHeight, containerOffset
- set scrollContainer
- (async) update containerHeight and containerOffset

Because of this, we can sometimes see a delay in pins being rendered when navigating back and forth in related pins.

This PR addresses the issue by "forcing" a measurement of `containerHeight` and `containerOffset` whenever we detect any change to scrollContainer or gridWrapper

After this change, the order of operations will now be:
- render
- set scrollContainer
- reset containerHeight, containerOffset

### Test Plan
Verified locally by patching this change into devapp and testing mobile web related pins (which is where I was seeing this issue previously)