### PR TITLE
SearchGuide: fix border radius in VR image variant 

### DIFF
--- a/packages/gestalt/src/SearchGuide.css
+++ b/packages/gestalt/src/SearchGuide.css
@@ -41,6 +41,11 @@
   min-height: 48px;
 }
 
+.imageThumbnailMask {
+  border-radius: var(--sema-rounding-400);
+  overflow: hidden;
+}
+
 .imageDiv {
   background-color: var(--opacity-100);
   border-radius: 99px;
@@ -50,10 +55,7 @@
 }
 
 .imageDivVr {
-  border-end-start-radius: var(--rounding-400);
-  border-start-start-radius: var(--rounding-400);
   height: 48px;
-  overflow: hidden;
   position: relative;
   width: 44px;
 }

--- a/packages/gestalt/src/SearchGuide.tsx
+++ b/packages/gestalt/src/SearchGuide.tsx
@@ -270,6 +270,7 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
       <div
         className={classnames(
           styles.childrenDiv,
+          thumbnail && 'image' in thumbnail && styles.imageThumbnailMask,
           isInVRExperiment && selected && styles.selectedVr,
           isInVRExperiment && !selected && typeof color === 'string' && colorClassname,
           { [touchableStyles.tapCompress]: isTapping },

--- a/packages/gestalt/src/SearchGuide.tsx
+++ b/packages/gestalt/src/SearchGuide.tsx
@@ -270,7 +270,7 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
       <div
         className={classnames(
           styles.childrenDiv,
-          thumbnail && 'image' in thumbnail && styles.imageThumbnailMask,
+          isInVRExperiment && thumbnail && 'image' in thumbnail && styles.imageThumbnailMask,
           isInVRExperiment && selected && styles.selectedVr,
           isInVRExperiment && !selected && typeof color === 'string' && colorClassname,
           { [touchableStyles.tapCompress]: isTapping },


### PR DESCRIPTION
```
  border-end-start-radius: var(--rounding-400);
  border-start-start-radius: var(--rounding-400);

```
arent supported in Pinboard, replacing with border-radius

![Screenshot by Dropbox Capture](https://github.com/user-attachments/assets/c66e93f2-f967-40ee-922b-e1b04f81cf7c)

