### PR TITLE
DateRange: Remove overflow prop and apply border radius with css instead (web)

### DIFF
--- a/packages/gestalt-datepicker/src/DateRange.css
+++ b/packages/gestalt-datepicker/src/DateRange.css
@@ -14,6 +14,11 @@ html[dir="rtl"] .borderRight {
   position: relative;
 }
 
+.dateFieldSection:first-child {
+  border-top-left-radius: var(--rounding-400);
+  border-top-right-radius: var(--rounding-400);
+}
+
 .dateFieldSectionActive {
   background-color: var(--color-gray-roboflow-100);
 }

--- a/packages/gestalt-datepicker/src/DateRange.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.tsx
@@ -238,14 +238,7 @@ function DateRange({
   });
 
   return (
-    <Box
-      borderStyle="shadow"
-      color="default"
-      display="inlineBlock"
-      minHeight={425}
-      overflow="hidden"
-      rounding={4}
-    >
+    <Box borderStyle="shadow" color="default" display="inlineBlock" minHeight={425} rounding={4}>
       <Flex>
         {radioGroup &&
         // @ts-expect-error - TS2339


### PR DESCRIPTION
### Summary

#### What changed?

Remove overflow prop and apply border radius with css instead, this will fix a visual bug on pinboard when the component is wrapped in a Popover.

#### Why?

The prop `overflow=hidden` is causing a small gap at the bottom of the component when wrapped inside a Popover.

![Screenshot 2024-12-10 at 1 37 22 p m](https://github.com/user-attachments/assets/3434fcbe-c074-45fb-8874-b99cfbf92fa1)

### Links

- [ABC-3889](https://jira.pinadmin.com/browse/ABC-3889)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
