### PR TITLE
Masonry: Adding Window type to scroll container

### DIFF
--- a/docs/integration-test-helpers/masonry/MasonryContainer.tsx
+++ b/docs/integration-test-helpers/masonry/MasonryContainer.tsx
@@ -402,7 +402,6 @@ export default class MasonryContainer extends Component<Props<Record<any, any>>,
         }
       }
     } else {
-      // @ts-expect-error - TS2322 - Type '() => Window | undefined' is not assignable to type '() => HTMLElement'.
       dynamicGridProps.scrollContainer = typeof window === 'undefined' ? undefined : () => window;
     }
 

--- a/packages/gestalt/src/Masonry.tsx
+++ b/packages/gestalt/src/Masonry.tsx
@@ -95,7 +95,7 @@ type Props<T> = {
    *
    * This is required if the grid is expected to be scrollable.
    */
-  scrollContainer?: () => HTMLElement;
+  scrollContainer?: () => HTMLElement | Window;
   /**
    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.
    */

--- a/packages/gestalt/src/Masonry/ScrollContainer.ts
+++ b/packages/gestalt/src/Masonry/ScrollContainer.ts
@@ -17,17 +17,17 @@ import { Children, Component, ReactNode } from 'react';
 type Props = {
   children?: ReactNode;
   onScroll: (event: Event) => void;
-  scrollContainer: HTMLElement | null | undefined | (() => HTMLElement | null | undefined);
+  scrollContainer: HTMLElement | null | undefined | (() => HTMLElement | Window | null | undefined);
 };
 
 function getScrollContainer(
-  scrollContainer?: HTMLElement | (() => HTMLElement | null | undefined) | null,
+  scrollContainer?: HTMLElement | (() => HTMLElement | Window | null | undefined) | null,
 ) {
   return typeof scrollContainer === 'function' ? scrollContainer() : scrollContainer;
 }
 
 export default class ScrollContainer extends Component<Props> {
-  scrollContainer: HTMLElement | null | undefined;
+  scrollContainer: HTMLElement | Window | null | undefined;
 
   componentDidMount() {
     const scrollContainer = getScrollContainer(this.props.scrollContainer);
@@ -51,13 +51,13 @@ export default class ScrollContainer extends Component<Props> {
 
   // This is used in Masonry
   // eslint-disable-next-line react/no-unused-class-component-methods
-  getScrollContainerRef: () => HTMLElement | null | undefined = () => this.scrollContainer;
+  getScrollContainerRef: () => HTMLElement| Window | null | undefined = () => this.scrollContainer;
 
   handleScroll: (event: Event) => void = (event: Event) => {
     this.props.onScroll(event);
   };
 
-  updateScrollContainer(scrollContainer: HTMLElement) {
+  updateScrollContainer(scrollContainer: HTMLElement | Window) {
     if (this.scrollContainer) {
       // cleanup existing scroll container if it exists
       this.scrollContainer.removeEventListener('scroll', this.handleScroll);

--- a/packages/gestalt/src/Masonry/ScrollContainer.ts
+++ b/packages/gestalt/src/Masonry/ScrollContainer.ts
@@ -51,7 +51,7 @@ export default class ScrollContainer extends Component<Props> {
 
   // This is used in Masonry
   // eslint-disable-next-line react/no-unused-class-component-methods
-  getScrollContainerRef: () => HTMLElement| Window | null | undefined = () => this.scrollContainer;
+  getScrollContainerRef: () => HTMLElement | Window | null | undefined = () => this.scrollContainer;
 
   handleScroll: (event: Event) => void = (event: Event) => {
     this.props.onScroll(event);

--- a/packages/gestalt/src/Masonry/scrollUtils.ts
+++ b/packages/gestalt/src/Masonry/scrollUtils.ts
@@ -4,9 +4,8 @@
  * utils abstract away these differences.
  */
 
-export function getElementHeight(element: HTMLElement): number {
-  // @ts-expect-error - TS2367 - This condition will always return 'false' since the types 'HTMLElement' and 'Window & typeof globalThis' have no overlap. | TS2339 - Property 'innerHeight' does not exist on type 'never'.
-  return element === window ? window.innerHeight : element.clientHeight;
+export function getElementHeight(element: HTMLElement | Window): number {
+  return element instanceof Window ? window.innerHeight : element.clientHeight;
 }
 
 export function getWindowScrollPos(): number {
@@ -21,9 +20,8 @@ export function getWindowScrollPos(): number {
   return 0;
 }
 
-export function getRelativeScrollTop(element: HTMLElement): number {
-  // @ts-expect-error - TS2367 - This condition will always return 'false' since the types 'HTMLElement' and 'Window & typeof globalThis' have no overlap.
-  return element === window
+export function getRelativeScrollTop(element: HTMLElement | Window): number {
+  return element instanceof Window
     ? getWindowScrollPos()
     : element.scrollTop - element.getBoundingClientRect().top;
 }
@@ -35,7 +33,7 @@ export function getScrollHeight(element: HTMLElement): number {
     : element.scrollHeight;
 }
 
-export function getScrollPos(element: HTMLElement): number {
+export function getScrollPos(element: HTMLElement | Window): number {
   // @ts-expect-error - TS2367 - This condition will always return 'false' since the types 'HTMLElement' and 'Window & typeof globalThis' have no overlap.
   return element === window ? getWindowScrollPos() : element.scrollTop;
 }

--- a/packages/gestalt/src/MasonryV2.tsx
+++ b/packages/gestalt/src/MasonryV2.tsx
@@ -101,7 +101,7 @@ type Props<T> = {
    *
    * This is required if the grid is expected to be scrollable.
    */
-  scrollContainer?: () => HTMLElement;
+  scrollContainer?: () => HTMLElement | Window;
   /**
    * If `virtualize` is enabled, Masonry will only render items that fit in the viewport, plus some buffer. `virtualBoundsBottom` allows customization of the buffer size below the viewport, specified in pixels.
    */
@@ -234,7 +234,7 @@ function useScrollContainer({
   scrollContainer,
 }: {
   gridWrapper: HTMLElement | null | undefined;
-  scrollContainer: HTMLElement | null | undefined;
+  scrollContainer: HTMLElement | Window | null | undefined;
 }) {
   const containerHeight = useRef(0);
   const containerOffset = useRef(0);
@@ -324,7 +324,7 @@ function useFetchOnScroll({
       | undefined,
   ) => void;
   scrollTop: number;
-  scrollContainerElement: HTMLElement | null | undefined;
+  scrollContainerElement: HTMLElement | Window | null | undefined;
   width: number | null | undefined;
 }) {
   const isFetching = useRef<boolean>(false);
@@ -508,7 +508,7 @@ function useViewport({
 }: {
   containerHeight: number;
   containerOffset: number;
-  scrollContainer: HTMLElement | null | undefined;
+  scrollContainer: HTMLElement | Window | null | undefined;
   scrollTop: number;
   virtualBufferFactor: number;
   virtualBoundsTop: number | null | undefined;


### PR DESCRIPTION
## Summary

This PR adds `Window` type to Masonry's scroll container. This is already allowed, but we are explicitly adding it to avoid TS error suppressions

