### PR TITLE
SearchGuide: remove padding to align content to the center

### DIFF
--- a/packages/gestalt/src/SearchGuide.css
+++ b/packages/gestalt/src/SearchGuide.css
@@ -7,8 +7,7 @@
   height: 48px;
   isolation: isolate;
   min-width: 60px;
-  padding-left: var(--space-100);
-  padding-right: var(--space-100);
+  padding: var(--space-0) var(--space-100);
 }
 
 .searchguideVr {


### PR DESCRIPTION
### Summary

#### What changed?

Removed padding to the top and bottom in classic SearchGuides.

#### Why?

There is a padding of 1px that is added to the button tag by the user agent, that is causing the content of the guide to be slightly pushed to the bottom, making the content to look misaligned.

This issue only affects Web with classic theme.

Before

<img width="691" alt="Screenshot 2025-04-04 at 3 49 04 p m" src="https://github.com/user-attachments/assets/30a2fde7-2ae2-454c-9ec0-2eef3f6b21a2" />

After

<img width="675" alt="Screenshot 2025-04-04 at 4 04 46 p m" src="https://github.com/user-attachments/assets/189a3ca3-c1db-4aa7-9512-a21fb27608ef" />

### Links

- Jira: NA
- [Figma](https://www.figma.com/design/vjhfBsOtHw0wVg67vqwz1v/Gestalt-for-Web?node-id=33958-683&t=xxVl5AD5GIsRoXL9-0)
