### PR TITLE
Spinner: Opacity animation bug in Chrome

### DIFF
--- a/packages/gestalt/src/Spinner.css
+++ b/packages/gestalt/src/Spinner.css
@@ -21,5 +21,5 @@
 
 .delay {
   animation-delay: 0.3s;
-  opacity: 0;
+  opacity: var(--opacity-0);
 }

--- a/packages/gestalt/src/Spinner.css
+++ b/packages/gestalt/src/Spinner.css
@@ -12,11 +12,11 @@
 
 .icon {
   composes: block from "./Layout.css";
+  animation-composition: add;
   animation-duration: 1.2s;
   animation-iteration-count: infinite;
   animation-name: spin;
   animation-timing-function: linear;
-  animation-composition: add;
 }
 
 .delay {

--- a/packages/gestalt/src/Spinner.css
+++ b/packages/gestalt/src/Spinner.css
@@ -16,6 +16,7 @@
   animation-iteration-count: infinite;
   animation-name: spin;
   animation-timing-function: linear;
+  animation-composition: add;
 }
 
 .delay {


### PR DESCRIPTION
### Summary

Spinner with `delay=true` doesn't appear on the screen even after the delay has passed. This was because `opacity: 1` rule in the animation keyframes were not being applied correctly. Weirdly enough, it is applied only after mouse is moved, clicked, or inspected from DevTools. And it's only specific to Chrome, other browsers didn't have that bug.

The bug is fixed by "forcing" Chrome to apply the rules specified in animation keyframes. For that, `animation-composition: add` or `animation-composition: accumulate` rule needs to be added.
Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/animation-composition

Even when the default value is explicity set (`animation-composition: replace`), the bug remains. That could mean there is a rendering bug in Chrome with this rule and `opacity` and `tranform` rules.

The bug only appears when `opacity` and `tranform` rules are used together inside animation keyframes. I have tried different property combinations (backgroun, color, etc), but the bug didn't appear for those cases.

Initially reported here: https://pinterest.slack.com/archives/C13KLG5P0/p1727995902306289


### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
