### PR TITLE
Masonry: update layout logic to support rendering skeleton pins

### DIFF
--- a/docs/pages/visual-test/Masonry-items-loading-flexible.tsx
+++ b/docs/pages/visual-test/Masonry-items-loading-flexible.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, ColorSchemeProvider, Flex, Image, Masonry } from 'gestalt';
+import { TOKEN_COLOR_GRAY_ROBOFLOW_300 } from 'gestalt-design-tokens';
+
+type Pin = {
+  color: string;
+  naturalHeight: number;
+  src: string;
+  width: number;
+  name: string;
+};
+
+type SkeletonPin = {
+  key: string;
+  height: number;
+};
+
+const pins = [
+  {
+    color: '#2b3938',
+    naturalHeight: 316,
+    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+    width: 474,
+    name: 'the Hang Son Doong cave in Vietnam',
+  },
+  {
+    color: '#8e7439',
+    naturalHeight: 1081,
+    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+    width: 474,
+    name: 'La Gran Muralla, Pekín, China',
+  },
+  {
+    color: '#698157',
+    naturalHeight: 711,
+    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+    width: 474,
+    name: 'Plitvice Lakes National Park, Croatia',
+  },
+  {
+    color: '#4e5d50',
+    naturalHeight: 632,
+    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+    width: 474,
+    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+  },
+  {
+    color: '#6d6368',
+    naturalHeight: 710,
+    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+    width: 474,
+    name: 'Border of China and Vietnam',
+  },
+];
+
+function getPins(): Promise<Array<Pin>> {
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  return Promise.resolve(pinList);
+}
+
+const styles = {
+  backgroundColor: `${TOKEN_COLOR_GRAY_ROBOFLOW_300}`,
+  backgroundSize: '200vw 100%',
+  content: '',
+  position: 'relative',
+  width: '100%',
+} as const;
+
+function SkeletonPin({ data }: { data: SkeletonPin }) {
+  const { height } = data;
+  return (
+    <div style={styles}>
+      <Box height={height} />
+    </div>
+  );
+}
+
+function GridComponent({ data }: { data: Pin }) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.naturalHeight}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+    </Flex>
+  );
+}
+
+const smallPinHeight = 236;
+const largePinHeight = 356;
+
+function getSkeletonPins(numOfPins: number) {
+  return Array.from({ length: numOfPins }).reduce<Array<{ height: number; key: React.Key }>>(
+    (acc, _, i) => {
+      const height = i % 2 === 0 ? largePinHeight : smallPinHeight;
+      return [...acc, { height, key: `skeleton-pin-${i}`, isSkeletonPin: true }];
+    },
+    [],
+  );
+}
+
+export function isSkeletonPin<T>(item: T | SkeletonPin): item is SkeletonPin {
+  return Boolean(item && typeof item === 'object' && 'height' in item && 'isSkeletonPin' in item);
+}
+
+export default function Snapshot() {
+  const [items, setItems] = useState<Record<string, unknown>[]>([]);
+  const scrollContainerRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      getPins().then(setItems);
+    }, 2500);
+  }, []);
+
+  const skeletonPins = getSkeletonPins(50);
+  const finalItems = items.length === 0 ? skeletonPins : items;
+
+  return (
+    <ColorSchemeProvider colorScheme="light">
+      <div
+        ref={scrollContainerRef}
+        style={{ overflowY: 'scroll', height: '100vh', width: '100vw' }}
+      >
+        <Masonry
+          columnWidth={170}
+          gutterWidth={20}
+          items={finalItems}
+          layout="flexible"
+          renderItem={({ data, itemIdx }) => {
+            if (itemIdx >= items.length && isSkeletonPin(data)) {
+              return <SkeletonPin key={data.key} data={data} />;
+            }
+            return <GridComponent data={data as Pin} />;
+          }}
+        />
+      </div>
+    </ColorSchemeProvider>
+  );
+}

--- a/docs/pages/visual-test/Masonry-items-loading-uniformRow.tsx
+++ b/docs/pages/visual-test/Masonry-items-loading-uniformRow.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, ColorSchemeProvider, Flex, Image, Masonry } from 'gestalt';
+import { TOKEN_COLOR_GRAY_ROBOFLOW_300 } from 'gestalt-design-tokens';
+
+type Pin = {
+  color: string;
+  naturalHeight: number;
+  src: string;
+  width: number;
+  name: string;
+};
+
+type SkeletonPin = {
+  key: string;
+  height: number;
+};
+
+const pins = [
+  {
+    color: '#2b3938',
+    naturalHeight: 316,
+    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+    width: 474,
+    name: 'the Hang Son Doong cave in Vietnam',
+  },
+  {
+    color: '#8e7439',
+    naturalHeight: 1081,
+    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+    width: 474,
+    name: 'La Gran Muralla, Pekín, China',
+  },
+  {
+    color: '#698157',
+    naturalHeight: 711,
+    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+    width: 474,
+    name: 'Plitvice Lakes National Park, Croatia',
+  },
+  {
+    color: '#4e5d50',
+    naturalHeight: 632,
+    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+    width: 474,
+    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+  },
+  {
+    color: '#6d6368',
+    naturalHeight: 710,
+    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+    width: 474,
+    name: 'Border of China and Vietnam',
+  },
+];
+
+function getPins(): Promise<Array<Pin>> {
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  return Promise.resolve(pinList);
+}
+
+const styles = {
+  backgroundColor: `${TOKEN_COLOR_GRAY_ROBOFLOW_300}`,
+  backgroundSize: '200vw 100%',
+  content: '',
+  position: 'relative',
+  width: '100%',
+} as const;
+
+function SkeletonPin({ data }: { data: SkeletonPin }) {
+  const { height } = data;
+  return (
+    <div style={styles}>
+      <Box height={height} />
+    </div>
+  );
+}
+
+function GridComponent({ data }: { data: Pin }) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.naturalHeight}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+    </Flex>
+  );
+}
+
+const smallPinHeight = 236;
+const largePinHeight = 356;
+
+function getSkeletonPins(numOfPins: number) {
+  return Array.from({ length: numOfPins }).reduce<Array<{ height: number; key: React.Key }>>(
+    (acc, _, i) => {
+      const height = i % 2 === 0 ? largePinHeight : smallPinHeight;
+      return [...acc, { height, key: `skeleton-pin-${i}`, isSkeletonPin: true }];
+    },
+    [],
+  );
+}
+
+export function isSkeletonPin<T>(item: T | SkeletonPin): item is SkeletonPin {
+  return Boolean(item && typeof item === 'object' && 'height' in item && 'isSkeletonPin' in item);
+}
+
+export default function Snapshot() {
+  const [items, setItems] = useState<Record<string, unknown>[]>([]);
+  const scrollContainerRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      getPins().then(setItems);
+    }, 2500);
+  }, []);
+
+  const skeletonPins = getSkeletonPins(50);
+  const finalItems = items.length === 0 ? skeletonPins : items;
+
+  return (
+    <ColorSchemeProvider colorScheme="light">
+      <div
+        ref={scrollContainerRef}
+        style={{ overflowY: 'scroll', height: '100vh', width: '100vw' }}
+      >
+        <Masonry
+          columnWidth={170}
+          gutterWidth={20}
+          items={finalItems}
+          layout="uniformRow"
+          renderItem={({ data, itemIdx }) => {
+            if (itemIdx >= items.length && isSkeletonPin(data)) {
+              return <SkeletonPin key={data.key} data={data} />;
+            }
+            return <GridComponent data={data as Pin} />;
+          }}
+        />
+      </div>
+    </ColorSchemeProvider>
+  );
+}

--- a/docs/pages/visual-test/Masonry-items-loading.tsx
+++ b/docs/pages/visual-test/Masonry-items-loading.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, ColorSchemeProvider, Flex, Image, Masonry } from 'gestalt';
+import { TOKEN_COLOR_GRAY_ROBOFLOW_300 } from 'gestalt-design-tokens';
+
+type Pin = {
+  color: string;
+  naturalHeight: number;
+  src: string;
+  width: number;
+  name: string;
+};
+
+type SkeletonPin = {
+  key: string;
+  height: number;
+};
+
+const pins = [
+  {
+    color: '#2b3938',
+    naturalHeight: 316,
+    src: 'https://i.ibb.co/sQzHcFY/stock9.jpg',
+    width: 474,
+    name: 'the Hang Son Doong cave in Vietnam',
+  },
+  {
+    color: '#8e7439',
+    naturalHeight: 1081,
+    src: 'https://i.ibb.co/zNDxPtn/stock10.jpg',
+    width: 474,
+    name: 'La Gran Muralla, Pekín, China',
+  },
+  {
+    color: '#698157',
+    naturalHeight: 711,
+    src: 'https://i.ibb.co/M5TdMNq/stock11.jpg',
+    width: 474,
+    name: 'Plitvice Lakes National Park, Croatia',
+  },
+  {
+    color: '#4e5d50',
+    naturalHeight: 632,
+    src: 'https://i.ibb.co/r0NZKrk/stock12.jpg',
+    width: 474,
+    name: 'Ban Gioc – Detian Falls : 2 waterfalls straddling the Vietnamese and Chinese border.',
+  },
+  {
+    color: '#6d6368',
+    naturalHeight: 710,
+    src: 'https://i.ibb.co/zmFd0Dv/stock13.jpg',
+    width: 474,
+    name: 'Border of China and Vietnam',
+  },
+];
+
+function getPins(): Promise<Array<Pin>> {
+  const pinList = [...new Array(3)].map(() => [...pins]).flat();
+  return Promise.resolve(pinList);
+}
+
+const styles = {
+  backgroundColor: `${TOKEN_COLOR_GRAY_ROBOFLOW_300}`,
+  backgroundSize: '200vw 100%',
+  content: '',
+  position: 'relative',
+  width: '100%',
+} as const;
+
+function SkeletonPin({ data }: { data: SkeletonPin }) {
+  const { height } = data;
+  return (
+    <div style={styles}>
+      <Box height={height} />
+    </div>
+  );
+}
+
+function GridComponent({ data }: { data: Pin }) {
+  return (
+    <Flex direction="column">
+      <Image
+        alt={data.name}
+        color={data.color}
+        naturalHeight={data.naturalHeight}
+        naturalWidth={data.width}
+        src={data.src}
+      />
+    </Flex>
+  );
+}
+
+const smallPinHeight = 236;
+const largePinHeight = 356;
+
+function getSkeletonPins(numOfPins: number) {
+  return Array.from({ length: numOfPins }).reduce<Array<{ height: number; key: React.Key }>>(
+    (acc, _, i) => {
+      const height = i % 2 === 0 ? largePinHeight : smallPinHeight;
+      return [...acc, { height, key: `skeleton-pin-${i}`, isSkeletonPin: true }];
+    },
+    [],
+  );
+}
+
+export function isSkeletonPin<T>(item: T | SkeletonPin): item is SkeletonPin {
+  return Boolean(item && typeof item === 'object' && 'height' in item && 'isSkeletonPin' in item);
+}
+
+export default function Snapshot() {
+  const [items, setItems] = useState<Record<string, unknown>[]>([]);
+  const scrollContainerRef = useRef(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      getPins().then(setItems);
+    }, 2500);
+  }, []);
+
+  const skeletonPins = getSkeletonPins(50);
+  const finalItems = items.length === 0 ? skeletonPins : items;
+
+  return (
+    <ColorSchemeProvider colorScheme="light">
+      <div
+        ref={scrollContainerRef}
+        style={{ overflowY: 'scroll', height: '100vh', width: '100vw' }}
+      >
+        <Masonry
+          columnWidth={170}
+          gutterWidth={20}
+          items={finalItems}
+          renderItem={({ data, itemIdx }) => {
+            if (itemIdx >= items.length && isSkeletonPin(data)) {
+              return <SkeletonPin key={data.key} data={data} />;
+            }
+            return <GridComponent data={data as Pin} />;
+          }}
+        />
+      </div>
+    </ColorSchemeProvider>
+  );
+}

--- a/packages/gestalt/src/Masonry/defaultLayout.test.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.ts
@@ -7,6 +7,7 @@ type Item = {
   height: number;
   color?: string;
   columnSpan?: number;
+  isSkeletonPin?: boolean;
 };
 
 const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
@@ -324,6 +325,72 @@ describe('loadingStateItems', () => {
       { 'name': 'Pin 1', 'height': 120 },
       { 'name': 'Pin 2', 'height': 80 },
       { 'name': 'Pin 3', 'height': 100 },
+    ];
+    items.forEach((item: any) => {
+      /**
+       * Forcing the height to be different here since we always want to get the height from the measurement cache
+       * We only want to use the item's height if we are rendering loading state items
+       */
+      measurementStore.set(item, item.height + 1);
+    });
+
+    const layout = defaultLayout({
+      align: 'start',
+      measurementCache: measurementStore,
+      positionCache,
+      layout: 'basic',
+      minCols: 2,
+      rawItemCount: items.length,
+      width: 8000,
+    });
+
+    expect(layout(items)).toEqual([
+      { top: 0, height: 101, left: 0, width: 236 },
+      { top: 0, height: 121, left: 250, width: 236 },
+      { top: 0, height: 81, left: 500, width: 236 },
+      { top: 0, height: 101, left: 750, width: 236 },
+    ]);
+  });
+});
+
+describe('skeletonPins', () => {
+  test("uses the skeletonPin's height", () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const skeletonPins: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100, isSkeletonPin: true },
+      { 'name': 'Pin 1', 'height': 120, isSkeletonPin: true },
+      { 'name': 'Pin 2', 'height': 80, isSkeletonPin: true },
+      { 'name': 'Pin 3', 'height': 100, isSkeletonPin: true },
+    ];
+
+    const layout = defaultLayout({
+      align: 'start',
+      measurementCache: measurementStore,
+      positionCache,
+      layout: 'basic',
+      minCols: 2,
+      rawItemCount: skeletonPins.length,
+      width: 8000,
+      renderLoadingState: true,
+    });
+
+    expect(layout(skeletonPins)).toEqual([
+      { top: 0, height: 100, left: 0, width: 236 },
+      { top: 0, height: 120, left: 250, width: 236 },
+      { top: 0, height: 80, left: 500, width: 236 },
+      { top: 0, height: 100, left: 750, width: 236 },
+    ]);
+  });
+
+  test('uses the measurementCache height when not a skeletonPin', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100, isSkeletonPin: false },
+      { 'name': 'Pin 1', 'height': 120, isSkeletonPin: false },
+      { 'name': 'Pin 2', 'height': 80, isSkeletonPin: false },
+      { 'name': 'Pin 3', 'height': 100, isSkeletonPin: false },
     ];
     items.forEach((item: any) => {
       /**

--- a/packages/gestalt/src/Masonry/defaultLayout.test.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.test.ts
@@ -372,7 +372,6 @@ describe('skeletonPins', () => {
       minCols: 2,
       rawItemCount: skeletonPins.length,
       width: 8000,
-      renderLoadingState: true,
     });
 
     expect(layout(skeletonPins)).toEqual([
@@ -395,7 +394,7 @@ describe('skeletonPins', () => {
     items.forEach((item: any) => {
       /**
        * Forcing the height to be different here since we always want to get the height from the measurement cache
-       * We only want to use the item's height if we are rendering loading state items
+       * We only want to use the item's height if we are rendering a skeleton pin
        */
       measurementStore.set(item, item.height + 1);
     });

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -1,6 +1,11 @@
 import { Cache } from './Cache';
 import { getHeightAndGutter, offscreen } from './layoutHelpers';
-import { isLoadingStateItem, isLoadingStateItems, isSkeletonPin } from './loadingStateUtils';
+import {
+  areSkeletonPins,
+  isLoadingStateItem,
+  isLoadingStateItems,
+  isSkeletonPin,
+} from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { Align, Layout, LoadingStateItem, Position } from './types';
@@ -87,7 +92,9 @@ const defaultLayout =
       width,
     });
 
-    return _getColumnSpanConfig && !isLoadingStateItems(items, renderLoadingState)
+    return _getColumnSpanConfig &&
+      !isLoadingStateItems(items, renderLoadingState) &&
+      !areSkeletonPins(items)
       ? multiColumnLayout({
           items,
           columnWidth,

--- a/packages/gestalt/src/Masonry/defaultLayout.ts
+++ b/packages/gestalt/src/Masonry/defaultLayout.ts
@@ -1,6 +1,6 @@
 import { Cache } from './Cache';
 import { getHeightAndGutter, offscreen } from './layoutHelpers';
-import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
+import { isLoadingStateItem, isLoadingStateItems, isSkeletonPin } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { Align, Layout, LoadingStateItem, Position } from './types';
@@ -99,9 +99,10 @@ const defaultLayout =
           ...otherProps,
         })
       : items.map((item) => {
-          const height = isLoadingStateItem(item, renderLoadingState)
-            ? item.height
-            : measurementCache.get(item);
+          const height =
+            isLoadingStateItem(item, renderLoadingState) || isSkeletonPin(item)
+              ? item.height
+              : measurementCache.get(item);
 
           if (height == null) {
             return offscreen(columnWidth);

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -202,7 +202,6 @@ describe('skeletonPins', () => {
       minCols: 2,
       width: 1000,
       _getColumnSpanConfig: getColumnSpanConfig,
-      renderLoadingState: true,
     });
 
     expect(layout(skeletonPins)).toEqual([
@@ -225,7 +224,7 @@ describe('skeletonPins', () => {
     items.forEach((item: any) => {
       /**
        * Forcing the height to be different here since we always want to get the height from the measurement cache
-       * We only want to use the item's height if we are rendering loading state items
+       * We only want to use the item's height if we are rendering a skeleton pin
        */
       measurementStore.set(item, item.height + 1);
     });

--- a/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.test.ts
@@ -7,6 +7,7 @@ type Item = {
   height: number;
   color?: string;
   columnSpan?: number;
+  isSkeletonPin?: boolean;
 };
 
 const getColumnSpanConfig = (item: Item) => item.columnSpan ?? 1;
@@ -154,6 +155,72 @@ describe('loadingStateItems', () => {
       { 'name': 'Pin 1', 'height': 120 },
       { 'name': 'Pin 2', 'height': 80 },
       { 'name': 'Pin 3', 'height': 100 },
+    ];
+    items.forEach((item: any) => {
+      /**
+       * Forcing the height to be different here since we always want to get the height from the measurement cache
+       * We only want to use the item's height if we are rendering loading state items
+       */
+      measurementStore.set(item, item.height + 1);
+    });
+
+    const layout = fullWidthLayout({
+      measurementCache: measurementStore,
+      positionCache,
+      gutter: 10,
+      idealColumnWidth: 240,
+      minCols: 2,
+      width: 1000,
+      _getColumnSpanConfig: getColumnSpanConfig,
+    });
+
+    expect(layout(items)).toEqual([
+      { top: 0, height: 101, left: 5, width: 240 },
+      { top: 0, height: 121, left: 255, width: 240 },
+      { top: 0, height: 81, left: 505, width: 240 },
+      { top: 0, height: 101, left: 755, width: 240 },
+    ]);
+  });
+});
+
+describe('skeletonPins', () => {
+  test("uses the skeletonPin's height", () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const skeletonPins: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100, isSkeletonPin: true },
+      { 'name': 'Pin 1', 'height': 120, isSkeletonPin: true },
+      { 'name': 'Pin 2', 'height': 80, isSkeletonPin: true },
+      { 'name': 'Pin 3', 'height': 100, isSkeletonPin: true },
+    ];
+
+    const layout = fullWidthLayout({
+      measurementCache: measurementStore,
+      positionCache,
+      gutter: 10,
+      idealColumnWidth: 240,
+      minCols: 2,
+      width: 1000,
+      _getColumnSpanConfig: getColumnSpanConfig,
+      renderLoadingState: true,
+    });
+
+    expect(layout(skeletonPins)).toEqual([
+      { top: 0, height: 100, left: 5, width: 240 },
+      { top: 0, height: 120, left: 255, width: 240 },
+      { top: 0, height: 80, left: 505, width: 240 },
+      { top: 0, height: 100, left: 755, width: 240 },
+    ]);
+  });
+
+  test('uses the measurementCache height when not a skeletonPin', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: ReadonlyArray<Item> = [
+      { 'name': 'Pin 0', 'height': 100, isSkeletonPin: false },
+      { 'name': 'Pin 1', 'height': 120, isSkeletonPin: false },
+      { 'name': 'Pin 2', 'height': 80, isSkeletonPin: false },
+      { 'name': 'Pin 3', 'height': 100, isSkeletonPin: false },
     ];
     items.forEach((item: any) => {
       /**

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -1,6 +1,6 @@
 import { Cache } from './Cache';
 import { getHeightAndGutter } from './layoutHelpers';
-import { isLoadingStateItem, isLoadingStateItems } from './loadingStateUtils';
+import { isLoadingStateItem, isLoadingStateItems, isSkeletonPin } from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { LoadingStateItem, Position } from './types';
@@ -64,9 +64,10 @@ const fullWidthLayout = <T>({
         })
       : items.reduce<Array<any>>((acc, item) => {
           const positions = acc;
-          const height = isLoadingStateItem(item, renderLoadingState)
-            ? item.height
-            : measurementCache.get(item);
+          const height =
+            isLoadingStateItem(item, renderLoadingState) || isSkeletonPin(item)
+              ? item.height
+              : measurementCache.get(item);
           let position;
 
           if (height == null) {

--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -1,6 +1,11 @@
 import { Cache } from './Cache';
 import { getHeightAndGutter } from './layoutHelpers';
-import { isLoadingStateItem, isLoadingStateItems, isSkeletonPin } from './loadingStateUtils';
+import {
+  areSkeletonPins,
+  isLoadingStateItem,
+  isLoadingStateItems,
+  isSkeletonPin,
+} from './loadingStateUtils';
 import mindex from './mindex';
 import multiColumnLayout, { ColumnSpanConfig } from './multiColumnLayout';
 import { LoadingStateItem, Position } from './types';
@@ -51,7 +56,9 @@ const fullWidthLayout = <T>({
 
   return (items: ReadonlyArray<T> | ReadonlyArray<LoadingStateItem>) => {
     const heights = new Array<number>(columnCount).fill(0);
-    return _getColumnSpanConfig && !isLoadingStateItems(items, renderLoadingState)
+    return _getColumnSpanConfig &&
+      !isLoadingStateItems(items, renderLoadingState) &&
+      !areSkeletonPins(items)
       ? multiColumnLayout({
           items,
           columnWidth,

--- a/packages/gestalt/src/Masonry/loadingStateUtils.ts
+++ b/packages/gestalt/src/Masonry/loadingStateUtils.ts
@@ -1,4 +1,4 @@
-import { LoadingStateItem } from './types';
+import { LoadingStateItem, SkeletonPin } from './types';
 
 export function isLoadingStateItem<T>(
   item: T | LoadingStateItem,
@@ -14,6 +14,18 @@ export function isLoadingStateItems<T>(
   return items.some((item) => isLoadingStateItem(item, renderLoadingState));
 }
 
-export function isSkeletonPin<T>(item: T | LoadingStateItem): item is LoadingStateItem {
-  return Boolean(item && typeof item === 'object' && 'height' in item && 'isSkeletonPin' in item);
+export function isSkeletonPin<T>(item: T | SkeletonPin): item is SkeletonPin {
+  return Boolean(
+    item &&
+      typeof item === 'object' &&
+      'height' in item &&
+      'isSkeletonPin' in item &&
+      item.isSkeletonPin === true,
+  );
+}
+
+export function areSkeletonPins<T>(
+  items: ReadonlyArray<T> | ReadonlyArray<SkeletonPin>,
+): items is ReadonlyArray<SkeletonPin> {
+  return items.some((item) => isSkeletonPin(item));
 }

--- a/packages/gestalt/src/Masonry/loadingStateUtils.ts
+++ b/packages/gestalt/src/Masonry/loadingStateUtils.ts
@@ -13,3 +13,7 @@ export function isLoadingStateItems<T>(
 ): items is ReadonlyArray<LoadingStateItem> {
   return items.some((item) => isLoadingStateItem(item, renderLoadingState));
 }
+
+export function isSkeletonPin<T>(item: T | LoadingStateItem): item is LoadingStateItem {
+  return Boolean(item && typeof item === 'object' && 'height' in item && 'isSkeletonPin' in item);
+}

--- a/packages/gestalt/src/Masonry/types.ts
+++ b/packages/gestalt/src/Masonry/types.ts
@@ -30,3 +30,5 @@ export type Layout =
   | 'uniformRowFlexible';
 
 export type LoadingStateItem = { height: number };
+
+export type SkeletonPin = { height: number; isSkeletonPin: boolean };

--- a/packages/gestalt/src/Masonry/uniformRowLayout.test.ts
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.test.ts
@@ -159,3 +159,27 @@ describe('loadingStateItems', () => {
     ]);
   });
 });
+
+describe('skeletonPins', () => {
+  test("uses the skeletonPin's height", () => {
+    const skeletonPins = [
+      { 'name': 'Pin 0', 'height': 100, isSkeletonPin: true },
+      { 'name': 'Pin 1', 'height': 120, isSkeletonPin: true },
+      { 'name': 'Pin 2', 'height': 80, isSkeletonPin: true },
+      { 'name': 'Pin 3', 'height': 100, isSkeletonPin: true },
+    ];
+
+    const layout = uniformRowLayout({
+      cache: stubCache(),
+      width: 500,
+      renderLoadingState: true,
+    });
+
+    expect(layout(skeletonPins)).toEqual([
+      { top: 0, height: 100, left: 0, width: 236 },
+      { top: 0, height: 120, left: 250, width: 236 },
+      { top: 0, height: 80, left: 500, width: 236 },
+      { top: 134, height: 100, left: 0, width: 236 },
+    ]);
+  });
+});

--- a/packages/gestalt/src/Masonry/uniformRowLayout.ts
+++ b/packages/gestalt/src/Masonry/uniformRowLayout.ts
@@ -1,5 +1,5 @@
 import { Cache } from './Cache';
-import { isLoadingStateItem } from './loadingStateUtils';
+import { isLoadingStateItem, isSkeletonPin } from './loadingStateUtils';
 import { LoadingStateItem, Position } from './types';
 
 const offscreen = (width: number, height: number = Infinity) => ({
@@ -79,7 +79,10 @@ const uniformRowLayout =
 
     const heights: Array<number> = [];
     return items.map((item, i) => {
-      const height = isLoadingStateItem(item, renderLoadingState) ? item.height : cache.get(item);
+      const height =
+        isLoadingStateItem(item, renderLoadingState) || isSkeletonPin(item)
+          ? item.height
+          : cache.get(item);
 
       if (height == null) {
         return offscreen(columnWidth);


### PR DESCRIPTION
### Summary

#### What changed?

- Added a utility function to retrieve an item's height from the skeleton pin, using it instead of the measurement cache when applicable.

#### Why?

- This change is necessary to render skeleton pins as part of Masonry's `items` rather than `_loadingStateItems`.
  - This should help with overall performance since we are now having the real pins just replace the skeleton pins where currently, we render either the skeleton pins or the real pins
  - This also [unlocks infinite scrolling](https://github.com/pinternal/pinboard/pull/105265#discussion_r1834686408)

#### Test Plan
- Tested https://github.com/pinternal/pinboard/pull/105265 with local Gestalt 

#### Note
- If this change is okay, will also apply the same changes to Masonry v2!

### Checklist

- [x] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
