### PR TITLE
Toast: Compact icons

### DIFF
--- a/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
@@ -195,7 +195,7 @@ export function TypeThumbnail({ type }: { type: 'default' | 'success' | 'error' 
       accessibilityLabel={accessibilityIconSuccessLabel}
       color="default"
       icon="compact-check-circle-fill"
-      size={SIZE_ICON}
+      size={SIZE_ICON_VR}
     />
   ) : (
     <Icon

--- a/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
+++ b/packages/gestalt/src/sharedSubcomponents/thumbnailSubcomponents.tsx
@@ -13,6 +13,7 @@ import ColorSchemeProvider, { useColorScheme } from '../contexts/ColorSchemeProv
 import { useDefaultLabelContext } from '../contexts/DefaultLabelProvider';
 import DesignTokensProvider from '../contexts/DesignTokensProvider';
 import Icon, { IconColor } from '../Icon';
+import IconCompact from '../IconCompact';
 import Link from '../Link';
 import Mask from '../Mask';
 import Spinner from '../Spinner';
@@ -21,6 +22,7 @@ import useExperimentalTheme from '../utils/useExperimentalTheme';
 
 const SIZE_THUMBNAIL = 32;
 const SIZE_ICON = 24;
+const SIZE_ICON_VR = 20;
 
 export function Message({
   text,
@@ -172,26 +174,44 @@ export function TypeThumbnail({ type }: { type: 'default' | 'success' | 'error' 
   } = useDefaultLabelContext('Toast');
   const theme = useExperimentalTheme();
 
+  const errorIcon = theme.MAIN ? (
+    <IconCompact
+      accessibilityLabel={accessibilityIconErrorLabel}
+      color="inverse"
+      icon="compact-workflow-status-problem"
+      size={SIZE_ICON_VR}
+    />
+  ) : (
+    <Icon
+      accessibilityLabel={accessibilityIconErrorLabel}
+      color="inverse"
+      icon="workflow-status-problem"
+      size={SIZE_ICON}
+    />
+  );
+
+  const successIcon = theme.MAIN ? (
+    <IconCompact
+      accessibilityLabel={accessibilityIconSuccessLabel}
+      color="default"
+      icon="compact-check-circle-fill"
+      size={SIZE_ICON}
+    />
+  ) : (
+    <Icon
+      accessibilityLabel={accessibilityIconSuccessLabel}
+      color="success"
+      icon="workflow-status-ok"
+      size={SIZE_ICON}
+    />
+  );
+
   return (
     <Fragment>
-      {type === 'error' ? (
-        <Icon
-          accessibilityLabel={accessibilityIconErrorLabel}
-          color="inverse"
-          icon="workflow-status-problem"
-          size={SIZE_ICON}
-        />
-      ) : null}
+      {type === 'error' ? errorIcon : null}
       {type === 'success' ? (
         <ColorSchemeProvider colorScheme={colorSchemeName === 'darkMode' ? 'light' : 'dark'}>
-          <DesignTokensProvider id="icon-toast-success">
-            <Icon
-              accessibilityLabel={accessibilityIconSuccessLabel}
-              color={theme.MAIN ? 'default' : 'success'}
-              icon="workflow-status-ok"
-              size={SIZE_ICON}
-            />
-          </DesignTokensProvider>
+          <DesignTokensProvider id="icon-toast-success">{successIcon}</DesignTokensProvider>
         </ColorSchemeProvider>
       ) : null}
       {type === 'progress' ? (


### PR DESCRIPTION
Before:
<img width="907" alt="Screenshot 2025-03-31 at 08 27 54" src="https://github.com/user-attachments/assets/25058977-7804-4ae4-87bb-bfe6eabe6c2e" />
<img width="930" alt="Screenshot 2025-03-31 at 08 28 00" src="https://github.com/user-attachments/assets/02f77262-d5de-4cd3-b0c8-87c0358350a9" />

After:
<img width="914" alt="Screenshot 2025-03-31 at 08 27 44" src="https://github.com/user-attachments/assets/2a400794-97e7-40e7-bb08-f780a73c288e" />
<img width="920" alt="Screenshot 2025-03-31 at 08 27 38" src="https://github.com/user-attachments/assets/c70433e8-8d44-4a5a-a083-809343f6dce2" />
