### PR TITLE
BannerCallout: Remove Children.only logic prone to break if message is undefined in runtime

### DIFF
--- a/packages/gestalt/src/BannerCallout.tsx
+++ b/packages/gestalt/src/BannerCallout.tsx
@@ -1,4 +1,4 @@
-import { Children, ComponentProps, ReactElement } from 'react';
+import { ComponentProps, ReactElement } from 'react';
 import classnames from 'classnames';
 import styles from './BannerCallout.css';
 import VRBannerCallout from './BannerCallout/VRBannerCallout';

--- a/packages/gestalt/src/BannerCallout.tsx
+++ b/packages/gestalt/src/BannerCallout.tsx
@@ -287,11 +287,7 @@ export default function BannerCallout({
               {typeof message === 'string' && (
                 <Text align={responsiveMinWidth === 'xs' ? 'center' : undefined}>{message}</Text>
               )}
-              {typeof message !== 'string' &&
-              // @ts-expect-error - TS2339
-              Children.only<ReactElement>(message).type.displayName === 'Text'
-                ? message
-                : null}
+              {message && typeof message !== 'string' && message}
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
BannerCallout: Remove Children.only logic prone to break if message is undefined in runtime


BEFORE
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/42190516-fd66-49cd-8559-5f407dc68dff)


AFTER
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/8790822d-44ea-4b74-9114-1428dd8c4dcc)
