### PR TITLE
SideNavigation: patch for accessibility aria-selected bug

### DIFF
--- a/docs/pages/web/iconbuttonlink.tsx
+++ b/docs/pages/web/iconbuttonlink.tsx
@@ -49,7 +49,7 @@ export default function DocsPage({ generatedDocGen }: DocType) {
 
       <AccessibilitySection name={generatedDocGen?.displayName}>
         <MainSection.Subsection
-          description={`IconButtonLink has an "active" state that visually identifies it. To set them to "active" set 'active="page"' (page redirect) or 'active="section"'. Use routing hooks from React.Router or other frameworks to identify the current route. For example, if the current pathname matches the IconButtonLink href, set IconButtonLink to "page". Use the example below as a reference.`}
+          description={`IconButtonLink has an "active" state that visually identifies it. To set them to "active" set 'active="page"' (page redirect). Use routing hooks from React.Router or other frameworks to identify the current route. For example, if the current pathname matches the IconButtonLink href, set IconButtonLink to "page". Use the example below as a reference.`}
           title="Active state"
         >
           <MainSection.Card sandpackExample={<SandpackExample code={active} name="Active" />} />

--- a/packages/gestalt/src/IconButtonLink.tsx
+++ b/packages/gestalt/src/IconButtonLink.tsx
@@ -16,9 +16,9 @@ type Props = {
    */
   accessibilityLabel: string;
   /**
-   * When set to 'page' or 'section', it displays the item in "active" state. See the [active state](https://gestalt.pinterest.systems/web/iconbuttonlink#Active-state) guidelines to learn more.
+   * When set to 'page', it displays the item in "active" state. See the [active state](https://gestalt.pinterest.systems/web/iconbuttonlink#Active-state) guidelines to learn more.
    */
-  active?: 'page' | 'section';
+  active?: 'page';
   /**
    * Primary colors to apply to the IconButtonLink background.
    */

--- a/packages/gestalt/src/Link/InternalLink.tsx
+++ b/packages/gestalt/src/Link/InternalLink.tsx
@@ -250,7 +250,6 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
           : undefined
       }
       aria-label={accessibilityLabel}
-      aria-selected={accessibilityCurrent && accessibilityCurrent === 'section' ? true : undefined}
       className={isSearchGuide ? searchGuideClassNames : className}
       data-test-id={dataTestId}
       href={disabled ? undefined : href}
@@ -302,7 +301,6 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
         ...(target === 'blank' ? ['noopener', 'noreferrer'] : []),
         ...(rel === 'nofollow' ? ['nofollow'] : []),
       ].join(' ')}
-      role={accessibilityCurrent && accessibilityCurrent === 'section' ? 'tab' : undefined}
       tabIndex={disabled ? undefined : tabIndex}
       {...(tapStyle === 'compress' && compressStyle && !disabled ? { style: compressStyle } : {})}
       target={target ? `_${target}` : undefined}


### PR DESCRIPTION
### Breaking change

Remove prop active=section from all IconButtonLink.

### Changes

Some of our link components tried to implement aria-selected and role=tab. This is actually an incorrect implementation. Links cannot have aria-selected and role=tab. For example, more info https://www.stefanjudis.com/blog/aria-selected-and-when-to-use-it

This issue was raising some accessibility bugs requesting a parent with role=tablist but it was not possible to fix.

This PR removes internal usage of aria-selected and role=tab in links. It doesn't fix APIs completely but it allows unsilencing integration tests. 

The links are announced as links but they are not presented as tabs. It's an improvement that it requires changes Out of Scope for this PR which aimee d to fix the bug.

Errors are gone:
![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/9896e743-4dd2-453e-9793-5d40901b256e)
