### PR TITLE
TapAreaLink: support to `title` prop

### DIFF
--- a/packages/gestalt/src/Link/InternalLink.jsdom.test.tsx
+++ b/packages/gestalt/src/Link/InternalLink.jsdom.test.tsx
@@ -1,27 +1,44 @@
 import { render, screen } from '@testing-library/react';
 import InternalLink from './InternalLink';
 
-test('InternalLink handles onClick callback', () => {
-  const mockOnClick = jest.fn<
-    [
-      {
-        dangerouslyDisableOnNavigation: () => void;
-        event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
-      },
-    ],
-    // @ts-expect-error - TS2344 - Type 'undefined' does not satisfy the constraint 'any[]'.
-    undefined
-  >();
-  render(
-    <InternalLink
-      href="https://example.com"
-      onClick={mockOnClick}
-      tabIndex={0}
-      wrappedComponent="button"
-    >
-      InternalLink
-    </InternalLink>,
-  );
-  screen.getByText('InternalLink').click();
-  expect(mockOnClick).toHaveBeenCalled();
+describe('InternalLink', () => {
+  test('InternalLink handles onClick callback', () => {
+    const mockOnClick = jest.fn<
+      [
+        {
+          dangerouslyDisableOnNavigation: () => void;
+          event: React.MouseEvent<HTMLAnchorElement> | React.KeyboardEvent<HTMLAnchorElement>;
+        },
+      ],
+      // @ts-expect-error - TS2344 - Type 'undefined' does not satisfy the constraint 'any[]'.
+      undefined
+    >();
+    render(
+      <InternalLink
+        href="https://example.com"
+        onClick={mockOnClick}
+        tabIndex={0}
+        wrappedComponent="button"
+      >
+        InternalLink
+      </InternalLink>,
+    );
+    screen.getByText('InternalLink').click();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+  it('renders with a provided title', () => {
+    const TEST_TITLE = 'title with more information';
+    render(
+      <InternalLink
+        href="https://example.com"
+        tabIndex={0}
+        title={TEST_TITLE}
+        wrappedComponent="tapArea"
+      >
+        InternalLink
+      </InternalLink>,
+    );
+    const anchorTagElement = screen.getByRole('link');
+    expect(anchorTagElement.getAttribute('title')).toEqual(TEST_TITLE);
+  });
 });

--- a/packages/gestalt/src/Link/InternalLink.test.tsx
+++ b/packages/gestalt/src/Link/InternalLink.test.tsx
@@ -145,18 +145,34 @@ it('renders with download string', () =>
       .toJSON(),
   ).toMatchSnapshot());
 
-it('renders Button with onClick', () =>
-  expect(
-    renderer
+  it('renders Button with onClick', () =>
+    expect(
+      renderer
       .create(
         <InternalLink
-          href="https://example.com"
-          onClick={() => {}}
-          tabIndex={0}
-          wrappedComponent="button"
+        href="https://example.com"
+        onClick={() => {}}
+        tabIndex={0}
+        wrappedComponent="button"
         >
           InternalLink
         </InternalLink>,
       )
       .toJSON(),
-  ).toMatchSnapshot());
+    ).toMatchSnapshot());
+
+  it('renders with a title prop', () =>
+      expect(
+        renderer
+          .create(
+            <InternalLink
+              href="https://example.com"
+              tabIndex={0}
+              title="title with more information"
+              wrappedComponent="tapArea"
+            >
+              InternalLink
+            </InternalLink>,
+          )
+          .toJSON(),
+      ).toMatchSnapshot());

--- a/packages/gestalt/src/Link/InternalLink.test.tsx
+++ b/packages/gestalt/src/Link/InternalLink.test.tsx
@@ -145,34 +145,34 @@ it('renders with download string', () =>
       .toJSON(),
   ).toMatchSnapshot());
 
-  it('renders Button with onClick', () =>
-    expect(
-      renderer
+it('renders Button with onClick', () =>
+  expect(
+    renderer
       .create(
         <InternalLink
-        href="https://example.com"
-        onClick={() => {}}
-        tabIndex={0}
-        wrappedComponent="button"
+          href="https://example.com"
+          onClick={() => {}}
+          tabIndex={0}
+          wrappedComponent="button"
         >
           InternalLink
         </InternalLink>,
       )
       .toJSON(),
-    ).toMatchSnapshot());
+  ).toMatchSnapshot());
 
-  it('renders with a title prop', () =>
-      expect(
-        renderer
-          .create(
-            <InternalLink
-              href="https://example.com"
-              tabIndex={0}
-              title="title with more information"
-              wrappedComponent="tapArea"
-            >
-              InternalLink
-            </InternalLink>,
-          )
-          .toJSON(),
-      ).toMatchSnapshot());
+it('renders with a title prop', () =>
+  expect(
+    renderer
+      .create(
+        <InternalLink
+          href="https://example.com"
+          tabIndex={0}
+          title="title with more information"
+          wrappedComponent="tapArea"
+        >
+          InternalLink
+        </InternalLink>,
+      )
+      .toJSON(),
+  ).toMatchSnapshot());

--- a/packages/gestalt/src/Link/InternalLink.tsx
+++ b/packages/gestalt/src/Link/InternalLink.tsx
@@ -55,6 +55,7 @@ type Props = {
   size?: 'sm' | 'md' | 'lg';
   tapStyle?: 'none' | 'compress';
   target?: null | 'self' | 'blank';
+  title?: string;
   wrappedComponent: 'button' | 'iconButton' | 'tapArea' | 'searchGuide';
 };
 
@@ -89,6 +90,7 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
     size,
     tapStyle = 'compress',
     target,
+    title,
     wrappedComponent,
   }: Props,
   ref,
@@ -322,6 +324,7 @@ const InternalLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function
         : {})}
       tabIndex={disabled ? undefined : tabIndex}
       target={target ? `_${target}` : undefined}
+      title={title}
       {...(download ? { download } : {})}
     >
       {children}

--- a/packages/gestalt/src/Link/__snapshots__/InternalLink.test.tsx.snap
+++ b/packages/gestalt/src/Link/__snapshots__/InternalLink.test.tsx.snap
@@ -244,6 +244,31 @@ exports[`renders inline Button 1`] = `
 </a>
 `;
 
+exports[`renders with a title prop 1`] = `
+<a
+  className="noOutline inheritColor noUnderline tapTransition rounding0 accessibilityOutline block"
+  href="https://example.com"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onKeyPress={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseUp={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  rel=""
+  tabIndex={0}
+  title="title with more information"
+>
+  InternalLink
+</a>
+`;
+
 exports[`renders with download string 1`] = `
 <a
   className="noOutline inheritColor noUnderline tapTransition pill accessibilityOutline inlineFlex justifyCenter xsItemsCenter button"

--- a/packages/gestalt/src/TapAreaLink.jsdom.test.tsx
+++ b/packages/gestalt/src/TapAreaLink.jsdom.test.tsx
@@ -238,8 +238,6 @@ describe('TapAreaLink', () => {
       </TapAreaLink>,
     );
     const anchorTagElement = screen.getByRole('link');
-    expect(
-      anchorTagElement.getAttribute('title'),
-    ).toBe(TEST_TITLE);
+    expect(anchorTagElement.getAttribute('title')).toBe(TEST_TITLE);
   });
 });

--- a/packages/gestalt/src/TapAreaLink.jsdom.test.tsx
+++ b/packages/gestalt/src/TapAreaLink.jsdom.test.tsx
@@ -224,4 +224,22 @@ describe('TapAreaLink', () => {
       }),
     ).toBeVisible();
   });
+
+  it('renders with a provided title', () => {
+    const TEST_TITLE = 'test title';
+    render(
+      <TapAreaLink
+        accessibilityLabel="Visit Pinterest"
+        href="https://www.pinterest.com"
+        target="blank"
+        title={TEST_TITLE}
+      >
+        Visit Pinterest
+      </TapAreaLink>,
+    );
+    const anchorTagElement = screen.getByRole('link');
+    expect(
+      anchorTagElement.getAttribute('title'),
+    ).toBe(TEST_TITLE);
+  });
 });

--- a/packages/gestalt/src/TapAreaLink.tsx
+++ b/packages/gestalt/src/TapAreaLink.tsx
@@ -128,6 +128,10 @@ type Props = {
   - 'compress' scales down TapArea.
      */
   tapStyle?: 'none' | 'compress';
+  /**
+   * Value for the title general attribute on the anchor tag to provide additional information about the link.
+   */
+  title?: string;
 };
 
 /**
@@ -162,6 +166,7 @@ const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function 
     rounding = 0,
     tapStyle = 'none',
     target = null,
+    title,
   }: Props,
   ref,
 ) {
@@ -229,6 +234,7 @@ const TapAreaLinkWithForwardRef = forwardRef<HTMLAnchorElement, Props>(function 
       tabIndex={tabIndex}
       tapStyle={tapStyle}
       target={target}
+      title={title}
       wrappedComponent="tapArea"
     >
       {children}


### PR DESCRIPTION
 TapAreaLink: support to title prop #4022

Problem description

[TDD](https://docs.google.com/document/d/1tNdL_CSLc3DhCDa-qF1hs-3hEaY3CcrD8p2rS-9BWGk/edit?tab=t.0)


Currently TapAreaLink doesn’t have support for a title global attribute ([mdn link](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title)) on the anchor element <a/>. This attribute is useful for SEO purposes as it provides additional associated text with the link that can help SEO crawlers gather more context around links on a page. In addition, it commonly displays a tooltip with the title that can provide users with more information about the destination page as well. Though aria-label ([mdn link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)) may seem similar to title, it serves a different purpose and is not known to be considered by SEO crawlers. aria-label is also only displayed in assistive technologies, leaving regular users without that additional information about the destination page.

In order to get a title on an <a/> our team has to use a <Link/> component from a react-router-dom package, which is not ideal as it doesn’t have long term support from the Gestalt team. 

Proposal

With the proposed change we will add a new prop to the TapAreaLink component that will add a global attribute title to the <a/> tag used in its implementation.
