### PR TITLE
[Gestalt web][minor] Modal: Adding data test id prop

### DIFF
--- a/packages/gestalt/src/Modal.jsdom.test.tsx
+++ b/packages/gestalt/src/Modal.jsdom.test.tsx
@@ -109,4 +109,23 @@ describe('Modal', () => {
     expect(screen.getByLabelText('Bottom sheet')).toBeVisible();
     expect(screen.getByLabelText('Dismiss bottom sheet')).toBeVisible();
   });
+
+  test('Modal shows data test id when passed as a prop', ()=>{
+    render(
+      <Modal
+      accessibilityModalLabel="Test modal"
+      dataTestId="custom-modal-test-id"
+      heading="Heading"
+      onDismiss={() => {}}
+      size="sm"
+    >
+      Modal content
+    </Modal>
+
+    );
+
+    const modalContainer = screen.getByTestId('custom-modal-test-id');
+    expect(modalContainer).toBeInTheDocument();
+    expect(modalContainer).toBeVisible();
+  })
 });

--- a/packages/gestalt/src/Modal.tsx
+++ b/packages/gestalt/src/Modal.tsx
@@ -37,6 +37,10 @@ type Props = {
    */
   closeOnOutsideClick?: boolean;
   /**
+   * Available for testing purposes, if needed. Consider [better queries](https://testing-library.com/docs/queries/about/#priority) before using this prop.
+   */
+  dataTestId?: string;
+  /**
    * Supply the element(s) that will be used as Modal's custom footer. See the [Best Practices](https://gestalt.pinterest.systems/web/modal#Best-practices) for more info.
    */
   footer?: ReactNode;
@@ -111,6 +115,7 @@ export default function Modal({
   align = 'center',
   children,
   closeOnOutsideClick = true,
+  dataTestId,
   onDismiss,
   footer,
   padding = 'default',
@@ -197,7 +202,7 @@ export default function Modal({
               style={{ width }}
               tabIndex={-1}
             >
-              <Box direction="column" display="flex" flex="grow" position="relative" width="100%">
+              <Box data-test-id={dataTestId} direction="column" display="flex" flex="grow" position="relative" width="100%">
                 {Boolean(heading) && (
                   <Box
                     borderStyle={showTopShadow ? 'raisedTopShadow' : undefined}


### PR DESCRIPTION
### Summary

#### What changed?

This PR introduces a new optional **dataTestId** prop for the **Modal** component. When provided, this prop is passed as a **`data-test-id`** attribute to the main container of the modal (the Box that wraps the header and body). This allows test frameworks to easily target and select specific modals for integration testing.


#### Why?

The purpose of this PR is to make it easier and more reliable to select modal components and their children in automated integration tests. Currently, it's tough to find the right modal in the DOM when running tests—especially for complex flows like the "parental passcode" feature—since there's no unique attribute to select. Relying on accessibility props isn't best practice for testing purposes. With the new **`dataTestId`** prop, engineers can confidently attach a custom identifier for testing without affecting accessibility or user experience.


### Links

- [TDD](https://docs.google.com/document/d/1wMGDoUdHiny09_nHzQ0JWf1R5QZDhbRgGEOY7dJrwzI/edit?tab=t.u8lpg069nfln)

### Checklist

- [X] Added unit tests
- [X] Added documentation + accessibility tests
