### PR TITLE
DateField, DateRange: upgrade @mui/x-date-pickers to 7.27.2

### DIFF
--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -18,7 +18,7 @@
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
     "@mui/material": "^5.15.14",
-    "@mui/x-date-pickers": "^7.0.0",
+    "@mui/x-date-pickers": "^7.27.1",
     "classnames": "^2.2.6",
     "react-datepicker": "7.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,10 +3590,10 @@
     prop-types "^15.8.1"
     react-is "^19.0.0"
 
-"@mui/x-date-pickers@^7.0.0":
-  version "7.27.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-7.27.0.tgz#d5c90d76d9aeb2bbc9a0d5088927e9db42d41751"
-  integrity sha512-wSx8JGk4WQ2hTObfQITc+zlmUKNleQYoH1hGocaQlpWpo1HhauDtcQfX6sDN0J0dPT2eeyxDWGj4uJmiSfQKcw==
+"@mui/x-date-pickers@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-7.27.1.tgz#5c9769744598b1e10c1919ce0589b8d235131a17"
+  integrity sha512-2YPhTM9TM39dmIkEQdSB6P6NASePB9LuhXXKQqq0PX4FXGymYEPz/acQXkk617zwfxJJaDhJZ6g8SAv5pklTJQ==
   dependencies:
     "@babel/runtime" "^7.25.7"
     "@mui/utils" "^5.16.6 || ^6.0.0"


### PR DESCRIPTION
\DateField, DateRange: upgrade @mui/x-date-pickers to 7.27.2 #4019

Latest seem to not have findDOMNode in [react-transition-group](https://github.com/reactjs/react-transition-group)

https://github.com/reactjs/react-transition-group/releases?q=findDOMNode&expanded=true
