### PR TITLE
Internal: Set up JSON for RTL icon list

### DIFF
--- a/docs/pages/foundations/international_design/rtl_guidelines/iconography.tsx
+++ b/docs/pages/foundations/international_design/rtl_guidelines/iconography.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import cx from 'classnames';
 import { Box, Flex, Heading, Icon, Image, Mask, Table, Text } from 'gestalt';
+import rtlIconListJson from 'gestalt-design-tokens/src/utils/rtlIconList.json';
 import { DOCS_COPY_MAX_WIDTH_PX } from '../../../../docs-components/consts';
 import MainSection from '../../../../docs-components/MainSection';
 import Markdown from '../../../../docs-components/Markdown';
@@ -9,32 +10,18 @@ import PageHeader from '../../../../docs-components/PageHeader';
 
 type IconName = React.ComponentProps<typeof Icon>['icon'];
 export default function FormsLayoutOverview() {
-  const RTLIcons: IconName[] = [
-    'arrow-back',
-    'arrow-forward',
-    'arrow-circle-back',
-    'arrow-circle-forward',
-    'arrow-start',
-    'arrow-end',
-    'arrow-left-curved',
-    'chevron-down-circle',
-    'chevron-left-circle',
-    'directional-arrow-left',
-    'directional-arrow-right',
-    'list-numbered',
-    'indent',
-    'outdent',
-    'move-pin',
-    'reorder-images',
-    'send',
-    'visit',
-  ];
+  const flipOnRtlIconNames = rtlIconListJson.flipOnRtlIconNames as ReadonlyArray<
+    IconName | undefined
+  >;
+  const swapOnRtlIconNames = rtlIconListJson.swapOnRtlIconNames as ReadonlyArray<
+    IconName | undefined
+  >;
+  const rtlIcons = [...flipOnRtlIconNames, ...swapOnRtlIconNames].sort();
 
   const generateIconRow = (iconName: IconName) => {
     if (!iconName) return null;
-    const swapIcons = ['list-numbered'];
 
-    const shouldSwapIcon = swapIcons.includes(iconName);
+    const shouldSwapIcon = swapOnRtlIconNames.includes(iconName);
 
     return (
       <Table.Row>
@@ -125,7 +112,7 @@ Back and forward buttons and arrows are mirrored:
                   ))}
                 </Table.Row>
               </Table.Header>
-              <Table.Body>{RTLIcons.map((iconName) => generateIconRow(iconName))}</Table.Body>
+              <Table.Body>{rtlIcons.map((iconName) => generateIconRow(iconName))}</Table.Body>
             </Table>
           </Box>
         </Box>

--- a/packages/gestalt-design-tokens/src/utils/rtlIconList.json
+++ b/packages/gestalt-design-tokens/src/utils/rtlIconList.json
@@ -1,0 +1,32 @@
+{
+  "flipOnRtlIconNames": [
+    "ads-overview",
+    "ads-stats",
+    "arrow-back",
+    "arrow-circle-forward",
+    "arrow-end",
+    "arrow-forward",
+    "arrow-start",
+    "arrow-up-right",
+    "chevron-left-circle",
+    "chevron-right-circle",
+    "compose",
+    "directional-arrow-left",
+    "directional-arrow-right",
+    "flip-vertical",
+    "hand-pointing",
+    "link",
+    "mute",
+    "redo",
+    "reorder-images",
+    "send",
+    "sound",
+    "speech-ellipsis",
+    "speech",
+    "switch-account",
+    "text-size",
+    "undo",
+    "visit"
+  ],
+  "swapOnRtlIconNames": ["list-numbered"]
+}

--- a/packages/gestalt/src/Icon/RTLIconList.tsx
+++ b/packages/gestalt/src/Icon/RTLIconList.tsx
@@ -1,38 +1,14 @@
+import rtlIconListJson from 'gestalt-design-tokens/src/utils/rtlIconList.json';
 import icons from '../icons/index';
 import compactIconsVR from '../icons-vr-theme/compact/index';
 
 type IconName = keyof typeof icons | keyof typeof compactIconsVR;
 
-const swapOnRtlIconNames: ReadonlyArray<IconName> = Object.freeze(['list-numbered']);
-
-const flipOnRtlIconNames: ReadonlyArray<IconName | undefined> = Object.freeze([
-  'ads-stats',
-  'ads-overview',
-  'arrow-back',
-  'arrow-circle-forward',
-  'arrow-end',
-  'arrow-forward',
-  'arrow-start',
-  'arrow-up-right',
-  'compose',
-  'chevron-left-circle',
-  'chevron-right-circle',
-  'directional-arrow-left',
-  'directional-arrow-right',
-  'flip-vertical',
-  'hand-pointing',
-  'link',
-  'mute',
-  'reorder-images',
-  'send',
-  'sound',
-  'speech',
-  'speech-ellipsis',
-  'switch-account',
-  'text-size',
-  'redo',
-  'undo',
-  'visit',
-]);
+const swapOnRtlIconNames = Object.freeze(rtlIconListJson.swapOnRtlIconNames) as ReadonlyArray<
+  IconName | undefined
+>;
+const flipOnRtlIconNames = Object.freeze(rtlIconListJson.flipOnRtlIconNames) as ReadonlyArray<
+  IconName | undefined
+>;
 
 export { flipOnRtlIconNames, swapOnRtlIconNames };


### PR DESCRIPTION
### Summary

- Move the list of icons to a JSON file, and import it into
  `RTLIconList.tsx`. Test manually via the docs site.
- Update `/foundations/international_design/rtl_guidelines/iconography`
  to use this same icon list.

#### Why?

We define a list of icons in `RTLIconList.tsx` that we automatically
flip for right-to-left content. This works for web, but we need to make
this list available for iOS and Android.

#### Screenshots

##### Before (Classic theme)
Screenshot from `/foundations/international_design/rtl_guidelines/iconography`:

![Original "Directional icons that need to be mirrored" section, Classic theme](https://github.com/user-attachments/assets/27f59c0f-c770-4191-915f-1f777291c562)

##### After (Classic theme)
![New "Directional icons" section with additional icons, Classic theme](https://github.com/user-attachments/assets/c1eeef25-8534-480a-87e6-9da81acce0a4)

##### After (VR theme)
![New "Directional icons" section with additional icons, VR theme](https://github.com/user-attachments/assets/59c1fa34-b032-4143-9d33-7bca7245ff3e)

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-8856)
- [Preview](https://deploy-preview-3983--gestalt.netlify.app/foundations/international_design/rtl_guidelines/iconography#Directional-icons)

### Checklist

- [x] Added unit tests → Used existing tests
- [x] Added documentation + accessibility tests → Used existing tests
- [x] Verified accessibility: keyboard & screen reader interaction
- [x] Checked dark mode, responsiveness, and right-to-left support
- [x] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
