### PR TITLE
Revert "Masonry: Update fullWidthLayout to not floor column widths"

### DIFF
--- a/packages/gestalt/src/Masonry/fullWidthLayout.ts
+++ b/packages/gestalt/src/Masonry/fullWidthLayout.ts
@@ -45,7 +45,7 @@ const fullWidthLayout = <T>({
   // original implementation takes with CSS.
   const colguess = Math.floor(width / idealColumnWidth);
   const columnCount = Math.max(Math.floor((width - colguess * gutter) / idealColumnWidth), minCols);
-  const columnWidth = width / columnCount - gutter;
+  const columnWidth = Math.floor(width / columnCount) - gutter;
   const columnWidthAndGutter = columnWidth + gutter;
   const centerOffset = gutter / 2;
 

--- a/playwright/masonry/flexible-resize.spec.ts
+++ b/playwright/masonry/flexible-resize.spec.ts
@@ -76,7 +76,7 @@ test.describe('Masonry: flexible resize', () => {
     const itemRectsAfter = await Promise.all(
       gridItemsAfter.map((gridItemAfter) => gridItemAfter.boundingBox()),
     );
-    expect(Math.floor(itemRectsAfter[0]?.width)).toBe(273);
+    expect(itemRectsAfter[0]?.width).toBe(273);
     expect(itemRectsAfter[0]?.height).toBe(216);
 
     // Get new sizes of grid items.


### PR DESCRIPTION
Reverts pinterest/gestalt#3874

apparently having floating point column widths breaks pinboard 