### PR TITLE
Masonry: Fix Multi-Column Module Positioning Bug on Dynamic Heights V2

### DIFF
--- a/packages/gestalt/src/Masonry/dynamicHeightsUtils.test.ts
+++ b/packages/gestalt/src/Masonry/dynamicHeightsUtils.test.ts
@@ -354,4 +354,144 @@ describe('dynamic heights on masonry', () => {
       expect(newPos).toEqual(expectedPos[index]);
     });
   });
+
+  test('smaller module item that is above and in the area of a bigger module should be repositioned when the bigger module shrinks', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: readonly [Item, Item, ...Item[]] = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 200, 'color': '#A52019', columnSpan: 3 },
+      { 'name': 'Pin 4', 'height': 350, 'color': '#CF3476', columnSpan: 2 },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultLayout({
+      gutter,
+      columnWidth: 236,
+      align: 'start',
+      measurementCache: measurementStore,
+      positionCache,
+      layout: 'basic',
+      minCols: 3,
+      rawItemCount: items.length,
+      width: 236 * 3,
+      _getColumnSpanConfig: getColumnSpanConfig,
+      originalItems: items,
+    });
+
+    const positions = layout(items);
+
+    const expectedOriginalPos = [
+      { top: 0, left: 0, width: 236, height: 200 },
+      { top: 0, left: 236, width: 236, height: 201 },
+      { top: 0, left: 472, width: 236, height: 202 },
+      { top: 202, left: 0, width: 708, height: 200 },
+      { top: 402, left: 0, width: 472, height: 350 },
+    ];
+
+    items.forEach((_, index) => {
+      const originalPos = positions[index]!;
+      expect(originalPos).toEqual(expectedOriginalPos[index]);
+    });
+
+    const changedItemIndex = 3; // Pin 3
+    const heightDelta = -199;
+    const changedItemIndexNewHeight = 200 + heightDelta;
+
+    recalcHeights({
+      items,
+      changedItem: items[changedItemIndex],
+      newHeight: changedItemIndexNewHeight,
+      positionStore: positionCache,
+      measurementStore,
+      gutterWidth: gutter,
+    });
+
+    const expectedPos = [
+      { top: 0, left: 0, width: 236, height: 200 },
+      { top: 0, left: 236, width: 236, height: 201 },
+      { top: 0, left: 472, width: 236, height: 202 },
+      { top: 202, left: 0, width: 708, height: 1 },
+      { top: 203, left: 0, width: 472, height: 350 },
+    ];
+
+    items.forEach((item, index) => {
+      const newPos = positionCache.get(item);
+      expect(newPos).toEqual(expectedPos[index]);
+    });
+  });
+
+  test('smaller module item that is above and in the area of a bigger module should be repositioned when the bigger module increases', () => {
+    const measurementStore = new MeasurementStore<Record<any, any>, number>();
+    const positionCache = new MeasurementStore<Record<any, any>, Position>();
+    const items: readonly [Item, Item, ...Item[]] = [
+      { 'name': 'Pin 0', 'height': 200, 'color': '#E230BA' },
+      { 'name': 'Pin 1', 'height': 201, 'color': '#F67076' },
+      { 'name': 'Pin 2', 'height': 202, 'color': '#FAB032' },
+      { 'name': 'Pin 3', 'height': 1, 'color': '#A52019', columnSpan: 3 },
+      { 'name': 'Pin 4', 'height': 350, 'color': '#CF3476', columnSpan: 2 },
+    ];
+    items.forEach((item: any) => {
+      measurementStore.set(item, item.height);
+    });
+
+    const layout = defaultLayout({
+      gutter,
+      columnWidth: 236,
+      align: 'start',
+      measurementCache: measurementStore,
+      positionCache,
+      layout: 'basic',
+      minCols: 3,
+      rawItemCount: items.length,
+      width: 236 * 3,
+      _getColumnSpanConfig: getColumnSpanConfig,
+      originalItems: items,
+    });
+
+    const positions = layout(items);
+
+    const expectedOriginalPos = [
+      { top: 0, left: 0, width: 236, height: 200 },
+      { top: 0, left: 236, width: 236, height: 201 },
+      { top: 0, left: 472, width: 236, height: 202 },
+      { top: 202, left: 0, width: 708, height: 1 },
+      { top: 203, left: 0, width: 472, height: 350 },
+    ];
+
+    items.forEach((_, index) => {
+      const originalPos = positions[index]!;
+      expect(originalPos).toEqual(expectedOriginalPos[index]);
+    });
+
+    const changedItemIndex = 3; // Pin 3
+    const heightDelta = 500;
+    const changedItemIndexNewHeight = 1 + heightDelta;
+
+    recalcHeights({
+      items,
+      changedItem: items[changedItemIndex],
+      newHeight: changedItemIndexNewHeight,
+      positionStore: positionCache,
+      measurementStore,
+      gutterWidth: gutter,
+    });
+
+    const expectedPos = [
+      { top: 0, left: 0, width: 236, height: 200 },
+      { top: 0, left: 236, width: 236, height: 201 },
+      { top: 0, left: 472, width: 236, height: 202 },
+      { top: 202, left: 0, width: 708, height: 501 },
+      { top: 703, left: 0, width: 472, height: 350 },
+    ];
+
+    items.forEach((item, index) => {
+      const newPos = positionCache.get(item);
+      expect(newPos).toEqual(expectedPos[index]);
+    });
+  });
 });

--- a/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
+++ b/packages/gestalt/src/Masonry/dynamicHeightsV2Utils.ts
@@ -61,8 +61,10 @@ function getNewDelta<T>({
     const currentItemLeftLimit = position.left;
     const currentItemRightLimit = position.left + position.width;
     const itemIsAboveMulticolumn =
-      multiColumnLeftLimit <= currentItemLeftLimit &&
-      multiColumnRightLimit >= currentItemRightLimit;
+      (multiColumnLeftLimit <= currentItemLeftLimit &&
+        multiColumnRightLimit > currentItemLeftLimit) ||
+      (multiColumnLeftLimit < currentItemRightLimit &&
+        multiColumnRightLimit >= currentItemRightLimit);
 
     if (itemIsAboveMulticolumn) {
       if (


### PR DESCRIPTION
# Summary

This pull request addresses a reported bug that occurs when two multi-column modules are stacked directly above each other and the bottom module is smaller in size than the top module.

## What was the problem?

The bug stemmed from the method used by dynamic heights v2 to calculate affected areas and columns. The previous logic only considered situations where a multi-column item was greater than or expanded beyond the current area, leading to incorrect repositioning. Specifically, a multi-column item with a column span of 3 positioned directly above a multi-column item with a span of 2 would not trigger repositioning for the second item.

And fixed integration tests that causes a conflict with [3993](https://github.com/pinterest/gestalt/pull/3993)

## What changed?

The updated algorithm now checks if any boundary of the second multi-column item falls within the area of the first multi-column item, ensuring proper repositioning.

### Before
![image](https://github.com/user-attachments/assets/23918ecd-514f-4f9f-98bc-5a81477bfa0f)

### Now
![image](https://github.com/user-attachments/assets/6c0b268b-bba8-4f47-b511-4e26bf583f22)


# Checklist

- [x] Added unit tests
- [x] Fixed bug