### PR TITLE
Internal: Fix name collision in CI test result upload

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,5 +37,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-test-results
+          name: playwright-test-results-${{ matrix.shard }}
           path: playwright/test-results/


### PR DESCRIPTION
### Summary

#### What changed?

Fixed a name collision issue in CI when multiple workers attempted to upload test results. This was resolved by giving each shard a unique file name.

### Checklist

- [ ] Checked stakeholder feedback (e.g. CI/CD team)