### PR TITLE
ComboBox: update ARIA attributes for better accessibility

### DIFF
--- a/packages/gestalt/src/ComboBox.tsx
+++ b/packages/gestalt/src/ComboBox.tsx
@@ -441,8 +441,6 @@ const ComboBoxWithForwardRef = forwardRef<HTMLInputElement, Props>(function Comb
       <Box
         aria-autocomplete="list"
         aria-expanded={showOptionsList}
-        aria-haspopup
-        aria-owns={id}
         position="relative"
         role="combobox"
       >

--- a/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.tsx.snap
+++ b/packages/gestalt/src/__snapshots__/ComboBox.jsdom.test.tsx.snap
@@ -6,8 +6,6 @@ exports[`ComboBox Controlled ComboBox renders basic controlled components 1`] = 
     <div
       aria-autocomplete="list"
       aria-expanded="false"
-      aria-haspopup="true"
-      aria-owns="test"
       class="box relative"
       role="combobox"
     >
@@ -86,8 +84,6 @@ exports[`ComboBox Controlled ComboBox with Tags renders with tags 1`] = `
     <div
       aria-autocomplete="list"
       aria-expanded="false"
-      aria-haspopup="true"
-      aria-owns="test"
       class="box relative"
       role="combobox"
     >
@@ -611,8 +607,6 @@ exports[`ComboBox Uncontrolled ComboBox renders default 1`] = `
     <div
       aria-autocomplete="list"
       aria-expanded="false"
-      aria-haspopup="true"
-      aria-owns="test"
       class="box relative"
       role="combobox"
     >
@@ -691,8 +685,6 @@ exports[`ComboBox Uncontrolled ComboBox renders disabled state 1`] = `
     <div
       aria-autocomplete="list"
       aria-expanded="false"
-      aria-haspopup="true"
-      aria-owns="test"
       class="box relative"
       role="combobox"
     >


### PR DESCRIPTION
### Summary

#### What changed?

Removed redundant ARIA attributes fr om the ComboBox component:
- Removed `aria-haspopup` as it's not needed when the popup has role="listbox"
- Removed `aria-owns` in favor of aria-controls (which was already correctly implemented)

Kept essential ARIA attributes:
- `role="combobox"`
- `aria-expanded`
- `aria-autocomplete="list"`

#### Why?

These changes improve the ComboBox component's accessibility implementation by following [W3C ARIA best practices](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). The removed attributes were either redundant or not recommended:
- `aria-haspopup` is redundant when the popup has role="listbox" according to W3C guidelines
  > "If the popup has a role other than listbox, the element with role combobox has [aria-haspopup](https://w3c.github.io/aria/#aria-haspopup) set to a value that corresponds to the popup type. That is, aria-haspopup is set to grid, tree, or dialog. Note that elements with role combobox have an implicit aria-haspopup value of listbox."
- `aria-owns` is not recommended when `aria-controls` is already in use, as per W3C guidelines
  > "In ARIA 1.0, the combobox referenced its popup with [aria-owns](https://w3c.github.io/aria/#aria-owns) instead of [aria-controls](https://w3c.github.io/aria/#aria-controls). While user agents might support comboboxes with [aria-owns](https://w3c.github.io/aria/#aria-owns) for backwards compatibility with legacy content, it is strongly recommended that authors use [aria-controls](https://w3c.github.io/aria/#aria-controls)."

