### PR TITLE
ChartGraph: Upgrade recharts for ChartGraph to support React 19

### DIFF
--- a/packages/gestalt-charts/package.json
+++ b/packages/gestalt-charts/package.json
@@ -13,7 +13,7 @@
     "src"
   ],
   "dependencies": {
-    "recharts": "2.8.0"
+    "recharts": "2.13.0"
   },
   "peerDependencies": {
     "gestalt": ">0.0.0",

--- a/packages/gestalt-charts/src/ChartGraph/renderAxis.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/renderAxis.tsx
@@ -77,18 +77,16 @@ export default function renderAxis({
     <Fragment>
       {isHorizontalLayout && (
         <Fragment>
+          {/* @ts-expect-error - TS2769 - No overload matches this call. */}
           <XAxis
             axisLine={false}
             dataKey="name"
-            // @ts-expect-error - TS2322
             domain={isTimeSeries ? !Array.isArray(range) && range?.xAxisBottom : undefined}
             interval={0}
             orientation="bottom"
             reversed={isRtl}
             scale={isTimeSeries ? 'time' : undefined}
-            // @ts-expect-error - TS2322
             style={FONT_STYLE_CATEGORIES}
-            // @ts-expect-error - TS2322
             tickFormatter={
               isTimeSeries
                 ? tickFormatter?.xAxisBottom || tickFormatter?.timeseries
@@ -98,14 +96,13 @@ export default function renderAxis({
             type={isTimeSeries ? 'number' : 'category'}
             // DO NOT SET xAxisId here (it breaks the component, opaque behavior from Recharts)
           />
+          {/* @ts-expect-error - TS2769 - No overload matches this call. */}
           <YAxis
             axisLine={false}
             domain={Array.isArray(range) ? range : range?.yAxisLeft}
             orientation={isRtl ? 'right' : 'left'}
-            // @ts-expect-error - TS2322
             style={FONT_STYLE_VALUES}
             tickCount={tickCount}
-            // @ts-expect-error - TS2322
             tickFormatter={tickFormatter?.yAxisLeft}
             tickLine={false}
             yAxisId="left"
@@ -113,14 +110,13 @@ export default function renderAxis({
         </Fragment>
       )}
       {isHorizontalBiaxialLayout && (
+        // @ts-expect-error - TS2769 - No overload matches this call.
         <YAxis
           axisLine={false}
           domain={Array.isArray(range) ? range : range?.yAxisLeft}
           orientation={isRtl ? 'left' : 'right'}
-          // @ts-expect-error - TS2322
           style={FONT_STYLE_VALUES}
           tickCount={tickCount}
-          // @ts-expect-error - TS2322
           tickFormatter={tickFormatter?.yAxisRight}
           tickLine={false}
           yAxisId="right"
@@ -128,16 +124,14 @@ export default function renderAxis({
       )}
       {isVerticalLayout && (
         <Fragment>
+          {/* @ts-expect-error - TS2769 - No overload matches this call. */}
           <XAxis
             axisLine={false}
-            // @ts-expect-error - TS2322
             domain={range}
             orientation="bottom"
             reversed={isRtl}
-            // @ts-expect-error - TS2322
             style={FONT_STYLE_VALUES}
             tickCount={tickCount}
-            // @ts-expect-error - TS2322
             tickFormatter={tickFormatter?.xAxisBottom}
             tickLine={false}
             type="number"
@@ -157,16 +151,14 @@ export default function renderAxis({
         </Fragment>
       )}
       {isVerticalBiaxialLayout && (
+        // @ts-expect-error - TS2769 - No overload matches this call.
         <XAxis
           axisLine={false}
-          // @ts-expect-error - TS2322
           domain={range}
           orientation="top"
           reversed={isRtl}
-          // @ts-expect-error - TS2322
           style={FONT_STYLE_VALUES}
           tickCount={tickCount}
-          // @ts-expect-error - TS2322
           tickFormatter={tickFormatter?.xAxisTop}
           tickLine={false}
           type="number"

--- a/packages/gestalt-charts/src/ChartGraph/renderElements.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/renderElements.tsx
@@ -60,8 +60,8 @@ export default function renderElements({
 }: Props): ReadonlyArray<ReactNode> {
   const { length } = elements;
   const lastElementPos = length > 1 ? length - 1 : 1;
-  const squaredRadius = [0, 0, 0, 0];
-  const roundedRadius = ['vertical', 'verticalBiaxial'].includes(layout)
+  const squaredRadius: [number, number, number, number] = [0, 0, 0, 0];
+  const roundedRadius: [number, number, number, number] = ['vertical', 'verticalBiaxial'].includes(layout)
     ? [0, 4, 4, 0]
     : [4, 4, 0, 0];
 
@@ -78,7 +78,6 @@ export default function renderElements({
       return (
         <RechartsBar
           key={values.id}
-          // @ts-expect-error - TS2769
           barSize="50%"
           dataKey={values.id}
           fill={
@@ -87,8 +86,9 @@ export default function renderElements({
               : hexColor(values.color || defaultColor)
           }
           isAnimationActive={false}
-          // eslint-disable-next-line react/no-unstable-nested-components
-          shape={({ height, ...props }) => (
+
+          // @ts-expect-error - TS2769 - No overload matches this call.
+          shape={({ height, ...props }) => ( // eslint-disable-line react/no-unstable-nested-components
             <Rectangle
               {...props}
               height={stacked && index !== 0 && height > 0 ? height - 2 : height}

--- a/packages/gestalt-charts/src/ChartGraph/renderElements.tsx
+++ b/packages/gestalt-charts/src/ChartGraph/renderElements.tsx
@@ -61,7 +61,9 @@ export default function renderElements({
   const { length } = elements;
   const lastElementPos = length > 1 ? length - 1 : 1;
   const squaredRadius: [number, number, number, number] = [0, 0, 0, 0];
-  const roundedRadius: [number, number, number, number] = ['vertical', 'verticalBiaxial'].includes(layout)
+  const roundedRadius: [number, number, number, number] = ['vertical', 'verticalBiaxial'].includes(
+    layout,
+  )
     ? [0, 4, 4, 0]
     : [4, 4, 0, 0];
 
@@ -86,9 +88,9 @@ export default function renderElements({
               : hexColor(values.color || defaultColor)
           }
           isAnimationActive={false}
-
           // @ts-expect-error - TS2769 - No overload matches this call.
-          shape={({ height, ...props }) => ( // eslint-disable-line react/no-unstable-nested-components
+          // eslint-disable-next-line react/no-unstable-nested-components
+          shape={({ height, ...props }) => (
             <Rectangle
               {...props}
               height={stacked && index !== 0 && height > 0 ? height - 2 : height}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2247,13 +2247,6 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2":
-  version "7.22.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.3.tgz#0a7fce51d43adbf0f7b517a71f4c3aaca92ebcbb"
-  integrity sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==
-  dependencies:
-    regenerator-runtime "^0.13.11"
-
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz"
@@ -7397,11 +7390,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz"
@@ -7617,7 +7605,7 @@ clone@^1.0.2:
   resolved "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^2.1.0, clsx@^2.1.1:
+clsx@^2.0.0, clsx@^2.1.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -8154,11 +8142,6 @@ css-tree@~2.2.0:
   dependencies:
     mdn-data "2.0.28"
     source-map-js "^1.0.1"
-
-css-unit-converter@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.2.tgz#4c77f5a1954e6dbff60695ecb214e3270436ab21"
-  integrity sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
 
 css-what@^5.0.0:
   version "5.1.0"
@@ -8910,13 +8893,6 @@ dom-accessibility-api@^0.5.9:
   version "0.5.14"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
   integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
-
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -10147,10 +10123,10 @@ fast-equals@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-3.0.3.tgz#8e6cb4e51ca1018d87dd41982ef92758b3e4197f"
   integrity sha512-NCe8qxnZFARSHGztGMZOO/PC1qa5MIFB5Hp66WdzbCRAz8U8US3bx1UTgLS49efBQPcUtO9gf5oVEY8o7y/7Kg==
 
-fast-equals@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.0.1.tgz#a4eefe3c5d1c0d021aeed0bc10ba5e0c12ee405d"
-  integrity sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==
+fast-equals@^5.0.1:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.2.2.tgz#885d7bfb079fac0ce0e8450374bce29e9b742484"
+  integrity sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==
 
 fast-fifo@^1.1.0, fast-fifo@^1.2.0:
   version "1.3.2"
@@ -16903,11 +16879,6 @@ postcss-unique-selectors@^6.0.2:
   dependencies:
     postcss-selector-parser "^6.0.15"
 
-postcss-value-parser@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz"
-  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
-
 postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz"
@@ -17359,7 +17330,7 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -17374,6 +17345,11 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-is@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.0.0.tgz#d6669fd389ff022a9684f708cf6fa4962d1fea7a"
@@ -17386,11 +17362,6 @@ react-lazy-hydration@^0.1.0:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
 react-live@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-live/-/react-live-3.2.0.tgz#d3c243b8d4ce4b3e6a6009e6238b0f972bf99cac"
@@ -17400,13 +17371,6 @@ react-live@^3.0.0:
     sucrase "^3.21.0"
     use-editable "^2.3.3"
 
-react-resize-detector@^8.0.4:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-8.1.0.tgz#1c7817db8bc886e2dbd3fbe3b26ea8e56be0524a"
-  integrity sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==
-  dependencies:
-    lodash "^4.17.21"
-
 react-shallow-renderer@^16.15.0:
   version "16.15.0"
   resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
@@ -17415,13 +17379,14 @@ react-shallow-renderer@^16.15.0:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
 
-react-smooth@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-2.0.3.tgz#2845fa8f22914f2e4445856d5688fb8a7d72f3ae"
-  integrity sha512-yl4y3XiMorss7ayF5QnBiSprig0+qFHui8uh7Hgg46QX5O+aRMRKlfGGNGLHno35JkQSvSYY8eCWkBfHfrSHfg==
+react-smooth@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-4.0.4.tgz#a5875f8bb61963ca61b819cedc569dc2453894b4"
+  integrity sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==
   dependencies:
-    fast-equals "^5.0.0"
-    react-transition-group "2.9.0"
+    fast-equals "^5.0.1"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
 
 react-test-renderer@^18.1.0:
   version "18.1.0"
@@ -17431,16 +17396,6 @@ react-test-renderer@^18.1.0:
     react-is "^18.1.0"
     react-shallow-renderer "^16.15.0"
     scheduler "^0.22.0"
-
-react-transition-group@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react-transition-group@^4.4.5:
   version "4.4.5"
@@ -17588,19 +17543,18 @@ recharts-scale@^0.4.4:
   dependencies:
     decimal.js-light "^2.4.1"
 
-recharts@2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.8.0.tgz#90c95136e2cb6930224c94a51adce607701284fc"
-  integrity sha512-nciXqQDh3aW8abhwUlA4EBOBusRHLNiKHfpRZiG/yjups1x+auHb2zWPuEcTn/IMiN47vVMMuF8Sr+vcQJtsmw==
+recharts@2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.13.0.tgz#a293322ea357491393cc7ad6fcbb1e5f8e99bc93"
+  integrity sha512-sbfxjWQ+oLWSZEWmvbq/DFVdeRLqqA6d0CDjKx2PkxVVdoXo16jvENCE+u/x7HxOO+/fwx//nYRwb8p8X6s/lQ==
   dependencies:
-    classnames "^2.2.5"
+    clsx "^2.0.0"
     eventemitter3 "^4.0.1"
-    lodash "^4.17.19"
-    react-is "^16.10.2"
-    react-resize-detector "^8.0.4"
-    react-smooth "^2.0.2"
+    lodash "^4.17.21"
+    react-is "^18.3.1"
+    react-smooth "^4.0.0"
     recharts-scale "^0.4.4"
-    reduce-css-calc "^2.1.8"
+    tiny-invariant "^1.3.1"
     victory-vendor "^36.6.8"
 
 rechoir@^0.6.2:
@@ -17644,14 +17598,6 @@ redis-parser@^3.0.0:
   integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
-
-reduce-css-calc@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz#7ef8761a28d614980dc0c982f772c93f7a99de03"
-  integrity sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==
-  dependencies:
-    css-unit-converter "^1.1.1"
-    postcss-value-parser "^3.3.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
@@ -19580,6 +19526,11 @@ tiny-glob@^0.2.9:
   dependencies:
     globalyzer "0.1.0"
     globrex "^0.1.2"
+
+tiny-invariant@^1.3.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
 tinycolor2@1.6.0:
   version "1.6.0"


### PR DESCRIPTION

### Summary

#### What changed?

Upgrade recharts library

#### Why?

Current version is having issues when upgrading to React 19, Upgrading to version [2.13.0](https://github.com/recharts/recharts/releases/tag/v2.13.0) which according to the release should be compatible with React 19

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
