### PR TITLE
Masonry: Fix bug on edge case while using dynamicHeightsV2

### DIFF
--- a/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
+++ b/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
@@ -101,10 +101,10 @@ function recalcHeights<T>({
   gutterWidth: number;
 }): boolean {
   const changedItemPosition = positionStore.get(changedItem);
-  const positionStoreStatic: Cache<T, Position> = Masonry.createMeasurementStore();
+  const positionStoreOriginal: Cache<T, Position> = Masonry.createMeasurementStore();
   items.forEach((item) => {
     const position = positionStore.get(item);
-    positionStoreStatic.set(item, { ...position } as Position);
+    positionStoreOriginal.set(item, { ...position } as Position);
   });
 
   if (
@@ -152,9 +152,11 @@ function recalcHeights<T>({
           // Check all items above to check if movement is necessary
           const allPreviousItems = items
             .map((i) => {
-              const prevPosition = positionStoreStatic.get(i);
-              const newPosition = positionStore.get(i) as Position;
-              return prevPosition && prevPosition.top < multicolumCurrentPosition.top
+              const originalPosition = positionStoreOriginal.get(i);
+              const newPosition = positionStore.get(i);
+              return originalPosition &&
+                newPosition &&
+                originalPosition.top < multicolumCurrentPosition.top
                 ? { item: i, position: newPosition }
                 : undefined;
             })

--- a/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
+++ b/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
@@ -3,6 +3,7 @@
  */
 import { Cache } from './Cache';
 import { Position } from './types';
+import Masonry from '../Masonry';
 
 function isBelowArea(area: { left: number; right: number }, position: Position) {
   return position.left < area.right && position.left + position.width > area.left;
@@ -100,6 +101,11 @@ function recalcHeights<T>({
   gutterWidth: number;
 }): boolean {
   const changedItemPosition = positionStore.get(changedItem);
+  const positionStoreStatic: Cache<T, Position> = Masonry.createMeasurementStore();
+  items.forEach((item) => {
+    const position = positionStore.get(item);
+    positionStoreStatic.set(item, { ...position } as Position);
+  });
 
   if (
     !changedItemPosition ||
@@ -146,9 +152,10 @@ function recalcHeights<T>({
           // Check all items above to check if movement is necessary
           const allPreviousItems = items
             .map((i) => {
-              const p = positionStore.get(i);
-              return p && p.top < multicolumCurrentPosition.top
-                ? { item: i, position: p }
+              const prevPosition = positionStoreStatic.get(i);
+              const newPosition = positionStore.get(i) as Position;
+              return prevPosition && prevPosition.top < multicolumCurrentPosition.top
+                ? { item: i, position: newPosition }
                 : undefined;
             })
             .filter((itemPosition) => !!itemPosition)


### PR DESCRIPTION
## Summary

### What changed?

This PR addresses an issue where middle elements overlap when the item being resized has at least one item in between a multi-column element, and the height change exceeds the height of the middle elements.

### Why?

The bug was caused by how positions were determined for repositioning items. Previously, updated positions were used, which neglected to account for items that moved past the multi-column item, leading to the overlap. With this update, original positions are taken into account for determining overlap prevention, while new positions are used for recalculating item placement.


## Examples

---
### Case 1
 - Current state

https://github.com/user-attachments/assets/fce45e08-f967-4cd4-bd51-c09978155746

 - Fixed change

https://github.com/user-attachments/assets/a667225e-1013-472e-a9b8-b1ac7c2ab2a9


---
### Case 2
 - Current state

https://github.com/user-attachments/assets/84e4ae12-d1a5-494a-931c-2d4b558dd6f5

 - Fixed change

https://github.com/user-attachments/assets/529f2050-c0d6-4dde-ba58-9964a08b128d


---
### Case 3
 - Current state

https://github.com/user-attachments/assets/cc1ebaea-fc85-463b-98b2-7b70327e0576

 - Fixed change

https://github.com/user-attachments/assets/2c10dcd2-ac7f-4bca-b774-417f553149f2

---

## Checklist

- [x] Fixed Dynamic heights V2