### PR TITLE
Internal: Add support for dynamic basePath and trailingSlash in Next.js config

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -3,7 +3,17 @@ const redirects = require('./redirects');
 
 const root = path.join(__dirname, '../');
 
+// Set basePath from environment variable (e.g., BASE_PATH="/v1")
+const basePath = process.env.BASE_PATH;
+
 module.exports = {
+
+  // Only set basePath if the env var is defined
+  ...(basePath ? { basePath } : {}),
+  // Only set trailingSlash if basePath is defined
+  ...(basePath ? { trailingSlash: false } : {}),
+
+
   images: {
     domains: [
       'paper-attachments.dropbox.com',

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -7,12 +7,10 @@ const root = path.join(__dirname, '../');
 const basePath = process.env.BASE_PATH;
 
 module.exports = {
-
   // Only set basePath if the env var is defined
   ...(basePath ? { basePath } : {}),
   // Only set trailingSlash if basePath is defined
   ...(basePath ? { trailingSlash: false } : {}),
-
 
   images: {
     domains: [


### PR DESCRIPTION
Enhancement: Add support for dynamic basePath and trailingSlash in Next.js config

### Summary

Read BASE_PATH from build-time env and apply it only when present.
Tie trailingSlash: false to the same condition so trailing slash behavior changes only alongside the base path.

#### What changed?

`docs/next.config.js` now expects `BASE_PATH` to contain the leading / (e.g. /v1); omit the variable to run at /.
If `BASE_PATH` is set, remember to update any absolute URLs, redirects, and asset prefixes to include it.

#### Why?

New Gesalt proyect will have the existing docs v1 site under "/v1"


