### PR TITLE
Internal: change v.pinimg.com to v1.pinimg.com

### DIFF
--- a/docs/examples/animation/useExample.tsx
+++ b/docs/examples/animation/useExample.tsx
@@ -18,7 +18,7 @@ export default function Example() {
           onPlay={() => setPlaying(true)}
           onPlayError={({ error }) => error && setPlaying(false)}
           playing={playing}
-          src="https://v.pinimg.com/videos/mc/720p/f4/5c/51/f45c5182f7721c660309948a973c6408.mp4"
+          src="https://v1.pinimg.com/videos/mc/720p/f4/5c/51/f45c5182f7721c660309948a973c6408.mp4"
         />
       </Box>
       <Text align="center" italic>

--- a/docs/examples/video/autoplayAndErrorDetectionExample.tsx
+++ b/docs/examples/video/autoplayAndErrorDetectionExample.tsx
@@ -20,7 +20,7 @@ export default function Example() {
           onPlayError={({ error }) => error && setPlaying(false)}
           onVolumeChange={(e) => setVolume(e.volume)}
           playing={playing}
-          src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+          src="https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
           volume={volume}
         />
       </Box>

--- a/docs/examples/video/controlsExample.tsx
+++ b/docs/examples/video/controlsExample.tsx
@@ -33,7 +33,7 @@ export default function Example() {
             onVolumeChange={(e) => setVolume(e.volume)}
             playing={playing}
             poster="https://i.pinimg.com/videos/thumbnails/originals/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4.0000000.jpg"
-            src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+            src="https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
             volume={volume}
           >
             {!showControls ? (

--- a/docs/examples/video/localizationLabels.tsx
+++ b/docs/examples/video/localizationLabels.tsx
@@ -34,7 +34,7 @@ export default function Example() {
             onPlayError={({ error }) => error && setPlaying(false)}
             onVolumeChange={(e) => setVolume(e.volume)}
             playing={playing}
-            src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+            src="https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
             volume={volume}
           />
         </Box>

--- a/docs/examples/video/mainExample.tsx
+++ b/docs/examples/video/mainExample.tsx
@@ -18,7 +18,7 @@ export default function Example() {
           onPlayError={({ error }) => error && setPlaying(false)}
           onVolumeChange={(e) => setVolume(e.volume)}
           playing={playing}
-          src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+          src="https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
           volume={volume}
         />
       </Box>

--- a/docs/examples/video/updatesExample.tsx
+++ b/docs/examples/video/updatesExample.tsx
@@ -3,12 +3,12 @@ import { Box, Button, Flex, Label, Text, TextField, Video } from 'gestalt';
 
 export default function Example() {
   const [input, setInput] = useState(
-    'https://v.pinimg.com/videos/mc/expMp4/ce/b4/cc/ceb4cc8c4889a86432a65884c147021f_t1.mp4',
+    'https://v1.pinimg.com/videos/mc/expMp4/ce/b4/cc/ceb4cc8c4889a86432a65884c147021f_t1.mp4',
   );
   const [playbackRate, setPlaybackRate] = useState(1);
   const [playing, setPlaying] = useState(false);
   const [src, setSrc] = useState(
-    'https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4',
+    'https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4',
   );
   const [volume, setVolume] = useState(1);
 

--- a/docs/examples/video/withChildrenExample.tsx
+++ b/docs/examples/video/withChildrenExample.tsx
@@ -18,7 +18,7 @@ export default function Example() {
           onPlayError={({ error }) => error && setPlaying(false)}
           onVolumeChange={(e) => setVolume(e.volume)}
           playing={playing}
-          src="https://v.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
+          src="https://v1.pinimg.com/videos/mc/expMp4/c8/37/71/c83771d856bc1ee12e2d2f81083df9d4_t1.mp4"
           volume={volume}
         >
           <Box


### PR DESCRIPTION
## What changed?

Change the video asset URL from `v.pinimg.com` to `v1.pinimg.com`

## Why?

`v.pinimg.com` is being retired, and we have to use `v1.pinimg.com` instead of `v.pinimg.com`.
