### PR TITLE
Internal: Change React 19 Build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   presets: [
     ['@babel/preset-env', { modules: process.env.NODE_ENV === 'production' ? false : 'auto' }],
-    ['@babel/react', { 'runtime': 'automatic' }],
+    ['@babel/preset-react', { 'runtime': 'automatic' }],
     '@babel/preset-typescript',
   ],
   plugins: [

--- a/packages/gestalt-charts/package.json
+++ b/packages/gestalt-charts/package.json
@@ -17,8 +17,8 @@
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/packages/gestalt-charts/rollup.config.js
+++ b/packages/gestalt-charts/rollup.config.js
@@ -33,7 +33,7 @@ const rollupConfig = {
       sourcemap: true,
     },
   ],
-  external: ['react', 'classnames/bind', 'classnames', 'react-dom', 'recharts', 'gestalt'],
+  external: ['react', 'react/jsx-runtime', 'react-dom/client', 'classnames/bind', 'classnames', 'react-dom', 'recharts', 'gestalt'],
   acornInjectPlugins,
   plugins: plugins('gestalt-charts'),
 };

--- a/packages/gestalt-charts/rollup.config.js
+++ b/packages/gestalt-charts/rollup.config.js
@@ -33,7 +33,16 @@ const rollupConfig = {
       sourcemap: true,
     },
   ],
-  external: ['react', 'react/jsx-runtime', 'react-dom/client', 'classnames/bind', 'classnames', 'react-dom', 'recharts', 'gestalt'],
+  external: [
+    'react',
+    'react/jsx-runtime',
+    'react-dom/client',
+    'classnames/bind',
+    'classnames',
+    'react-dom',
+    'recharts',
+    'gestalt',
+  ],
   acornInjectPlugins,
   plugins: plugins('gestalt-charts'),
 };

--- a/packages/gestalt-core/build.js
+++ b/packages/gestalt-core/build.js
@@ -160,7 +160,11 @@ export const plugins = (name) => [
     babelrc: false,
     exclude: 'node_modules/**',
     rootMode: 'upward',
-    presets: [['@babel/preset-env', { targets: { node: true } }], '@babel/preset-typescript'],
+    presets: [
+      ['@babel/preset-env', { targets: { node: true } }],
+      '@babel/preset-typescript',
+      '@babel/preset-react',
+    ],
     shouldPrintComment: (comment) => /[#@]__PURE__/.exec(comment),
   }),
   commonjs(),

--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -24,8 +24,8 @@
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",

--- a/packages/gestalt-datepicker/rollup.config.js
+++ b/packages/gestalt-datepicker/rollup.config.js
@@ -33,7 +33,7 @@ const rollupConfig = {
       sourcemap: true,
     },
   ],
-  external: ['react', 'classnames/bind', 'classnames', 'react-dom', 'react-datepicker', 'gestalt'],
+  external: ['react', 'react', 'react/jsx-runtime', 'react-dom/client', 'classnames/bind', 'classnames', 'react-dom', 'react-datepicker', 'gestalt'],
   acornInjectPlugins,
   plugins: plugins('gestalt-datepicker'),
 };

--- a/packages/gestalt-datepicker/rollup.config.js
+++ b/packages/gestalt-datepicker/rollup.config.js
@@ -33,7 +33,17 @@ const rollupConfig = {
       sourcemap: true,
     },
   ],
-  external: ['react', 'react', 'react/jsx-runtime', 'react-dom/client', 'classnames/bind', 'classnames', 'react-dom', 'react-datepicker', 'gestalt'],
+  external: [
+    'react',
+    'react',
+    'react/jsx-runtime',
+    'react-dom/client',
+    'classnames/bind',
+    'classnames',
+    'react-dom',
+    'react-datepicker',
+    'gestalt',
+  ],
   acornInjectPlugins,
   plugins: plugins('gestalt-datepicker'),
 };

--- a/packages/gestalt/rollup.config.js
+++ b/packages/gestalt/rollup.config.js
@@ -31,7 +31,14 @@ const rollupConfig = {
       sourcemap: true,
     },
   ],
-  external: ['react', 'classnames/bind', 'classnames', 'react-dom'],
+  external: [
+    'react',
+    'classnames/bind',
+    'classnames',
+    'react-dom',
+    'react/jsx-runtime',
+    'react-dom/client',
+  ],
   acornInjectPlugins,
   plugins: plugins('gestalt'),
 };


### PR DESCRIPTION
# Pull Request Instructions

This imports the JSX runtime from the react library instead of compiling it inline as part of the CJS.

<img width="1673" alt="image" src="https://github.com/user-attachments/assets/d74dbb20-5ff1-4eb6-b8fa-3adeb52aca85" />

When upgrading to React 19, this variation among the JSX runtime causes incompatible build outputs between both. Until we start using React 19 features, this should keep the library working for both

### Summary

#### What changed?

Added `react/jsx-runtime` and `react-dom/client` as external dependencies. See [SO](https://stackoverflow.com/questions/76135802/how-do-i-make-my-react-package-use-an-external-jsx-runtime) question


Also, changing `@babel/react` to `@babel/preset-react` (which seemed to be the correct package name).

At a high level, what changes does this PR introduce?
