### PR TITLE
Checkbox: VR adjustments

### DIFF
--- a/packages/gestalt/src/Checkbox/VRInternalCheckbox.tsx
+++ b/packages/gestalt/src/Checkbox/VRInternalCheckbox.tsx
@@ -209,7 +209,7 @@ const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
           type="checkbox"
         />
       </div>
-      {Boolean(image) && <Box paddingX={1}>{image}</Box>}
+      {Boolean(image) && <div className={classnames(styles.labelWrapper)}>{image}</div>}
       {label && (
         <Box
           //  marginTop: '-1px'/'2px' is needed to  visually align the label text & radiobutton input
@@ -227,7 +227,7 @@ const InternalCheckboxWithForwardRef = forwardRef<HTMLInputElement, Props>(funct
             </Label>
           </div>
 
-          <div className={classnames(styles.labelWrapper, {})}>
+          <div className={classnames(styles.labelWrapper)}>
             {helperText ? (
               <FormHelperText
                 disabled={disabled}


### PR DESCRIPTION
Checkbox: VR adjustments


## Why

Adding one side padding rather than paddingX, so it doesn't add spacing on the edge of the label