### PR TITLE
AvatarGroup: fix VR default size bug

### DIFF
--- a/packages/gestalt/src/AvatarGroup.tsx
+++ b/packages/gestalt/src/AvatarGroup.tsx
@@ -103,7 +103,7 @@ const AvatarGroupWithForwardRef = forwardRef<UnionRefs, Props>(function AvatarGr
     href,
     onClick,
     role,
-    size = isInVRExperiment ? 'md' : 'fit',
+    size = 'fit',
   } = props;
 
   const isDisplayOnly = !role;


### PR DESCRIPTION
AvatarGroup: fix VR default size bug

This change was causing 
![image](https://github.com/user-attachments/assets/ca31e921-6ca0-40c0-b40d-1268fe52aef0)