### PR TITLE
Image, Video: if image or track `src` is empty string "" then set as undefined

### DIFF
--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -226,7 +226,7 @@ export default class Image extends PureComponent<Props> {
           onLoad={this.handleLoad}
           role={role === 'presentation' ? 'presentation' : undefined}
           sizes={sizes}
-          src={src || undefined}
+          src={typeof src === 'string' && src !== '' ? src : undefined}
           srcSet={srcSet}
           {...conditionalProps}
         />

--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -73,7 +73,7 @@ type Props = {
   /**
    * The URL for the image.
    */
-  src: string;
+  src: string | undefined;
   /**
    * A comma-separated list of one or more strings indicating a set of possible image sources for the user agent to use.
    */

--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -226,7 +226,7 @@ export default class Image extends PureComponent<Props> {
           onLoad={this.handleLoad}
           role={role === 'presentation' ? 'presentation' : undefined}
           sizes={sizes}
-          src={src}
+          src={src || undefined}
           srcSet={srcSet}
           {...conditionalProps}
         />

--- a/packages/gestalt/src/Image.tsx
+++ b/packages/gestalt/src/Image.tsx
@@ -137,7 +137,9 @@ export default class Image extends PureComponent<Props> {
       image.onload = this.handleLoad;
       // @ts-expect-error - TS2322 - Type '(event: SyntheticEvent<HTMLImageElement, Event>) => void' is not assignable to type 'OnErrorEventHandler'.
       image.onerror = this.handleError;
-      image.src = this.props.src;
+      if (this.props.src) {
+        image.src = this.props.src;
+      }
     }
   }
 
@@ -226,7 +228,7 @@ export default class Image extends PureComponent<Props> {
           onLoad={this.handleLoad}
           role={role === 'presentation' ? 'presentation' : undefined}
           sizes={sizes}
-          src={typeof src === 'string' && src !== '' ? src : undefined}
+          src={typeof src === 'string' && src === '' ? undefined : src}
           srcSet={srcSet}
           {...conditionalProps}
         />

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -704,7 +704,12 @@ export default class Video extends PureComponent<Props, State> {
           playsInline={playsInline}
           poster={poster}
           preload={preload}
-          src={typeof src === 'string' && src === '' ? undefined : src}
+          src={(() => {
+            if (typeof src === 'string') {
+              return src === '' ? undefined : src;
+            }
+            return undefined;
+          })()}
         >
           {Array.isArray(src) &&
             src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -707,7 +707,7 @@ export default class Video extends PureComponent<Props, State> {
         >
           {Array.isArray(src) &&
             src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}
-          <track kind="captions" src={captions} />
+          <track kind="captions" src={captions || undefined} />
         </video>
         {Boolean(children) && (
           <Box bottom left overflow="hidden" position="absolute" right top>

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -6,6 +6,7 @@ import VideoControls from './Video/Controls';
 
 type Source =
   | string
+  | undefined
   | ReadonlyArray<{
       type: 'video/m3u8' | 'video/mp4' | 'video/ogg';
       src: string;
@@ -28,7 +29,7 @@ type Props = {
   /**
    * The URL of the captions track for the video (.vtt file). See the [accessibility section](https://gestalt.pinterest.systems/web/video#Captions) to learn more.
    */
-  captions?: string;
+  captions?: string | undefined;
   /**
    * This `children` prop is not same as children inside the native html `video` element. Instead, it serves to add overlays on top of the html video element, while still being under the video controls. See [children example](https://gestalt.pinterest.systems/web/video#video-with-children) for more details.
    */
@@ -263,7 +264,7 @@ const isNewSource = (oldSource: Source, newSource: Source): boolean => {
     return true;
   }
   if (Array.isArray(newSource)) {
-    if (oldSource.length !== newSource.length) {
+    if (oldSource?.length !== newSource.length) {
       // If the sources are both an Array, and the lengths
       // do not match we evaluate as a new source
       return true;

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -703,11 +703,11 @@ export default class Video extends PureComponent<Props, State> {
           playsInline={playsInline}
           poster={poster}
           preload={preload}
-          src={typeof src === 'string' ? src : undefined}
+          src={typeof src === 'string' && src !== '' ? src : undefined}
         >
           {Array.isArray(src) &&
             src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}
-          <track kind="captions" src={captions || undefined} />
+          <track kind="captions" src={typeof captions === 'string' && captions !== '' ? captions : undefined} />
         </video>
         {Boolean(children) && (
           <Box bottom left overflow="hidden" position="absolute" right top>

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -704,13 +704,13 @@ export default class Video extends PureComponent<Props, State> {
           playsInline={playsInline}
           poster={poster}
           preload={preload}
-          src={typeof src === 'string' && src !== '' ? src : undefined}
+          src={typeof src === 'string' && src === '' ? undefined : src}
         >
           {Array.isArray(src) &&
             src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}
           <track
             kind="captions"
-            src={typeof captions === 'string' && captions !== '' ? captions : undefined}
+            src={typeof captions === 'string' && captions === '' ? undefined : captions}
           />
         </video>
         {Boolean(children) && (

--- a/packages/gestalt/src/Video.tsx
+++ b/packages/gestalt/src/Video.tsx
@@ -707,7 +707,10 @@ export default class Video extends PureComponent<Props, State> {
         >
           {Array.isArray(src) &&
             src.map((source) => <source key={source.src} src={source.src} type={source.type} />)}
-          <track kind="captions" src={typeof captions === 'string' && captions !== '' ? captions : undefined} />
+          <track
+            kind="captions"
+            src={typeof captions === 'string' && captions !== '' ? captions : undefined}
+          />
         </video>
         {Boolean(children) && (
           <Box bottom left overflow="hidden" position="absolute" right top>


### PR DESCRIPTION
# Pull Request Instructions

### Summary

#### What changed?

If the src is empty in img or track inside the Image and Video component, then it sets it to undefined.

#### Why?

We are getting many errors like this one when upgrading to React 19: `An empty string ("") was passed to the src attribute`. I tested this on my devapp and this fixes this errors.

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
