### PR TITLE
DateRange: fix date selection bug when you disable secondary range

### DIFF
--- a/packages/gestalt-datepicker/src/DateRange.tsx
+++ b/packages/gestalt-datepicker/src/DateRange.tsx
@@ -206,6 +206,12 @@ function DateRange({
     if (dateRangeHandlers?.onRender) dateRangeHandlers?.onRender();
   }, [dateRangeHandlers]);
 
+  useEffect(() => {
+    if (secondaryDateValue === undefined) {
+      setSelectedRange(DateRangeType.Primary);
+    }
+  }, [secondaryDateValue]);
+
   if (!dateValue.startDate && dateValue.endDate) {
     onDateChange({ value: null }, { value: null });
   }
@@ -265,6 +271,7 @@ function DateRange({
                 const { startDate, endDate } = dateValues;
                 const isInputSelected = selectedRange === key;
                 const shouldHighlight = secondaryDateValue && isInputSelected;
+                const multipleRanges = dateInputs.length > 1;
 
                 return (
                   <div
@@ -278,7 +285,7 @@ function DateRange({
                         [borderStyles.dateFieldSectionLeftBorder]: shouldHighlight,
                       })}
                     />
-                    <TapArea disabled={false} onTap={() => setSelectedRange(key)}>
+                    <TapArea disabled={!multipleRanges} onTap={() => setSelectedRange(key)}>
                       <Flex gap={3}>
                         <Box width={isMobile ? MOBILE_DATEFIELD_WIDTH : DATEFIELD_WIDTH}>
                           <InternalDateField


### PR DESCRIPTION
### Summary

#### What changed?

Automatically select primary range if the secondaryDateValues goes undefined.

#### Why?

If you disable or make secondaryDateValues undefined, the DateRange will not let you select new dates since the secondary range is still selected inside the component.

### Links

- [Jira](https://jira.pinadmin.com/browse/RI-2836)

### Screenshots
| Before | After |
|--------|------|
| <video src=https://github.com/user-attachments/assets/814ed538-b1f1-4489-b3dc-6342b3e57908> | <video src=https://github.com/user-attachments/assets/e3b5d8ac-709a-4138-b0e3-5ac17beca588> |





### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
