### PR TITLE
Modal: add aria-modal attribute for a11y

### DIFF
--- a/packages/gestalt/src/Modal.tsx
+++ b/packages/gestalt/src/Modal.tsx
@@ -190,7 +190,7 @@ export default function Modal({
   return (
     <StopScrollBehavior>
       <TrapFocusBehavior>
-        <div aria-label={accessibilityModalLabel} className={modalStyles.container} role={role}>
+        <div aria-label={accessibilityModalLabel} aria-modal="true" className={modalStyles.container} role={role}>
           <Backdrop closeOnOutsideClick={closeOnOutsideClick} onClick={handleOutsideClick}>
             <div
               className={classnames(modalStyles.wrapper, focusStyles.hideOutline)}


### PR DESCRIPTION
# Pull Request Instructions

Thanks for creating a PR! 🎉

- Please follow this template and delete items/sections that are not relevant to your changes, _including these instructions_.
- Make sure your [PR title](https://github.com/pinterest/gestalt/#releasing) matches our format: `{ComponentName}: Description (mention platform if relevant)`. If there are changes to multiple components, use `{ComponentName}, {OtherComponentName}: Description (mention platform if relevant)`.
- Each PR needs a [label](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) indicating which [semantic version](https://semver.org/) should be applied:
  - _Major_: Breaking changes to existing components (e.g. removing a prop, removing a prop value, removing a component).
  - _Minor_: New components, non-breaking changes to existing components (e.g. adding a new prop, adding a new prop value).

## Pull Request Template

### Summary

#### What changed?

Add attribute [aria-label](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-modal) to enhance a11y on screen readers users
#### Why?

Setting aria-modal="true" tells assistive technologies to let the user know the ability to interact with, or access other content on the page requires the modal dialog to be closed or otherwise lose focus. All Gestalt Modals should include this attribute

### Links

- [Jira](https://jira.pinadmin.com/browse/GESTALT-XXXX)
- [TDD](link to Paper doc)
- [Figma](link to Figma file)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [ ] Checked dark mode, responsiveness, and right-to-left support
- [ ] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
