### PR TITLE
Link: fix a warning from accessibility pause in AccessibilityLinkActionIcon

### DIFF
--- a/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Dropdown.jsdom.test.tsx.snap
@@ -745,8 +745,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         width="12"
                       >
                         <title>
-                          , 
-                          Opens a new tab
+                          , Opens a new tab
                         </title>
                         <path
                           d="test-file-stub"
@@ -928,8 +927,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         width="12"
                       >
                         <title>
-                          , 
-                          Opens a new tab
+                          , Opens a new tab
                         </title>
                         <path
                           d="test-file-stub"
@@ -1008,8 +1006,7 @@ exports[`Dropdown renders a menu of 6 items 1`] = `
                         width="12"
                       >
                         <title>
-                          , 
-                          Opens a new tab
+                          , Opens a new tab
                         </title>
                         <path
                           d="test-file-stub"

--- a/packages/gestalt/src/__snapshots__/Link.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/Link.test.tsx.snap
@@ -98,8 +98,7 @@ exports[`external link with nofollow 1`] = `
       width={16}
     >
       <title>
-        , 
-        Opens a new tab
+        , Opens a new tab
       </title>
       <path
         d="test-file-stub"

--- a/packages/gestalt/src/accessibility/AccessibilityLinkActionIcon.tsx
+++ b/packages/gestalt/src/accessibility/AccessibilityLinkActionIcon.tsx
@@ -37,9 +37,11 @@ export default function AccessibilityLinkActionIcon({ size, color, icon = 'visit
     titleLabel = accessibilityDownloadLabel;
   }
 
+  titleLabel = `, ${titleLabel}`;
+
   return (
     <svg className={classNames} height={size} role="img" viewBox="0 0 24 24" width={size}>
-      <title>, {titleLabel}</title>
+      <title>{titleLabel}</title>
       <path d={(isInExperiment ? vrIcons : icons)[icon ?? 'visit']} />
     </svg>
   );


### PR DESCRIPTION
# Pull Request Instructions

## What changed?

Refactor how we prepend ", " to the svg title of `<AccessibilityLinkActionIcon />`.

## Why?

When we render
```tsx
<title>, {titleLabel}</title>
```

React throws the following warning:

> Warning: A title element received an array with more than 1 element as children. In browsers title Elements can only have Text Nodes as children. If the children being rendered output more than a single text node in aggregate the browser will display markup and comments as text in the title and hydration will likely fail and fall back to client rendering

This is because React treats `, {titleLabel}` as two children nodes: `[', ', titleLabel]`.

To fix, reassign `titleLabel` as `, ${titleLabel}`.

