### PR TITLE
SearchGuide: fix stacking context bug with isolation='isolate'

### DIFF
--- a/packages/gestalt/src/SearchGuide.css
+++ b/packages/gestalt/src/SearchGuide.css
@@ -5,6 +5,7 @@
   cursor: pointer;
   display: flex;
   height: 48px;
+  isolation: isolate;
   min-width: 60px;
   padding-left: var(--space-100);
   padding-right: var(--space-100);
@@ -18,6 +19,7 @@
   border-width: 2px;
   box-sizing: border-box;
   display: inherit;
+  isolation: isolate;
   padding: var(--sema-space-0) var(--sema-space-0);
   text-wrap: balance;
 }
@@ -67,7 +69,6 @@
   height: 100%;
   position: absolute;
   width: 100%;
-  z-index: 1;
 }
 
 /* STATES */

--- a/packages/gestalt/src/SearchGuide.tsx
+++ b/packages/gestalt/src/SearchGuide.tsx
@@ -234,7 +234,7 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
   const inBackgroundGradient =
     !isInVRExperiment && typeof color !== 'string' && Array.isArray(color);
 
-    return (
+  return (
     <button
       ref={innerRef}
       aria-controls={accessibilityControls}

--- a/packages/gestalt/src/SearchGuide.tsx
+++ b/packages/gestalt/src/SearchGuide.tsx
@@ -133,7 +133,7 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
 
   const colorClassname = typeof color === 'string' ? styles[colorClass[color]!] : null;
 
-  const buttonClasses = isInVRExperiment
+  const style = isInVRExperiment
     ? classnames(styles.searchguideVr, touchableStyles.tapTransition, {
         [focusStyles.hideOutline]: !isFocusVisible,
         [styles.vrFocused]: isFocusVisible,
@@ -233,7 +233,8 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
   const variant = thumbnail ? thumbnailVariant : textVariant;
   const inBackgroundGradient =
     !isInVRExperiment && typeof color !== 'string' && Array.isArray(color);
-  return (
+
+    return (
     <button
       ref={innerRef}
       aria-controls={accessibilityControls}
@@ -241,7 +242,7 @@ const SearchGuideWithForwardRef = forwardRef<HTMLButtonElement, Props>(function 
       aria-haspopup={accessibilityHaspopup || expandable}
       aria-label={accessibilityLabel}
       aria-pressed={selected}
-      className={buttonClasses}
+      className={style}
       data-test-id={dataTestId}
       onBlur={handleBlur}
       onClick={(event) => onClick?.({ event })}


### PR DESCRIPTION
SearchGuide: fix stacking context bug with isolation='isolate'