### PR TITLE
Internal: Fix key prop error on Flex Component for React 19

### DIFF
--- a/packages/gestalt/src/Flex.tsx
+++ b/packages/gestalt/src/Flex.tsx
@@ -172,9 +172,8 @@ const FlexWithForwardRef = forwardRef<HTMLDivElement, Props>(
           return wrapWithComponent({
             element: child,
             Component: FlexItem,
-            props: {
-              key: index,
-            },
+            props: {},
+            index,
           });
         }).filter(Boolean)
       : childrenProp;

--- a/packages/gestalt/src/utils/wrapWithComponent.tsx
+++ b/packages/gestalt/src/utils/wrapWithComponent.tsx
@@ -53,6 +53,8 @@ export default function wrapWithComponent<P>({
   return isElementOfType(element, Component) ? (
     element
   ) : (
-    <Component key={index} {...props}>{element}</Component>
+    <Component key={index} {...props}>
+      {element}
+    </Component>
   );
 }

--- a/packages/gestalt/src/utils/wrapWithComponent.tsx
+++ b/packages/gestalt/src/utils/wrapWithComponent.tsx
@@ -39,10 +39,12 @@ export default function wrapWithComponent<P>({
   element,
   Component,
   props,
+  index,
 }: {
   element: ReactNode | null | undefined;
   Component: ComponentType<P>;
   props: P;
+  index: number;
 }) {
   if (element === null || element === undefined) {
     return null;
@@ -51,6 +53,6 @@ export default function wrapWithComponent<P>({
   return isElementOfType(element, Component) ? (
     element
   ) : (
-    <Component {...props}>{element}</Component>
+    <Component key={index} {...props}>{element}</Component>
   );
 }


### PR DESCRIPTION
### Summary

Fix key prop error on Flex Component for React 19

#### What changed?

Separate key from props in `wrapWithComponent`
#### Why?

Fixing upgrade to React 19
### Links


### Checklist

- [x] Added unit tests
- [x] Added documentation + accessibility tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
