### PR TITLE
DatePicker: upgraded package to latest 7.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/eslint": "^8.56.10",
     "@types/jscodeshift": "^0.11.11",
     "@types/react": "^18.1.0",
-    "@types/react-datepicker": "^6.2.0",
     "@types/react-dom": "^18.1.0",
     "@types/react-test-renderer": "^18.3.0",
     "@types/ua-parser-js": "^0.7.39",

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -20,7 +20,7 @@
     "@mui/material": "^5.12.0",
     "@mui/x-date-pickers": "^6.18.2",
     "classnames": "^2.2.6",
-    "react-datepicker": "6.9.0"
+    "react-datepicker": "7.5.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-datepicker/src/DatePicker.css
+++ b/packages/gestalt-datepicker/src/DatePicker.css
@@ -25,6 +25,7 @@
   font-weight: var(--font-weight-datepicker-heading);
   line-height: var(--font-lineheight-datepicker-heading);
   margin-bottom: var(--space-400);
+  margin-top: var(--space-0);
   text-decoration: var(--font-textdecoration-datepicker-heading);
 }
 

--- a/packages/gestalt-datepicker/src/DatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker.tsx
@@ -61,7 +61,7 @@ export type Props = {
    */
   label?: string;
   /**
-   * DatePicker accepts imported locales from the open source date utility library date-fns. See the [locales example](https://gestalt.pinterest.systems/web/datepicker#localeData) to learn more.
+   * DatePicker accepts imported locales from the open source date utility library date-fns. See the [locales example](https://gestalt.pinterest.systems/web/datepicker#localeData) to learn more. Type is Locale from 'date-fns/locale'.
    */
   localeData?: Locale;
   /**

--- a/packages/gestalt-datepicker/src/DatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker.tsx
@@ -85,7 +85,10 @@ export type Props = {
   /**
    * Callback triggered when the user selects a date.
    */
-  onChange: (arg1: { event: React.ChangeEvent<HTMLInputElement>; value: Date | null }) => void;
+  onChange: (arg1: {
+    event: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement> | undefined;
+    value: Date | null;
+  }) => void;
   /**
    * Placeholder text shown if the user has not yet input a value. The default placeholder value shows the date format for each locale, e.g. MM/DD/YYYY.
    */

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import {ComponentProps,  forwardRef, ReactElement, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import { limitShift, shift } from '@floating-ui/react';
 import {
@@ -74,7 +74,7 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
     // in the month and we need to keep the popover pointed at the input correctly
     const [, setMonth] = useState<number | null | undefined>();
     const [format, setFormat] = useState<string | undefined>();
-    const [updatedLocale, setUpdatedLocale] = useState<string | null | undefined>();
+    const [updatedLocale, setUpdatedLocale] = useState<ComponentProps<typeof ReactDatePicker>['locale']>();
     const [initRangeHighlight, setInitRangeHighlight] = useState<Date | null | undefined>();
 
     useEffect(() => {

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
@@ -73,7 +73,7 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
     // We keep month in state to trigger a re-render when month changes since height will vary by where days fall
     // in the month and we need to keep the popover pointed at the input correctly
     const [, setMonth] = useState<number | null | undefined>();
-    const [format, setFormat] = useState<string | null | undefined>();
+    const [format, setFormat] = useState<string | undefined>();
     const [updatedLocale, setUpdatedLocale] = useState<string | null | undefined>();
     const [initRangeHighlight, setInitRangeHighlight] = useState<Date | null | undefined>();
 
@@ -113,7 +113,6 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
             </Box>
           </Label>
         )}
-        {/* @ts-expect-error - TS2769 - No overload matches this call. | TS2786 - 'ReactDatePicker' cannot be used as a JSX component. */}
         <ReactDatePicker
           calendarClassName={
             inline ? styles['react-datepicker-inline'] : styles['react-datepicker']
@@ -148,12 +147,20 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
           nextMonthButtonLabel={
             <Icon accessibilityLabel={nextMonth} color="default" icon="arrow-forward" size={16} />
           }
-          onChange={(value: Date, event: React.ChangeEvent<HTMLInputElement>) => {
+          onChange={(
+            value: Date | null,
+            event:
+              | React.MouseEvent<HTMLElement, MouseEvent>
+              | React.KeyboardEvent<HTMLElement>
+              | undefined,
+          ) => {
             if (controlledValue === undefined) setUncontrolledValue(value);
-            onChange({ event, value });
-            if (event.type === 'click') {
-              nextRef?.current?.focus();
-              onSelect?.();
+            if (event !== undefined) {
+              onChange({ event, value });
+              if (event.type === 'click') {
+                nextRef?.current?.focus();
+                onSelect?.();
+              }
             }
           }}
           onKeyDown={(event) => {

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
@@ -1,4 +1,12 @@
-import {ComponentProps,  forwardRef, ReactElement, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import {
+  ComponentProps,
+  forwardRef,
+  ReactElement,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import { limitShift, shift } from '@floating-ui/react';
 import {
@@ -14,7 +22,7 @@ import { Props } from '../DatePicker';
 import styles from '../DatePicker.css';
 
 type InternalProps = Props & {
-  inline?: boolean;
+  inline?: ComponentProps<typeof ReactDatePicker>['inline'];
   inputOnly?: boolean;
   onFocus?: () => void;
   onSelect?: () => void;
@@ -74,7 +82,8 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
     // in the month and we need to keep the popover pointed at the input correctly
     const [, setMonth] = useState<number | null | undefined>();
     const [format, setFormat] = useState<string | undefined>();
-    const [updatedLocale, setUpdatedLocale] = useState<ComponentProps<typeof ReactDatePicker>['locale']>();
+    const [updatedLocale, setUpdatedLocale] =
+      useState<ComponentProps<typeof ReactDatePicker>['locale']>();
     const [initRangeHighlight, setInitRangeHighlight] = useState<Date | null | undefined>();
 
     useEffect(() => {

--- a/packages/gestalt-datepicker/src/DateRange/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DateRange/InternalDatePicker.tsx
@@ -1,4 +1,12 @@
-import { forwardRef, ReactElement, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import {
+  ComponentProps,
+  forwardRef,
+  ReactElement,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import ReactDatePicker, { registerLocale } from 'react-datepicker';
 import { Icon, useDeviceType } from 'gestalt';
 import { Props } from '../DatePicker';
@@ -41,7 +49,9 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, ModifiedPr
     // in the month and we need to keep the popover pointed at the input correctly
     const [, setMonth] = useState<number | null | undefined>();
     const [format, setFormat] = useState<string | string[] | undefined>();
-    const [updatedLocale, setUpdatedLocale] = useState<string | null | undefined>();
+    const [updatedLocale, setUpdatedLocale] = useState<
+      ComponentProps<typeof ReactDatePicker>['locale'] | undefined
+    >();
 
     useEffect(() => {
       if (localeData && localeData.code) {

--- a/packages/gestalt-datepicker/src/DateRange/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DateRange/InternalDatePicker.tsx
@@ -40,7 +40,7 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, ModifiedPr
     // We keep month in state to trigger a re-render when month changes since height will vary by where days fall
     // in the month and we need to keep the popover pointed at the input correctly
     const [, setMonth] = useState<number | null | undefined>();
-    const [format, setFormat] = useState<string | null | undefined>();
+    const [format, setFormat] = useState<string | string[] | undefined>();
     const [updatedLocale, setUpdatedLocale] = useState<string | null | undefined>();
 
     useEffect(() => {
@@ -96,7 +96,6 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, ModifiedPr
     return (
       <div className="_gestalt">
         <div className={isMobile ? undefined : '_gestalt_daterange'}>
-          {/* @ts-expect-error - TS2769 - No overload matches this call. | TS2786 - 'ReactDatePicker' cannot be used as a JSX component. */}
           <ReactDatePicker
             ref={(refElement) => {
               if (!innerInputRef || !refElement) {

--- a/packages/gestalt-datepicker/src/__snapshots__/DatePicker.jsdom.test.tsx.snap
+++ b/packages/gestalt-datepicker/src/__snapshots__/DatePicker.jsdom.test.tsx.snap
@@ -238,11 +238,11 @@ exports[`DatePicker Mobile Datepicker renders 1`] = `
                           <div
                             class="react-datepicker__header "
                           >
-                            <div
+                            <h2
                               class="react-datepicker__current-month"
                             >
                               December 2018
-                            </div>
+                            </h2>
                             <div
                               class="react-datepicker__header__dropdown react-datepicker__header__dropdown--select"
                             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,19 +2916,26 @@
     "@floating-ui/core" "^1.4.2"
     "@floating-ui/utils" "^0.1.3"
 
-"@floating-ui/react-dom@^2.0.0", "@floating-ui/react-dom@^2.0.8":
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.9.tgz#264ba8b061000baa132b5910f0427a6acf7ad7ce"
-  integrity sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==
-  dependencies:
-    "@floating-ui/dom" "^1.0.0"
-
 "@floating-ui/react-dom@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.2.tgz#fab244d64db08e6bed7be4b5fcce65315ef44d20"
   integrity sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==
   dependencies:
     "@floating-ui/dom" "^1.5.1"
+
+"@floating-ui/react-dom@^2.0.8":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.9.tgz#264ba8b061000baa132b5910f0427a6acf7ad7ce"
+  integrity sha512-q0umO0+LQK4+p6aGyvzASqKbKOJcAHJ7ycE9CuUvfx3s9zTHWmGJTPOIlM/hmSBfUfg/XfY5YhLBLR/LHwShQQ==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
+"@floating-ui/react-dom@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.2.tgz#a1349bbf6a0e5cb5ded55d023766f20a4d439a31"
+  integrity sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
 
 "@floating-ui/react@^0.25.4":
   version "0.25.4"
@@ -2939,13 +2946,13 @@
     "@floating-ui/utils" "^0.1.1"
     tabbable "^6.0.1"
 
-"@floating-ui/react@^0.26.2":
-  version "0.26.13"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.13.tgz#81dc03b08ec8db40c48bf2e1f2a2e1a5e9a1997a"
-  integrity sha512-kBa9wntpugzrZ8t/4yWelvSmEKZdeTXTJzrxqyrLmcU/n1SM4nvse8yQh2e1b37rJGvtu0EplV9+IkBrCJ1vkw==
+"@floating-ui/react@^0.26.23":
+  version "0.26.28"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.26.28.tgz#93f44ebaeb02409312e9df9507e83aab4a8c0dc7"
+  integrity sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==
   dependencies:
-    "@floating-ui/react-dom" "^2.0.0"
-    "@floating-ui/utils" "^0.2.0"
+    "@floating-ui/react-dom" "^2.1.2"
+    "@floating-ui/utils" "^0.2.8"
     tabbable "^6.0.0"
 
 "@floating-ui/utils@^0.1.1", "@floating-ui/utils@^0.1.3":
@@ -2957,6 +2964,11 @@
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
   integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
+
+"@floating-ui/utils@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.8.tgz#21a907684723bbbaa5f0974cf7730bd797eb8e62"
+  integrity sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==
 
 "@humanwhocodes/config-array@^0.10.4":
   version "0.10.4"
@@ -5657,15 +5669,6 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-datepicker@^6.2.0":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@types/react-datepicker/-/react-datepicker-6.2.0.tgz#1c93c10d12d1d683eacf46a82e35b953cd0da117"
-  integrity sha512-+JtO4Fm97WLkJTH8j8/v3Ldh7JCNRwjMYjRaKh4KHH0M3jJoXtwiD3JBCsdlg3tsFIw9eQSqyAPeVDN2H2oM9Q==
-  dependencies:
-    "@floating-ui/react" "^0.26.2"
-    "@types/react" "*"
-    date-fns "^3.3.1"
-
 "@types/react-dom@^18.0.0":
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
@@ -7640,7 +7643,7 @@ clsx@^1.2.1:
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
-clsx@^2.0.0, clsx@^2.1.0:
+clsx@^2.0.0, clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -8432,7 +8435,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^3.3.1, date-fns@^3.6.0:
+date-fns@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
   integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
@@ -17325,16 +17328,15 @@ react-cookie@^4.1.1:
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
 
-react-datepicker@6.9.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-6.9.0.tgz#0ad234dad81d567ae64cad79697bbad69c95490b"
-  integrity sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==
+react-datepicker@7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-7.5.0.tgz#e7b1014a6dbd3b314839a5c57a6dacfbb16074e4"
+  integrity sha512-6MzeamV8cWSOcduwePHfGqY40acuGlS1cG//ePHT6bVbLxWyqngaStenfH03n1wbzOibFggF66kWaBTb1SbTtQ==
   dependencies:
-    "@floating-ui/react" "^0.26.2"
-    clsx "^2.1.0"
-    date-fns "^3.3.1"
-    prop-types "^15.7.2"
-    react-onclickoutside "^6.13.0"
+    "@floating-ui/react" "^0.26.23"
+    clsx "^2.1.1"
+    date-fns "^3.6.0"
+    prop-types "^15.8.1"
 
 react-devtools-inline@4.4.0:
   version "4.4.0"
@@ -17414,11 +17416,6 @@ react-live@^3.0.0:
     prism-react-renderer "^1.3.1"
     sucrase "^3.21.0"
     use-editable "^2.3.3"
-
-react-onclickoutside@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz#e165ea4e5157f3da94f4376a3ab3e22a565f4ffc"
-  integrity sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==
 
 react-resize-detector@^8.0.4:
   version "8.1.0"


### PR DESCRIPTION
https://github.com/Hacker0x01/react-datepicker/releases

Side benefit: Remove usages of react-onclickoutside to support React 19 by @hamidrezahanafi in https://github.com/Hacker0x01/react-datepicker/pull/4979

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/7ff9067f-f778-494a-8523-8e06f557886d)
