### PR TITLE
Masonry: Experimental breakpoints for gridSize

### DIFF
--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -910,9 +910,8 @@ describe('responsive module layout test cases', () => {
             ? {
                 sm: 2,
                 md: 3,
-                lg: 5,
                 _lg1: 5,
-                _lg2: 6,
+                lg: 6,
                 xl: 9,
               }
             : 1,

--- a/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.test.ts
@@ -911,15 +911,32 @@ describe('responsive module layout test cases', () => {
                 sm: 2,
                 md: 3,
                 lg: 5,
+                _lg1: 5,
+                _lg2: 6,
                 xl: 9,
               }
             : 1,
       });
 
+    const getExpectedColumnSpan = (columnCount: number): number => {
+      if (columnCount <= 2) {
+        return 2;
+      }
+      if (columnCount <= 4) {
+        return 3;
+      }
+      if (columnCount <= 6) {
+        return 5;
+      }
+      if (columnCount <= 8) {
+        return 6;
+      }
+      return 9;
+    };
+
     const breakpoints = [2, 3, 4, 5, 6, 7, 8, 9, 10].map((columnCount) => ({
       columnCount,
-      // eslint-disable-next-line no-nested-ternary
-      expectedColumnSpan: columnCount < 3 ? 2 : columnCount < 5 ? 3 : columnCount < 9 ? 5 : 9,
+      expectedColumnSpan: getExpectedColumnSpan(columnCount),
     }));
 
     breakpoints.forEach(({ columnCount, expectedColumnSpan }) => {

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -8,7 +8,7 @@ import { GetGraphPositionsReturn, NodeData, Position } from './types';
 // This may need to be tweaked to balance the tradeoff of delayed rendering vs having enough possible layouts
 export const MULTI_COL_ITEMS_MEASURE_BATCH_SIZE = 5;
 
-type GridSizeConfig = { 'sm': number, 'md': number, '_lg1'?: number, 'lg': number, 'xl': number }
+type GridSizeConfig = { 'sm': number; 'md': number; '_lg1'?: number; 'lg': number; 'xl': number };
 type GridSize = keyof GridSizeConfig;
 
 export type ColumnSpanConfig = number | GridSizeConfig;

--- a/packages/gestalt/src/Masonry/multiColumnLayout.ts
+++ b/packages/gestalt/src/Masonry/multiColumnLayout.ts
@@ -8,16 +8,16 @@ import { GetGraphPositionsReturn, NodeData, Position } from './types';
 // This may need to be tweaked to balance the tradeoff of delayed rendering vs having enough possible layouts
 export const MULTI_COL_ITEMS_MEASURE_BATCH_SIZE = 5;
 
-type GridSize = 'sm' | 'md' | 'lg' | '_lg1' | '_lg2' | 'xl';
+type GridSizeConfig = { 'sm': number, 'md': number, '_lg1'?: number, 'lg': number, 'xl': number }
+type GridSize = keyof GridSizeConfig;
 
-export type ColumnSpanConfig = number | { [Size in GridSize]: number };
+export type ColumnSpanConfig = number | GridSizeConfig;
 
 // maps the number of columns to a grid breakpoint
 // sm: 2 columns
 // md: 3-4 columns
 // _lg1: 5-6 columns (Experimental)
-// _lg2: 7-8 columns (Experimental)
-// lg: 5-8 columns (To be removed in favor of experimental _lg1 and _lg2)
+// lg: 5-8 columns (To be removed in favor of experimental _lg1)
 // xl: 9+ columns
 export function columnCountToGridSize(columnCount: number): GridSize {
   if (columnCount <= 2) {
@@ -30,7 +30,7 @@ export function columnCountToGridSize(columnCount: number): GridSize {
     return '_lg1';
   }
   if (columnCount <= 8) {
-    return '_lg2';
+    return 'lg';
   }
   return 'xl';
 }
@@ -48,7 +48,7 @@ function getColumnSpanFromGridSize(columnSpanConfig: ColumnSpanConfig, gridSize:
   if (typeof columnSpanConfig === 'number') {
     return columnSpanConfig;
   }
-  if (gridSize === '_lg1' || gridSize === '_lg2') {
+  if (gridSize === '_lg1') {
     return columnSpanConfig[gridSize] ?? columnSpanConfig.lg ?? 1;
   }
   return columnSpanConfig[gridSize] ?? 1;


### PR DESCRIPTION
## Summary

This PR adds on Masonry's multi-column module new experimental breakpoints for grid size. 

For original Masonry's responsive modules please refer to: https://github.com/pinterest/gestalt/pull/3636


### Current State 

Current grid size breakpoints: 
- sm: 2 columns
- md: 3-4 columns
- lg: 5-8 columns
- xl: 9+ columns

### Changes introduced

New experimental breakpoints: 
- sm: 2 columns
- md: 3-4 columns
- _lg1: 5-6 columns (New)
- lg: 5-8 columns (Existing)
- xl: 9+ columns

This change also adds logic for retro compatibility, to avoid breaking current configurations. 
In cases where `_lg1` is not configured, it would fallback to use existing `lg`

## Test plan

Unit test has been updated. 
Also tested locally: 

Using following configuration, verified multicolumn module size for different grid sizes: 

```
_getColumnSpanConfig = () => {
    return {
        sm: 1,
        md: 2, 
        _lg1: 3
        lg: 4,
        xl: 6,
    }
}
```

md size grid: 
![image](https://github.com/user-attachments/assets/8e84ab79-3aae-4458-8c0e-a3842aaa7477)

_lg1 size grid:
![image](https://github.com/user-attachments/assets/1bb185e6-eadc-4e41-ae38-98412df8848b)

lg size grid:
![image](https://github.com/user-attachments/assets/64810e43-b584-46a5-b5f9-e4ae961808d4)

xl size grid:
![image](https://github.com/user-attachments/assets/f0a22af5-8b7a-4984-948e-27f62f2e7b6a)

When `_lg1` is not defined, it falls back to `lg`: 
<img width="1584" alt="image" src="https://github.com/user-attachments/assets/96b785d3-0f40-4339-a7c9-66ecece63f43" />


