### PR TITLE
Spinner: Remove Opacity Token

### DIFF
--- a/packages/gestalt/src/Spinner.css
+++ b/packages/gestalt/src/Spinner.css
@@ -20,5 +20,5 @@
 
 .delay {
   animation-delay: 0.3s;
-  opacity: var(--opacity-0);
+  opacity: 0;
 }


### PR DESCRIPTION
This is a hypothesis for Spinner not showing when a delay is added. 

It removes the opacity variable that is then used to animate when spinning. Sometimes this transition fails and the spinner doesn't appear.

A similar problem also happened here. So removing the usage of tokens because we didn't change anything otherwise:
https://github.com/pinterest/gestalt/pull/3213/files
