### PR TITLE
DateRange: fix date input border radius when radio group is present (web)

### DIFF
--- a/packages/gestalt-datepicker/src/DateRange.css
+++ b/packages/gestalt-datepicker/src/DateRange.css
@@ -15,8 +15,11 @@ html[dir="rtl"] .borderRight {
 }
 
 .dateFieldSection:first-child {
-  border-top-left-radius: var(--rounding-400);
   border-top-right-radius: var(--rounding-400);
+}
+
+.dateFieldSectionTopLeftBorder:first-child {
+  border-top-left-radius: var(--rounding-400);
 }
 
 .dateFieldSectionActive {

--- a/packages/gestalt-datepicker/src/DateRange.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.tsx
@@ -271,6 +271,7 @@ function DateRange({
                     key={key}
                     className={classnames(borderStyles.dateFieldSection, {
                       [borderStyles.dateFieldSectionActive]: shouldHighlight,
+                      [borderStyles.dateFieldSectionTopLeftBorder]: !radioGroup,
                     })}
                   >
                     <div


### PR DESCRIPTION
### Summary

#### What changed?

Fix small visual bug in DateRange component, the top left border radius is only applied if there is no radio group.

#### Why?

Previously, the border was applied even if the radio group was present, making the DateRange to look weird.

### Links

- [Jira](https://jira.pinadmin.com/browse/RI-2835)

### Screenshots
| Before | After |
|--------|------|
| <img width="342" alt="Screenshot 2025-01-20 at 12 21 45 p m" src="https://github.com/user-attachments/assets/7d32f0fc-a1cb-46b8-af42-00030fd0c1ae" /> | <img width="351" alt="Screenshot 2025-01-20 at 12 21 53 p m" src="https://github.com/user-attachments/assets/83daa3d7-83ef-4061-a579-070034206f73" /> |


### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
