### PR TITLE
Docs: adds DesignTokensProvider to Sandpack code editor

### DIFF
--- a/docs/docs-components/SandpackExample.tsx
+++ b/docs/docs-components/SandpackExample.tsx
@@ -250,7 +250,7 @@ export default function SandpackExample({
           code: `import React, { StrictMode } from "react";
           import { createRoot } from "react-dom/client";
           import "./styles.css";
-          import { Box, ColorSchemeProvider, ExperimentProvider } from 'gestalt';
+          import { Box, ColorSchemeProvider, ExperimentProvider, DesignTokensProvider } from 'gestalt';
           import App from "./App";
 
           const html = document.querySelector('html');
@@ -261,9 +261,11 @@ export default function SandpackExample({
             <StrictMode>
               <ExperimentProvider value={${JSON.stringify(experimentsObj)}}>
                 <ColorSchemeProvider colorScheme="${exampleColorScheme}">
-                  <Box color="default" height="100%" width="100%">
-                    <App />
-                  </Box>
+                  <DesignTokensProvider>
+                    <Box color="default" height="100%" width="100%">
+                      <App />
+                    </Box>
+                  </DesignTokensProvider>
                 </ColorSchemeProvider>
               </ExperimentProvider>
             </StrictMode>


### PR DESCRIPTION
Docs: adds DesignTokensProvider to Sandpack code editor
