### PR TITLE
DatePicker: add private prop _overrideRangeDateFix to enable correct logic in date ranges

### DIFF
--- a/packages/gestalt-datepicker/src/DatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker.tsx
@@ -133,6 +133,7 @@ export type Props = {
    * DatePicker can be a controlled component. `value` sets the current value of the input. See the [controlled component date example](https://gestalt.pinterest.systems/web/datepicker#Controlled-component) to learn more.
    */
   value?: Date | null;
+  _overrideRangeDateFix?: boolean;
 };
 
 /**
@@ -170,6 +171,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
     selectLists,
     size,
     value,
+    _overrideRangeDateFix = false,
   }: Props,
   ref,
 ) {
@@ -198,6 +200,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
       <Fragment>
         <InternalDatePicker
           ref={innerInputRef}
+          _overrideRangeDateFix={_overrideRangeDateFix}
           disabled={disabled}
           errorMessage={errorMessage}
           excludeDates={excludeDates}
@@ -264,6 +267,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
                     width="100%"
                   >
                     <InternalDatePicker
+                      _overrideRangeDateFix={_overrideRangeDateFix}
                       errorMessage={errorMessage}
                       excludeDates={excludeDates}
                       id={id}
@@ -280,8 +284,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
                       rangeSelector={rangeSelector}
                       rangeStartDate={rangeStartDate}
                       selectLists={selectLists}
-                      size={size}
-                      value={value}
+                      size={size} value={value}
                     />
                   </Flex>
                 )}
@@ -296,6 +299,7 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
   return (
     <InternalDatePicker
       ref={innerInputRef}
+      _overrideRangeDateFix={_overrideRangeDateFix}
       disabled={disabled}
       errorMessage={errorMessage}
       excludeDates={excludeDates}

--- a/packages/gestalt-datepicker/src/DatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker.tsx
@@ -284,7 +284,8 @@ const DatePickerWithForwardRef = forwardRef<HTMLInputElement, Props>(function Da
                       rangeSelector={rangeSelector}
                       rangeStartDate={rangeStartDate}
                       selectLists={selectLists}
-                      size={size} value={value}
+                      size={size}
+                      value={value}
                     />
                   </Flex>
                 )}

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
@@ -114,7 +114,7 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
       left: 'left',
     } as const;
 
-    // This logic is making the component uncontrolled and causes unexpected behaviour. We need to deprecate when all instances of DatePicker set _overrideRangeDateFix to true
+    // This logic is making the component uncontrolled and causes unexpected behaviour. We need to deprecate it when all instances of DatePicker set _overrideRangeDateFix to true
     const controlledMaxDate = rangeSelector === 'end' ? maxDate : rangeEndDate || maxDate;
     const controlledMinDate = rangeSelector === 'start' ? minDate : rangeStartDate || minDate;
 

--- a/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
+++ b/packages/gestalt-datepicker/src/DatePicker/InternalDatePicker.tsx
@@ -62,6 +62,7 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
       selectLists,
       size,
       value: controlledValue,
+      _overrideRangeDateFix,
     }: InternalProps,
     ref,
   ): ReactElement {
@@ -113,6 +114,10 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
       left: 'left',
     } as const;
 
+    // This logic is making the component uncontrolled and causes unexpected behaviour. We need to deprecate when all instances of DatePicker set _overrideRangeDateFix to true
+    const controlledMaxDate = rangeSelector === 'end' ? maxDate : rangeEndDate || maxDate;
+    const controlledMinDate = rangeSelector === 'start' ? minDate : rangeStartDate || minDate;
+
     return (
       <div className="_gestalt">
         {label && !isInVRExperiment && !inline && (
@@ -151,8 +156,8 @@ const InternalDatePickerWithForwardRef = forwardRef<HTMLInputElement, InternalPr
           includeDates={includeDates && [...includeDates]}
           inline={inline}
           locale={updatedLocale}
-          maxDate={rangeSelector === 'end' ? maxDate : rangeEndDate || maxDate}
-          minDate={rangeSelector === 'start' ? minDate : rangeStartDate || minDate}
+          maxDate={_overrideRangeDateFix ? maxDate : controlledMaxDate}
+          minDate={_overrideRangeDateFix ? minDate : controlledMinDate}
           nextMonthButtonLabel={
             <Icon accessibilityLabel={nextMonth} color="default" icon="arrow-forward" size={16} />
           }


### PR DESCRIPTION
DatePicker: add private prop _overrideRangeDateFix to enable correct logic in date ranges     


This component contains logic that made the component uncontrolled and causes unexpected behavior when trying to define min an max dates. We need to deprecate when all instances of DatePicker set _overrideRangeDateFix to true
