### PR TITLE
Docs: Add DocSearch transformData prop

### DIFF
--- a/docs/docs-components/DocSearch.tsx
+++ b/docs/docs-components/DocSearch.tsx
@@ -143,7 +143,7 @@ export default function DocSearch({
     } catch (e) {
       return url;
     }
-  }
+  };
 
   useEffect(() => {
     // @ts-expect-error - TS2339 - Property 'docsearch' does not exist on type 'Window & typeof globalThis'.

--- a/docs/docs-components/DocSearch.tsx
+++ b/docs/docs-components/DocSearch.tsx
@@ -2,6 +2,7 @@ import { Fragment, Ref, useCallback, useEffect, useState } from 'react';
 import { Box, FixedZIndex, Icon, IconButton, Tooltip } from 'gestalt';
 
 const INPUT_ID = 'algolia-doc-search';
+const DEFAULT_VERSION = '/v1';
 
 function SearchBox({ popoverZIndex }: { popoverZIndex?: FixedZIndex }) {
   // Icon placement is copied directly from  SearchField
@@ -129,6 +130,21 @@ export default function DocSearch({
     }
   }, [isMobileSearchExpandedOpen]);
 
+  const addVersionToSearchResultURL = (url: string): string => {
+    try {
+      const parsedUrl = new URL(url);
+      const match = window.location.pathname.match(/^\/(v\d+)\b/);
+      const version = match ? `/${match[1]}` : DEFAULT_VERSION;
+
+      parsedUrl.pathname = parsedUrl.pathname.replace(/^\/v\d+\b/, '');
+      parsedUrl.pathname = version + parsedUrl.pathname;
+
+      return parsedUrl.toString();
+    } catch (e) {
+      return url;
+    }
+  }
+
   useEffect(() => {
     // @ts-expect-error - TS2339 - Property 'docsearch' does not exist on type 'Window & typeof globalThis'.
     if (typeof window === 'undefined' || !window.docsearch) {
@@ -141,6 +157,13 @@ export default function DocSearch({
       debug: false, // Set debug to true if you want to keep open and inspect the dropdown
       indexName: 'gestalt',
       inputSelector: `#${INPUT_ID}`,
+      transformData(hits: Array<{ url: string }>) {
+        const transformedHits = hits.map((hit) => ({
+          ...hit,
+          url: addVersionToSearchResultURL(hit.url),
+        }));
+        return transformedHits;
+      },
     });
   }, []);
 


### PR DESCRIPTION
## Pull Request Template

### Summary
This PR fixes a bug in the search input where DocSearch was returning page routes without the version, resulting in incorrect links. A validation was added to ensure that searched links include the current version based on the pathname. If the version is not found, the default version (/v1) will be assigned.


https://github.com/user-attachments/assets/cc4bfc6d-7652-499b-8c23-d3e528e4a707

Result after implementation:

https://github.com/user-attachments/assets/c894f791-4e91-478b-9675-054fd0b8ae7d





#### What changed?
Added transformData prop to DocSearch on DocSearch.tsx file

### Links

- [Jira](https://pinterest.atlassian.net/jira/software/c/projects/SUB/boards/969?assignee=712020%3Abab0ea78-f360-4cd9-84bb-a27426cc5526&selectedIssue=SUB-12886)

### Checklist

- [ ] Added unit tests
- [ ] Added documentation + accessibility tests
- [ ] Verified accessibility: keyboard & screen reader interaction
- [X] Checked dark mode, responsiveness, and right-to-left support
- [X] Checked stakeholder feedback (e.g. Gestalt designers, relevant feature teams)
