### PR TITLE
Internal: Upgrade mui-material

### DIFF
--- a/packages/gestalt-datepicker/package.json
+++ b/packages/gestalt-datepicker/package.json
@@ -17,7 +17,7 @@
     "@floating-ui/react": "^0.25.4",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@mui/material": "^5.15.14",
+    "@mui/material": "^5.16.12",
     "@mui/x-date-pickers": "^7.27.1",
     "classnames": "^2.2.6",
     "react-datepicker": "7.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,7 +3510,7 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.14.tgz#e6536f1b6caa873f7915fbf9703fdc840a5a98d9"
   integrity sha512-sbjXW+BBSvmzn61XyTMun899E7nGPTXwqD9drm1jBUAvWEhJpPFIRxwQQiATWZnd9rvdxtnhhdsDxEGWI0jxqA==
 
-"@mui/material@^5.15.14":
+"@mui/material@^5.16.12":
   version "5.16.14"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.16.14.tgz#da8a75822f039d8c1b0ab7fb4146d767c2f9248a"
   integrity sha512-eSXQVCMKU2xc7EcTxe/X/rC9QsV2jUe8eLM3MUCPYbo6V52eCE436akRIvELq/AqZpxx2bwkq7HC0cRhLB+yaw==


### PR DESCRIPTION
# Pull Request Instructions

### Summary

#### What changed?

Upgrading @mui/material library to version [5.16.12](https://github.com/mui/material-ui/releases/tag/v5.16.12)

#### Why?

For upgrading pinboard to React 19, this is the version of mui/material that is now compatible with React 19


### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
